### PR TITLE
Fix typo: protoype -> prototype

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -6520,7 +6520,7 @@ merge(Compressor.prototype, {
 
     OPT(AST_Dot, function(self, compressor) {
         if (self.property == "arguments" || self.property == "caller") {
-            compressor.warn("Function.protoype.{prop} not supported [{file}:{line},{col}]", {
+            compressor.warn("Function.prototype.{prop} not supported [{file}:{line},{col}]", {
                 prop: self.property,
                 file: self.start.file,
                 line: self.start.line,

--- a/test/compress/issue-2719.js
+++ b/test/compress/issue-2719.js
@@ -26,7 +26,7 @@ warn: {
         }().length);
     }
     expect_warnings: [
-        "WARN: Function.protoype.caller not supported [test/compress/issue-2719.js:5,19]",
-        "WARN: Function.protoype.arguments not supported [test/compress/issue-2719.js:5,19]",
+        "WARN: Function.prototype.caller not supported [test/compress/issue-2719.js:5,19]",
+        "WARN: Function.prototype.arguments not supported [test/compress/issue-2719.js:5,19]",
     ]
 }


### PR DESCRIPTION
Just a little typo fix :)