### PR TITLE
Revert "Revert "Fix compressed source-maps have non-terminated segments""

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -74,12 +74,21 @@ function SourceMap(options) {
     }
 
     function add(source, gen_line, gen_col, orig_line, orig_col, name) {
+        var generatedPos = { line: gen_line + options.dest_line_diff, column: gen_col };
         if (orig_map) {
             var info = orig_map.originalPositionFor({
                 line: orig_line,
                 column: orig_col
             });
             if (info.source === null) {
+                if (generatedPos.column !== 0) {
+                    generator.addMapping({
+                        generated: generatedPos,
+                        original: null,
+                        source: null,
+                        name: null
+                    });
+                }
                 return;
             }
             source = info.source;
@@ -88,7 +97,7 @@ function SourceMap(options) {
             name = info.name || name;
         }
         generator.addMapping({
-            generated : { line: gen_line + options.dest_line_diff, column: gen_col },
+            generated : generatedPos,
             original  : { line: orig_line + options.orig_line_diff, column: orig_col },
             source    : source,
             name      : name


### PR DESCRIPTION
Reverts terser-js/terser#381, which is a revert of #342

Context:

The #342 PR was reverted to quickly work around a bug caused by source-map.

Merge this when mozilla/source-map#385 is closed.