### PR TITLE
refactor: update the org name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ## v4.0.2
 
-(Hotfix release. Reverts unmapped segments PR [#342](https://github.com/terser-js/terser/pull/342), which will be put back on Terser when the upstream issue is resolved)
+(Hotfix release. Reverts unmapped segments PR [#342](https://github.com/terser/terser/pull/342), which will be put back on Terser when the upstream issue is resolved)
 
 ## v4.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img src="https://raw.githubusercontent.com/terser-js/terser/master/logo.svg?sanitize=true" alt="Terser" width="450" height="190"></h1>
+<h1><img src="https://raw.githubusercontent.com/terser/terser/master/logo.svg?sanitize=true" alt="Terser" width="450" height="190"></h1>
 
   [![NPM Version][npm-image]][npm-url]
   [![NPM Downloads][downloads-image]][downloads-url]
@@ -6,13 +6,13 @@
 
 A JavaScript parser and mangler/compressor toolkit for ES6+.
 
-*note*: You can support this project on patreon: <a target="_blank" rel="nofollow" href="https://www.patreon.com/fabiosantoscode"><img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" alt="patron" width="100px" height="auto"></a>. Check out [PATRONS.md](https://github.com/terser-js/terser/blob/master/PATRONS.md) for our first-tier patrons.
+*note*: You can support this project on patreon: <a target="_blank" rel="nofollow" href="https://www.patreon.com/fabiosantoscode"><img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" alt="patron" width="100px" height="auto"></a>. Check out [PATRONS.md](https://github.com/terser/terser/blob/master/PATRONS.md) for our first-tier patrons.
 
 Terser recommends you use RollupJS to bundle your modules, as that produces smaller code overall.
 
 *Beautification* has been undocumented and is *being removed* from terser, we recommend you use [prettier](https://npmjs.com/package/prettier).
 
-Find the changelog in [CHANGELOG.md](https://github.com/terser-js/terser/blob/master/CHANGELOG.md)
+Find the changelog in [CHANGELOG.md](https://github.com/terser/terser/blob/master/CHANGELOG.md)
 
 
 
@@ -20,8 +20,8 @@ Find the changelog in [CHANGELOG.md](https://github.com/terser-js/terser/blob/ma
 [npm-url]: https://npmjs.org/package/terser
 [downloads-image]: https://img.shields.io/npm/dm/terser.svg
 [downloads-url]: https://npmjs.org/package/terser
-[travis-image]: https://img.shields.io/travis/terser-js/terser/master.svg
-[travis-url]: https://travis-ci.org/terser-js/terser
+[travis-image]: https://img.shields.io/travis/terser/terser/master.svg
+[travis-url]: https://travis-ci.org/terser/terser
 
 Why choose terser?
 ------------------
@@ -953,7 +953,7 @@ Terser.minify(code, { mangle: { toplevel: true } }).code;
 - `undeclared` (default: `false`) - Mangle those names when they are accessed
   as properties of known top level variables but their declarations are never
   found in input code. May be useful when only minifying parts of a project.
-  See [#397](https://github.com/terser-js/terser/issues/397) for more details.
+  See [#397](https://github.com/terser/terser/issues/397) for more details.
 
 ## Output options
 
@@ -1315,7 +1315,7 @@ In the terser CLI we use [source-map-support](https://npmjs.com/source-map-suppo
 
 # README.md Patrons:
 
-*note*: You can support this project on patreon: <a target="_blank" rel="nofollow" href="https://www.patreon.com/fabiosantoscode"><img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" alt="patron" width="100px" height="auto"></a>. Check out [PATRONS.md](https://github.com/terser-js/terser/blob/master/PATRONS.md) for our first-tier patrons.
+*note*: You can support this project on patreon: <a target="_blank" rel="nofollow" href="https://www.patreon.com/fabiosantoscode"><img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" alt="patron" width="100px" height="auto"></a>. Check out [PATRONS.md](https://github.com/terser/terser/blob/master/PATRONS.md) for our first-tier patrons.
 
 These are the second-tier patrons. Great thanks for your support!
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1515,7 +1515,7 @@ class Compressor extends TreeWalker {
                         var sym = fn.argnames[i];
                         var arg = iife.args[i];
                         // The following two line fix is a duplicate of the fix at
-                        // https://github.com/terser-js/terser/commit/011d3eb08cefe6922c7d1bdfa113fc4aeaca1b75
+                        // https://github.com/terser/terser/commit/011d3eb08cefe6922c7d1bdfa113fc4aeaca1b75
                         // This might mean that these two pieces of code (one here in collapse_vars and another in reduce_vars
                         // Might be doing the exact same thing.
                         const def = sym.definition && sym.definition();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terser",
   "description": "JavaScript parser, mangler/compressor and beautifier toolkit for ES6+",
-  "homepage": "https://github.com/terser-js/terser",
+  "homepage": "https://github.com/terser/terser",
   "author": "Mihai Bazon <mihai.bazon@gmail.com> (http://lisperator.net/)",
   "license": "BSD-2-Clause",
   "version": "4.2.1",

--- a/test/compress/issue-t120.js
+++ b/test/compress/issue-t120.js
@@ -155,7 +155,7 @@ issue_t120_5: {
 }
 
 pr_152_regression: {
-    reminify: false // TODO: remove when https://github.com/terser-js/terser/issues/156 fixed
+    reminify: false // TODO: remove when https://github.com/terser/terser/issues/156 fixed
     options = {
         collapse_vars: true,
         evaluate: true,

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -4838,7 +4838,7 @@ escape_conditional: {
 }
 
 /*
-https://github.com/terser-js/terser/issues/431
+https://github.com/terser/terser/issues/431
 escape_sequence: {
     options = {
         reduce_funcs: true,


### PR DESCRIPTION
terser's github org name is no longer "terser-js". This PR changes all instances of the old name for the new one (just "terser").