### PR TITLE
Add option to return source-map as object

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -135,6 +135,7 @@ function minify(files, options) {
         }
         if (options.sourceMap) {
             options.sourceMap = defaults(options.sourceMap, {
+                asObject: false,
                 content: null,
                 filename: null,
                 includeSources: false,
@@ -228,9 +229,14 @@ function minify(files, options) {
             toplevel.print(stream);
             result.code = stream.get();
             if (options.sourceMap) {
-                result.map = options.output.source_map.toString();
+                if(options.sourceMap.asObject) {
+                    result.map = options.output.source_map.get().toJSON();
+                } else {
+                    result.map = options.output.source_map.toString();
+                }
                 if (options.sourceMap.url == "inline") {
-                    result.code += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," + to_base64(result.map);
+                    var sourceMap = typeof result.map === "object" ? JSON.stringify(result.map) : result.map;
+                    result.code += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," + to_base64(sourceMap);
                 } else if (options.sourceMap.url) {
                     result.code += "\n//# sourceMappingURL=" + options.sourceMap.url;
                 }

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -119,6 +119,17 @@ describe("sourcemaps", function() {
         assert.strictEqual(result.code, code);
         assert.strictEqual(result.map, '{"version":3,"sources":["0"],"names":["console","log"],"mappings":"AAAAA,QAAQC,IAAI","sourceRoot":"//foo.bar/"}');
     });
+    it("Should return source map as object when asObject is given", function() {
+        var code = "console.log(42);";
+        var result = UglifyJS.minify(code, {
+            sourceMap: {
+                asObject: true,
+            },
+        });
+        if (result.error) throw result.error;
+        assert.strictEqual(result.code, code);
+        assert.deepStrictEqual(result.map, {"version":3,"sources":["0"],"names":["console","log"],"mappings":"AAAAA,QAAQC,IAAI"});
+    });
 
     describe("inSourceMap", function() {
         it("Should read the given string filename correctly when sourceMapIncludeSources is enabled", function() {
@@ -232,6 +243,18 @@ describe("sourcemaps", function() {
             assert.strictEqual(map.names.length, 2);
             assert.strictEqual(map.names[0], "tëst");
             assert.strictEqual(map.names[1], "alert");
+        });
+        it("Should append source map to file when asObject is present", function() {
+            var result = UglifyJS.minify('var a = function(foo) { return foo; };', {
+                sourceMap: {
+                    url: "inline",
+                    asObject: true
+                }
+            });
+            if (result.error) throw result.error;
+            var code = result.code;
+            assertCodeWithInlineMapEquals(code, "var a=function(n){return n};\n" +
+                "//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIjAiXSwibmFtZXMiOlsiYSIsImZvbyJdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSUEsRUFBSSxTQUFTQyxHQUFPLE9BQU9BIn0=");
         });
     });
 

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -145,7 +145,7 @@ export interface MinifyOutput {
     ast?: AST_Node;
     code?: string;
     error?: Error;
-    map?: any;
+    map?: RawSourceMap | string;
     warnings?: string[];
 }
 

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -145,7 +145,7 @@ export interface MinifyOutput {
     ast?: AST_Node;
     code?: string;
     error?: Error;
-    map?: string;
+    map?: any;
     warnings?: string[];
 }
 


### PR DESCRIPTION
Fixes #278 

Same approach which was discussed, adding `sourceMap.asObject` will return the source map as an object.

@fabiosantoscode Let me know if any changes are needed