### PR TITLE
fix the type of OutputOptions.max_line_len

### DIFF
--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -103,7 +103,7 @@ export interface OutputOptions {
     inline_script?: boolean;
     ie8?: boolean;
     keep_quoted_props?: boolean;
-    max_line_len?: boolean;
+    max_line_len?: false | number;
     preamble?: string;
     quote_keys?: boolean;
     quote_style?: OutputQuoteStyle;


### PR DESCRIPTION
`max_line_len: false | number` is a correct type for the current code.

I think `max_line_len: number` (default: `Infinity`) is more natural ([kei-ito/terser/commit/119bd09](https://github.com/kei-ito/terser/commit/119bd09f8731fff254e3b8b0c731d87fb46e8fd9)). But it is imcompatible with UglifyJS.
