### PR TITLE
Fixes #438, Modify default --Coments value

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -157,8 +157,8 @@ const CODE_LINE_BREAK = 10;
 const CODE_SPACE = 32;
 
 function is_some_comments(comment) {
-    // multiline comment
-    return comment.type == "comment2" && /@preserve|@lic|@cc_on|^\/\*+!/i.test(comment.value);
+    // multiline comment    
+    return comment.type == "comment2" && /@preserve|@lic|@cc_on|^\**!/i.test(comment.value);
 }
 
 function OutputStream(options) {
@@ -196,7 +196,7 @@ function OutputStream(options) {
     // Convert comment option to RegExp if neccessary and set up comments filter
     var comment_filter = return_false; // Default case, throw all comments away
     if (options.comments) {
-        var comments = options.comments;
+        let comments = options.comments;
         if (typeof options.comments === "string" && /^\/.*\/[a-zA-Z]*$/.test(options.comments)) {
             var regex_pos = options.comments.lastIndexOf("/");
             comments = new RegExp(

--- a/lib/output.js
+++ b/lib/output.js
@@ -168,7 +168,7 @@ function OutputStream(options) {
         ascii_only       : false,
         beautify         : false,
         braces           : false,
-        comments         : false,
+        comments         : "some",
         ecma             : 5,
         ie8              : false,
         indent_level     : 4,

--- a/lib/output.js
+++ b/lib/output.js
@@ -158,7 +158,7 @@ const CODE_SPACE = 32;
 
 function is_some_comments(comment) {
     // multiline comment
-    return comment.type == "comment2" && /@preserve|@license|@cc_on/i.test(comment.value);
+    return comment.type == "comment2" && /@preserve|@lic|@cc_on|^\/\*+!/i.test(comment.value);
 }
 
 function OutputStream(options) {

--- a/test/compress/comments.js
+++ b/test/compress/comments.js
@@ -17,3 +17,22 @@ print_every_comment_only_once: {
         "/* this is a block line */(foo2.bar={}).test=123;",
     ]
 }
+
+preserve_comments_by_default: {
+    beautify = {
+        comments: "some"
+    }
+    input: {
+        var foo = {};
+        /* @license */
+        /**! foo */
+        /*! foo */
+        /* lost */
+    }
+    expect_exact: [
+        "var foo={};",
+        "/* @license */",
+        "/**! foo */",
+        "/*! foo */",
+    ]
+}


### PR DESCRIPTION
Default value for --Coments now is `'some'`, comments that include `/*!` will also be preserved...