### PR TITLE
[Docs] Correct regex documentation example for property mangling

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ way to use this is to use the `regex` option like so:
 terser example.js -c -m --mangle-props regex=/_$/
 ```
 
-This will mangle all properties that start with an
+This will mangle all properties that end with an
 underscore. So you can use it to mangle internal methods.
 
 By default, it will mangle all properties in the


### PR DESCRIPTION
Thought that the text should say **end** rather than _start_, as `$` denotes end-of-string rather than the beginning.