### PR TITLE
Optimize condition for full char

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -249,7 +249,7 @@ function get_full_char(str, pos) {
             return char + next;
         }
     }
-    if (is_surrogate_pair_tail(char)) {
+    else if (is_surrogate_pair_tail(char)) {
         var prev = str.charAt(pos - 1);
         if (is_surrogate_pair_head(prev)) {
             return prev + char;


### PR DESCRIPTION
I just optimized condition. if `is_surrogate_pair_head` it can't be `tail`