### PR TITLE
disabled binary ops optimizations for BigInt

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5704,6 +5704,8 @@ function is_object(node) {
 }
 
 def_optimize(AST_Binary, function(self, compressor) {
+    if (self.left instanceof AST_BigInt || self.right instanceof AST_BigInt) return self;
+
     function reversible() {
         return self.left.is_constant()
             || self.right.is_constant()

--- a/test/compress/big_int.js
+++ b/test/compress/big_int.js
@@ -49,3 +49,14 @@ big_int_bad_digits_for_base: {
         message: "Invalid or unexpected token"
     })
 }
+
+big_int_math: {
+    input: {
+        const sum = 10n + 15n;
+        const exp = 5n ** 10n;
+        const sub = 1n - 3n;
+        const mul = 5n * 5n;
+        const div = 15n / 5n;
+    }
+    expect_exact: "const sum=10n+15n;const exp=5n**10n;const sub=1n-3n;const mul=5n*5n;const div=15n/5n;"
+}


### PR DESCRIPTION
optimizations for AST_Binary will prevented if one of operands is BigInt

Closes #546 
