### PR TITLE
Remove extra comparison in while loop

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -416,7 +416,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     }
 
     function forward(i) {
-        while (i-- > 0) next();
+        while (i--) next();
     }
 
     function looking_at(str) {


### PR DESCRIPTION
Since seems to be used with string lengths only, a `val < 0` isn't possible. Loop will end at `0` naturally. Since the current code is using `i--` (vs `--i`), if `i === 0` initially, the while loop won't run. If a number `< 0` is expected, I'd propose checking before the loop vs each iteration.

```js
// current
while (i-- > 0) // ...

// proposed
while (i--) // ...
```