### PR TITLE
Optimize checking surrogate pair

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -252,8 +252,8 @@ function OutputStream(options) {
     } : function(str) {
         var s = "";
         for (var i = 0, len = str.length; i < len; i++) {
-            if (is_surrogate_pair_head(str[i]) && !is_surrogate_pair_tail(str[i + 1])
-                || is_surrogate_pair_tail(str[i]) && !is_surrogate_pair_head(str[i - 1])) {
+            if (is_surrogate_pair_head(str.charCodeAt(i)) && !is_surrogate_pair_tail(str.charCodeAt(i + 1))
+                || is_surrogate_pair_tail(str.charCodeAt(i)) && !is_surrogate_pair_head(str.charCodeAt(i - 1))) {
                 s += "\\u" + str.charCodeAt(i).toString(16);
             } else {
                 s += str[i];

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -244,24 +244,21 @@ var UNICODE = {
 };
 
 function get_full_char(str, pos) {
-    var char = str.charAt(pos);
-    if (is_surrogate_pair_head(char)) {
-        var next = str.charAt(pos + 1);
-        if (is_surrogate_pair_tail(next)) {
-            return char + next;
+    if (is_surrogate_pair_head(str.charCodeAt(pos))) {
+        if (is_surrogate_pair_tail(str.charCodeAt(pos + 1))) {
+            return str.charAt(pos) + str.charAt(pos + 1);
         }
-    } else if (is_surrogate_pair_tail(char)) {
-        var prev = str.charAt(pos - 1);
-        if (is_surrogate_pair_head(prev)) {
-            return prev + char;
+    } else if (is_surrogate_pair_tail(str.charCodeAt(pos))) {
+        if (is_surrogate_pair_head(str.charCodeAt(pos - 1))) {
+            return str.charAt(pos - 1) + str.charAt(pos);
         }
     }
-    return char;
+    return str.charAt(pos);
 }
 
 function get_full_char_code(str, pos) {
     // https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Surrogates
-    if (is_surrogate_pair_head(str.charAt(pos))) {
+    if (is_surrogate_pair_head(str.charCodeAt(pos))) {
         return 0x10000 + (str.charCodeAt(pos) - 0xd800 << 10) + str.charCodeAt(pos + 1) - 0xdc00;
     }
     return str.charCodeAt(pos);
@@ -271,11 +268,9 @@ function get_full_char_length(str) {
     var surrogates = 0;
 
     for (var i = 0; i < str.length; i++) {
-        if (is_surrogate_pair_head(str.charCodeAt(i))) {
-            if (is_surrogate_pair_tail(str.charCodeAt(i + 1))) {
-                surrogates++;
-                i++;
-            }
+        if (is_surrogate_pair_head(str.charCodeAt(i)) && is_surrogate_pair_tail(str.charCodeAt(i + 1))) {
+            surrogates++;
+            i++;
         }
     }
 
@@ -293,15 +288,10 @@ function from_char_code(code) {
 }
 
 function is_surrogate_pair_head(code) {
-    if (typeof code === "string")
-        code = code.charCodeAt(0);
-
     return code >= 0xd800 && code <= 0xdbff;
 }
 
 function is_surrogate_pair_tail(code) {
-    if (typeof code === "string")
-        code = code.charCodeAt(0);
     return code >= 0xdc00 && code <= 0xdfff;
 }
 


### PR DESCRIPTION
I refactored function `is_surrogate_pair_head` and `is_surrogate_pair_tail` to use only one type argument.
string or number. (no good for v8 optimization)