### PR TITLE
Collapse multiple if-statements with the same consequents

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6589,18 +6589,17 @@ def_optimize(AST_Conditional, function(self, compressor) {
             alternative: alternative.alternative
         }).optimize(compressor);
     }
-    // a ? b : (c, b) --> (a || c) ? b : b
+    // a ? b : (c, b) --> (a || c), b
     if (alternative instanceof AST_Sequence
         && consequent.equivalent_to(alternative.expressions[alternative.expressions.length - 1])) {
-        return make_node(AST_Conditional, self, {
-            condition: make_node(AST_Binary, self, {
+        return make_sequence(self, [
+            make_node(AST_Binary, self, {
                 operator: "||",
                 left: condition,
                 right: make_sequence(self, alternative.expressions.slice(0, -1))
             }),
-            consequent: consequent,
-            alternative: consequent
-        }).optimize(compressor);
+            consequent
+        ]).optimize(compressor);
     }
     // a ? b : (c && b) --> (a || c) && b
     if (alternative instanceof AST_Binary

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6603,6 +6603,7 @@ def_optimize(AST_Conditional, function(self, compressor) {
     }
     // a ? b : (c && b) --> (a || c) && b
     if (alternative instanceof AST_Binary
+        && alternative.operator == "&&"
         && consequent.equivalent_to(alternative.right)) {
         return make_node(AST_Binary, self, {
             operator: "&&",

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6576,6 +6576,45 @@ def_optimize(AST_Conditional, function(self, compressor) {
         });
         return node;
     }
+    // a ? b : c ? b : d --> (a || c) ? b : d
+    if (alternative instanceof AST_Conditional
+        && consequent.equivalent_to(alternative.consequent)) {
+        return make_node(AST_Conditional, self, {
+            condition: make_node(AST_Binary, self, {
+                operator: "||",
+                left: condition,
+                right: alternative.condition
+            }),
+            consequent: consequent,
+            alternative: alternative.alternative
+        }).optimize(compressor);
+    }
+    // a ? b : (c, b) --> (a || c) ? b : b
+    if (alternative instanceof AST_Sequence
+        && consequent.equivalent_to(alternative.expressions[alternative.expressions.length - 1])) {
+        return make_node(AST_Conditional, self, {
+            condition: make_node(AST_Binary, self, {
+                operator: "||",
+                left: condition,
+                right: make_sequence(self, alternative.expressions.slice(0, -1))
+            }),
+            consequent: consequent,
+            alternative: consequent
+        }).optimize(compressor);
+    }
+    // a ? b : (c && b) --> (a || c) && b
+    if (alternative instanceof AST_Binary
+        && consequent.equivalent_to(alternative.right)) {
+        return make_node(AST_Binary, self, {
+            operator: "&&",
+            left: make_node(AST_Binary, self, {
+                operator: "||",
+                left: condition,
+                right: alternative.left
+            }),
+            right: consequent
+        }).optimize(compressor);
+    }
     // x?y?z:a:a --> x&&y?z:a
     if (consequent instanceof AST_Conditional
         && consequent.alternative.equivalent_to(alternative)) {

--- a/test/compress/conditionals.js
+++ b/test/compress/conditionals.js
@@ -332,7 +332,7 @@ cond_7: {
         x = 'foo';
         x = 'foo';
         x = (condition(), 20);
-        x = z ? 'fuji' : (condition(), 'fuji');
+        x = ((z || condition()), 'fuji');
         x = (condition(), 'foobar');
         x = y ? a : b;
         x = y ? 'foo' : 'fo';
@@ -1346,4 +1346,44 @@ to_and_or: {
         });
     }
     expect_stdout: true
+}
+
+ifs_same_consequent: {
+    options = {
+        conditionals: true,
+    }
+    input: {
+        if (foo) {
+            x();
+        } else if (bar) {
+            x();
+        } else if (baz) {
+            x();
+        }
+
+        if (foo) {
+            x();
+        } else if (bar) {
+            x();
+        } else if (baz) {
+            x();
+        } else {
+            x();
+        }
+
+        if (foo) {
+            x();
+        } else if (bar) {
+            x();
+        } else if (baz) {
+            x();
+        } else {
+            y();
+        }
+    }
+    expect: {
+        (foo || bar || baz) && x();
+        (foo || bar || baz), x();
+        (foo || bar || baz) ? x() : y();
+    }
 }

--- a/test/compress/if_return.js
+++ b/test/compress/if_return.js
@@ -487,3 +487,44 @@ issue_2747: {
     }
     expect_stdout: "null 5 4"
 }
+
+if_return_same_value: {
+    options = {
+        conditionals: true,
+        if_return: true,
+        sequences: true,
+    }
+    input: {
+        function f() {
+            if (foo) {
+                return x();
+            }
+            if (bar) {
+                return x();
+            }
+        }
+        function g() {
+            if (foo) {
+                return x();
+            }
+            if (bar) {
+                return x();
+            }
+            return x();
+        }
+        function h() {
+            if (foo) {
+                return x();
+            }
+            if (bar) {
+                return x();
+            }
+            return y();
+        }
+    }
+    expect: {
+        function f() { return (foo || bar) ? x() : void 0 }
+        function g() { return (foo || bar), x() }
+        function h() { return (foo || bar) ? x() : y() }
+    }
+}

--- a/test/compress/transform.js
+++ b/test/compress/transform.js
@@ -124,7 +124,7 @@ if_return: {
                 if (w) {
                     if (y) return;
                 } else if (z) return;
-                return x == y || (x && w(), y && z(), !0);
+                return x == y || (x && w(), y && z()), !0;
             }
         }
     }


### PR DESCRIPTION
I frequently write separated if-statements-with-return, even if the consequents are the same:

```js
if (foo) {
  return null;
}

if (bar) {
  return null;
}
```

This is mainly to add ample comments above each if-statement. Having these join together into `foo || bar` ternarys should be a win if the consequents are large.