### PR TITLE
Set AST_Node.prototype.constructor.

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -74,6 +74,7 @@ function DEFNODE(type, props, methods, base = AST_Node) {
     }
     if (base) base.SUBCLASSES.push(ctor);
     ctor.prototype.CTOR = ctor;
+    ctor.prototype.constructor = ctor;
     ctor.PROPS = props || null;
     ctor.SELF_PROPS = self_props;
     ctor.SUBCLASSES = [];


### PR DESCRIPTION
This makes console.log() and similar tooling print the right type for
the class.