### PR TITLE
Fix typing for SourceMapOptions.content

### DIFF
--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -163,7 +163,7 @@ export interface MinifyOutput {
 }
 
 export interface SourceMapOptions {
-    content?: RawSourceMap;
+    content?: RawSourceMap | 'inline';
     includeSources?: boolean;
     filename?: string;
     root?: string;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -163,7 +163,8 @@ export interface MinifyOutput {
 }
 
 export interface SourceMapOptions {
-    content?: RawSourceMap | 'inline';
+    /** Source map object, 'inline' or source map file content */
+    content?: RawSourceMap | string;
     includeSources?: boolean;
     filename?: string;
     root?: string;


### PR DESCRIPTION
- `SourceMapOptions.content` can be source map object,  `'inline'` or source map file content according to documentation and [tests](https://github.com/terser/terser/blob/6ba84bc30a231ba94a844c2ac43821123add6b64/test/mocha/sourcemaps.js#L153)