### PR TITLE
Implement `unsafe_symbols` optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,9 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `unsafe_math` (default: `false`) -- optimize numerical expressions like
   `2 * x * 3` into `6 * x`, which may give imprecise floating point results.
 
+- `unsafe_symbols` (default: `false`) -- removes keys from native Symbol 
+  declarations, e.g `Symbol("kDog")` becomes `Symbol()`.
+
 - `unsafe_methods` (default: false) -- Converts `{ m: function(){} }` to
   `{ m(){} }`. `ecma` must be set to `6` or greater to enable this transform.
   If `unsafe_methods` is a RegExp then key/value pairs with keys matching the

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4994,8 +4994,8 @@ def_optimize(AST_Call, function(self, compressor) {
             }
             break;
           case "Symbol":
-            if (compressor.option("unsafe_symbols"))
-                return make_node(AST_SymbolRef, self, exp).optimize(compressor);
+            if (self.args.length == 1 && compressor.option("unsafe_symbols"))
+                self.args.length = 0;
                 break;
           case "Boolean":
             if (self.args.length == 0) return make_node(AST_False, self);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4994,7 +4994,7 @@ def_optimize(AST_Call, function(self, compressor) {
             }
             break;
           case "Symbol":
-            if (self.args.length == 1 && compressor.option("unsafe_symbols"))
+            if (self.args.length == 1 && self.args[0] instanceof AST_String && compressor.option("unsafe_symbols"))
                 self.args.length = 0;
                 break;
           case "Boolean":

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -260,6 +260,7 @@ class Compressor extends TreeWalker {
             unsafe_comps  : false,
             unsafe_Function: false,
             unsafe_math   : false,
+            unsafe_symbols: false,
             unsafe_methods: false,
             unsafe_proto  : false,
             unsafe_regexp : false,
@@ -4992,6 +4993,10 @@ def_optimize(AST_Call, function(self, compressor) {
                 }).optimize(compressor);
             }
             break;
+          case "Symbol":
+            if (compressor.option("unsafe_symbols"))
+                return make_node(AST_SymbolRef, self, exp).optimize(compressor);
+                break;
           case "Boolean":
             if (self.args.length == 0) return make_node(AST_False, self);
             if (self.args.length == 1) return make_node(AST_UnaryPrefix, self, {

--- a/test/compress/unsafe_symbols.js
+++ b/test/compress/unsafe_symbols.js
@@ -8,6 +8,7 @@ unsafe_symbols_1: {
 
 unsafe_symbols_2: {
     options = {
+        unsafe: true,
         unsafe_symbols: true
     }
     input: {

--- a/test/compress/unsafe_symbols.js
+++ b/test/compress/unsafe_symbols.js
@@ -1,0 +1,17 @@
+unsafe_symbols_1: {
+    options = {}
+    input: {
+        Symbol("kDog");
+    }
+    expect_exact: 'Symbol("kDog");'
+}
+
+unsafe_symbols_2: {
+    options = {
+        unsafe_symbols: true
+    }
+    input: {
+        Symbol("kDog");
+    }
+    expect_exact: 'Symbol();'
+}

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -63,6 +63,7 @@ export interface CompressOptions {
     unsafe_comps?: boolean;
     unsafe_Function?: boolean;
     unsafe_math?: boolean;
+    unsafe_symbols?: boolean;
     unsafe_methods?: boolean;
     unsafe_proto?: boolean;
     unsafe_regexp?: boolean;


### PR DESCRIPTION
Since I suggested this in #580, I decided to take a stab at implementing it as it seemed simple enough. That being said, with absolutely no familiarity with this code-base, I'm going to need some pointers.

With this, the following code:
```
const SYMBOL_DOG = Symbol("kDog");
const SYMBOL_CAT = Symbol("kCat");
console.log(SYMBOL_DOG, SYMBOL_CAT);
```
Is optimized into this:
```
const SYMBOL_DOG=Symbol,SYMBOL_CAT=Symbol;console.log(SYMBOL_DOG,SYMBOL_CAT);
```

This is *almost* correct, but the lack of parenthesis is an error because `Symbol` is a native constructor. I'm not sure how to resolve that, so I could use a pointer!

Additionally, I'm 70% sure that my use of passing `exp` directly as the `props` parameter for `make_node` is actually wrong, but again I'm not familiar with this at all. Should it just be a new object? I kept hitting a wall trying to provide that.

- [x] Updated README.md
- [ ] Implement tests.