### PR TITLE
Implement `drop_assert` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,9 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
   such as `console.info` and/or retain side effects from function arguments
   after dropping the function call then use `pure_funcs` instead.
 
+- `drop_assert` (default: `false`) -- Pass `true` to discard calls to
+  `assert.*` functions (part of NodeJS).
+
 - `drop_debugger` (default: `true`) -- remove `debugger;` statements
 
 - `ecma` (default: `5`) -- Pass `2015` or greater to enable `compress` options that

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -227,6 +227,7 @@ class Compressor extends TreeWalker {
             defaults      : true,
             directives    : !false_by_default,
             drop_console  : false,
+            drop_assert   : false,
             drop_debugger : !false_by_default,
             ecma          : 5,
             evaluate      : !false_by_default,
@@ -366,9 +367,12 @@ class Compressor extends TreeWalker {
         var mangle = { ie8: this.option("ie8") };
         for (var pass = 0; pass < passes; pass++) {
             toplevel.figure_out_scope(mangle);
+            // must be run before reduce_vars and compress pass
             if (pass === 0 && this.option("drop_console")) {
-                // must be run before reduce_vars and compress pass
                 toplevel = toplevel.drop_console();
+            }
+            if (pass === 0 && this.option("drop_assert")) {
+                toplevel = toplevel.drop_assert();
             }
             if (pass > 0 || this.option("reduce_vars")) {
                 toplevel.reset_opt_flags(this);
@@ -470,6 +474,23 @@ AST_Toplevel.DEFMETHOD("drop_console", function() {
                     name = name.expression;
                 }
                 if (is_undeclared_ref(name) && name.name == "console") {
+                    return make_node(AST_Undefined, self);
+                }
+            }
+        }
+    }));
+});
+
+AST_Toplevel.DEFMETHOD("drop_assert", function() {
+    return this.transform(new TreeTransformer(function(self) {
+        if (self.TYPE == "Call") {
+            var exp = self.expression;
+            if (exp instanceof AST_PropAccess) {
+                var name = exp.expression;
+                while (name.expression) {
+                    name = name.expression;
+                }
+                if (is_undeclared_ref(name) && name.name == "assert") {
                     return make_node(AST_Undefined, self);
                 }
             }

--- a/test/compress/drop-assert.js
+++ b/test/compress/drop-assert.js
@@ -1,0 +1,26 @@
+drop_assert_1: {
+    options = {}
+    input: {
+        assert.equal(true, true);
+        assert.equal.apply(assert, arguments);
+    }
+    expect: {
+        assert.equal(true, true);
+        assert.equal.apply(assert, arguments);
+    }
+}
+
+drop_assert_2: {
+    options = {
+        drop_assert: true,
+    }
+    input: {
+        assert.equal(true, true);
+        assert.equal.apply(assert, arguments);
+    }
+    expect: {
+        // with regular compression these will be stripped out as well
+        void 0;
+        void 0;
+    }
+}

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -27,6 +27,7 @@ export interface CompressOptions {
     defaults?: boolean;
     directives?: boolean;
     drop_console?: boolean;
+    drop_assert?: boolean;
     drop_debugger?: boolean;
     ecma?: ECMA;
     evaluate?: boolean;


### PR DESCRIPTION
Following on the similar mindset of being able to remove all calls to `console.*` from the code, I believe it's fairly common to do the same thing with `assert.*` calls in a NodeJS environment if they're used exclusively as a development feature rather than runtime enforcement.

I know that Terser doesn't operate solely with NodeJS people in-mind, but I figured that being completely optional, it doesn't hurt to have; I'd love to do away with having to list every assert function in `pure_funcs` (I'm not aware of any ability to wildcard in `pure_funcs`).

Feel free to tell me to shoo if this is out-of-scope for Terser!