### PR TITLE
Add unsafe optimization to inline undefined for missing objlit props

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6878,6 +6878,7 @@ def_optimize(AST_Sub, function(self, compressor) {
     if (key !== prop) {
         var sub = self.flatten_object(property, compressor);
         if (sub) {
+            if (sub instanceof AST_Undefined) return sub;
             expr = self.expression = sub.expression;
             prop = self.property = sub.property;
         }
@@ -6941,14 +6942,37 @@ AST_Lambda.DEFMETHOD("contains_this", function() {
     });
 });
 
+const objectPrototypeProperties = new Set([
+    "__count__",
+    "__defineGetter__",
+    "__defineSetter__",
+    "__lookupGetter__",
+    "__lookupSetter__",
+    "__noSuchMethod__",
+    "__parent__",
+    "__proto__",
+    "constructor",
+    "eval",
+    "hasOwnProperty",
+    "isPrototypeOf",
+    "propertyIsEnumerable",
+    "toLocaleString",
+    "toSource",
+    "toString",
+    "unwatch",
+    "valueOf",
+    "watch",
+]);
 AST_PropAccess.DEFMETHOD("flatten_object", function(key, compressor) {
     if (!compressor.option("properties")) return;
     var arrows = compressor.option("unsafe_arrows") && compressor.option("ecma") >= 2015;
     var expr = this.expression;
     if (expr instanceof AST_Object) {
         var props = expr.properties;
+        var collapse_missing_props = compressor.option("unsafe");
         for (var i = props.length; --i >= 0;) {
             var prop = props[i];
+            if (prop.value instanceof AST_Accessor) collapse_missing_props = false;
             if ("" + (prop instanceof AST_ConciseMethod ? prop.key.name : prop.key) == key) {
                 if (!props.every((prop) => {
                     return prop instanceof AST_ObjectKeyVal
@@ -6972,6 +6996,9 @@ AST_PropAccess.DEFMETHOD("flatten_object", function(key, compressor) {
                     })
                 });
             }
+        }
+        if (i < 0 && collapse_missing_props && !objectPrototypeProperties.has(key)) {
+            return make_node(AST_Undefined, this);
         }
     }
 });

--- a/test/compress/eval2.js
+++ b/test/compress/eval2.js
@@ -1,0 +1,17 @@
+unsafe_integer_key: {
+    options = {
+        evaluate: true,
+        unsafe: true,
+    }
+    input: {
+        console.log(
+            ({0:1})[1] + 1,
+        );
+    }
+    expect: {
+        console.log(
+            ({0:1})[1] + 1,
+        );
+    }
+    expect_stdout: true
+}

--- a/test/compress/prop2.js
+++ b/test/compress/prop2.js
@@ -1,0 +1,33 @@
+missing_prop: {
+    options = {
+        inline: true,
+        properties: true,
+        unsafe: true,
+    }
+    input: {
+        console.log({x: 42}.y);
+    }
+    expect: {
+        console.log(void 0);
+    }
+    expect_stdout: [
+        "undefined",
+    ]
+}
+
+missing_prop_object_prototype_method: {
+    options = {
+        inline: true,
+        properties: true,
+        unsafe: true,
+    }
+    input: {
+        console.log({}.toString());
+    }
+    expect: {
+        console.log({}.toString());
+    }
+    expect_stdout: [
+        "[object Object]",
+    ]
+}

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1224,6 +1224,23 @@ prop_side_effects_2: {
     ]
 }
 
+missing_prop: {
+    options = {
+        inline: true,
+        properties: true,
+        unsafe: true,
+    }
+    input: {
+        console.log({x: 42}.y);
+    }
+    expect: {
+        console.log(void 0);
+    }
+    expect_stdout: [
+        "undefined",
+    ]
+}
+
 accessor_1: {
     options = {
         properties: true,


### PR DESCRIPTION
Fixes #584 

This is safe unless the code is relying on non-standard properties being defined on Object.prototype, which is why the optimization is protected behind the "unsafe" option.

Enabling this allows the following general pattern:
```
const ENABLE_ASSERTS = process.env.ENABLE_ASSERTS ?? process.env.NODE_ENV === 'development';
```

If compiled with `--define process.env={}` as the last define, then it allows individually toggling (in this case) asserts, but if nothing is specified then it will smoothly fall back on NODE_ENV.  In addition to debugging features this can be useful for differential compilation (e.g. a "master" switch for "assume browsers released after 20XX" that provides reasonable defaults for avoiding feature detection in most cases, but also providing fine-grained overrides for individual features that may be more important to actually detect for one application over another.