### PR TITLE
Fixed issue #585 (Problem with setting --comments to false)

### DIFF
--- a/bin/terser
+++ b/bin/terser
@@ -99,7 +99,7 @@ if (program.beautify) {
 }
 if (program.comments) {
     if (typeof options.output != "object") options.output = {};
-    options.output.comments = typeof program.comments == "string" ? program.comments : "some";
+    options.output.comments = typeof program.comments == "string" ? (program.comments == "false" ? false : program.comments) : "some";
 }
 if (program.define) {
     if (typeof options.compress != "object") options.compress = {};

--- a/test/input/issue-585/input.js
+++ b/test/input/issue-585/input.js
@@ -1,0 +1,6 @@
+/*!
+ * This comment should get removed in output if command
+ * line argument --comment has been set to false.
+ *
+ * @license ISC
+ */

--- a/test/mocha/issue-585.js
+++ b/test/mocha/issue-585.js
@@ -1,0 +1,16 @@
+var assert = require("assert");
+var exec = require("child_process").exec;
+
+describe("bin/terser", function() {
+    var tersercmd = '"' + process.argv[0] + '" bin/terser';
+    it("Should be able to filter comments correctly with `--comments false`", function (done) {
+        var command = tersercmd + " test/input/issue-585/input.js --comments false";
+
+        exec(command, function (err, stdout) {
+            if (err) throw err;
+
+            assert.strictEqual(stdout, "\n");
+            done();
+        });
+    });
+});


### PR DESCRIPTION
As described in #585 setting the CLI argument `--comments` to `false` results in unexpected behaviour since the non-empty string `'false'` gets passed as a string and later gets evaluated to `true`.

I added an mocha test case for this issue and fixed it.