### PR TITLE
fix: call "contains_this" only for AST_Lambda

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6796,9 +6796,9 @@ function safe_to_flatten(value, compressor) {
         value = value.fixed_value();
     }
     if (!value) return false;
-    return !(value instanceof AST_Lambda || value instanceof AST_Class)
-        || compressor.parent() instanceof AST_New
-        || !value.contains_this();
+    if (!(value instanceof AST_Lambda || value instanceof AST_Class)) return true;
+    if (!(value instanceof AST_Lambda && value.contains_this())) return true;
+    return compressor.parent() instanceof AST_New;
 }
 
 def_optimize(AST_Sub, function(self, compressor) {


### PR DESCRIPTION
before `value.contains_this()` could be called for `AST_Lambda` or `AST_Class` but method itself defined only for `AST_Lambda` and attemp to call it on `AST_Class` cause terser to crash

Closes #593 