### PR TITLE
Optimize template literals in binary expressions

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2566,9 +2566,7 @@ function is_undefined(node, compressor) {
 (function(def_is_string) {
     def_is_string(AST_Node, return_false);
     def_is_string(AST_String, return_true);
-    def_is_string(AST_TemplateString, function() {
-        return true;
-    });
+    def_is_string(AST_TemplateString, return_true);
     def_is_string(AST_UnaryPrefix, function() {
         return this.operator == "typeof";
     });
@@ -6090,7 +6088,6 @@ def_optimize(AST_Binary, function(self, compressor) {
                 }
                 return l;
             }
-            // `((("" + "1") + `2${any}3`) + "4) => `1${bar}2foo${bar}baz`
           case "*":
             associative = compressor.option("unsafe_math");
           case "&":

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2567,7 +2567,7 @@ function is_undefined(node, compressor) {
     def_is_string(AST_Node, return_false);
     def_is_string(AST_String, return_true);
     def_is_string(AST_TemplateString, function() {
-        return this.segments.length === 1;
+        return true;
     });
     def_is_string(AST_UnaryPrefix, function() {
         return this.operator == "typeof";
@@ -5978,56 +5978,64 @@ def_optimize(AST_Binary, function(self, compressor) {
             if (self.left instanceof AST_Constant
                 && self.right instanceof AST_Binary
                 && self.right.operator == "+"
-                && self.right.left instanceof AST_Constant
                 && self.right.is_string(compressor)) {
-                self = make_node(AST_Binary, self, {
+                var binary = make_node(AST_Binary, self, {
                     operator: "+",
-                    left: make_node(AST_String, self.left, {
-                        value: "" + self.left.getValue() + self.right.left.getValue(),
-                        start: self.left.start,
-                        end: self.right.left.end
-                    }),
-                    right: self.right.right
+                    left: self.left,
+                    right: self.right.left,
                 });
+                var l = binary.optimize(compressor);
+                if (binary !== l) {
+                    self = make_node(AST_Binary, self, {
+                        operator: "+",
+                        left: l,
+                        right: self.right.right
+                    });
+                }
             }
             // (x + "foo") + "bar" => x + "foobar"
             if (self.right instanceof AST_Constant
                 && self.left instanceof AST_Binary
                 && self.left.operator == "+"
-                && self.left.right instanceof AST_Constant
                 && self.left.is_string(compressor)) {
-                self = make_node(AST_Binary, self, {
+                var binary = make_node(AST_Binary, self, {
                     operator: "+",
-                    left: self.left.left,
-                    right: make_node(AST_String, self.right, {
-                        value: "" + self.left.right.getValue() + self.right.getValue(),
-                        start: self.left.right.start,
-                        end: self.right.end
-                    })
+                    left: self.left.right,
+                    right: self.right,
                 });
+                var r = binary.optimize(compressor);
+                if (binary !== r) {
+                    self = make_node(AST_Binary, self, {
+                        operator: "+",
+                        left: self.left.left,
+                        right: r
+                    });
+                }
             }
             // (x + "foo") + ("bar" + y) => (x + "foobar") + y
             if (self.left instanceof AST_Binary
                 && self.left.operator == "+"
                 && self.left.is_string(compressor)
-                && self.left.right instanceof AST_Constant
                 && self.right instanceof AST_Binary
                 && self.right.operator == "+"
-                && self.right.left instanceof AST_Constant
                 && self.right.is_string(compressor)) {
-                self = make_node(AST_Binary, self, {
+                var binary = make_node(AST_Binary, self, {
                     operator: "+",
-                    left: make_node(AST_Binary, self.left, {
-                        operator: "+",
-                        left: self.left.left,
-                        right: make_node(AST_String, self.left.right, {
-                            value: "" + self.left.right.getValue() + self.right.left.getValue(),
-                            start: self.left.right.start,
-                            end: self.right.left.end
-                        })
-                    }),
-                    right: self.right.right
+                    left: self.left.right,
+                    right: self.right.left,
                 });
+                var m = binary.optimize(compressor);
+                if (binary !== m) {
+                    self = make_node(AST_Binary, self, {
+                        operator: "+",
+                        left: make_node(AST_Binary, self.left, {
+                            operator: "+",
+                            left: self.left.left,
+                            right: m
+                        }),
+                        right: self.right.right
+                    });
+                }
             }
             // a + -b => a - b
             if (self.right instanceof AST_UnaryPrefix
@@ -6052,6 +6060,37 @@ def_optimize(AST_Binary, function(self, compressor) {
                 });
                 break;
             }
+            // `foo${bar}baz` + 1 => `foo${bar}baz1`
+            if (self.left instanceof AST_TemplateString) {
+                var l = self.left;
+                var r = self.right.evaluate(compressor);
+                if (r != self.right) {
+                    l.segments[l.segments.length - 1].value += r.toString();
+                    return l;
+                }
+            }
+            // 1 + `foo${bar}baz` => `1foo${bar}baz`
+            if (self.right instanceof AST_TemplateString) {
+                var r = self.right;
+                var l = self.left.evaluate(compressor);
+                if (l != self.left) {
+                    r.segments[0].value = l.toString() + r.segments[0].value ;
+                    return r;
+                }
+            }
+            // `1${bar}2` + `foo${bar}baz` => `1${bar}2foo${bar}baz`
+            if (self.left instanceof AST_TemplateString
+                && self.right instanceof AST_TemplateString) {
+                var l = self.left;
+                var segments = l.segments;
+                var r = self.right;
+                segments[segments.length - 1].value += r.segments[0].value;
+                for (var i = 1; i < r.segments.length; i++) {
+                    segments.push(r.segments[i]);
+                }
+                return l;
+            }
+            // `((("" + "1") + `2${any}3`) + "4) => `1${bar}2foo${bar}baz`
           case "*":
             associative = compressor.option("unsafe_math");
           case "&":
@@ -7182,12 +7221,51 @@ def_optimize(AST_TemplateString, function(self, compressor) {
                 segments[segments.length - 1].value = segments[segments.length - 1].value + result + self.segments[++i].value;
                 continue;
             }
+            // `before ${`innerBefore ${any} innerAfter`} after` => `before innerBefore ${any} innerAfter after`
+            // TODO:
+            // `before ${'test' + foo} after` => `before innerBefore ${any} innerAfter after`
+            // `before ${foo + 'test} after` => `before innerBefore ${any} innerAfter after`
+            if (segment instanceof AST_TemplateString) {
+                var inners = segment.segments;
+                segments[segments.length - 1].value += inners[0].value;
+                for (var j = 1; j < inners.length; j++) {
+                    segment = inners[j];
+                    segments.push(segment);
+                }
+                continue;
+            }
         }
         segments.push(segment);
     }
     self.segments = segments;
 
-    return segments.length == 1 ? make_node(AST_String, self, segments[0]) : self;
+    // `foo` => "foo"
+    if (segments.length == 1) {
+        return make_node(AST_String, self, segments[0]);
+    }
+    if (segments.length === 3 && segments[1] instanceof AST_Node) {
+        // `foo${bar}` => "foo" + bar
+        if (segments[2].value === "") {
+            return make_node(AST_Binary, self, {
+                operator: "+",
+                left: make_node(AST_String, self, {
+                    value: segments[0].value,
+                }),
+                right: segments[1],
+            });
+        }
+        // `{bar}baz` => bar + "baz"
+        if (segments[0].value === "") {
+            return make_node(AST_Binary, self, {
+                operator: "+",
+                left: segments[1],
+                right: make_node(AST_String, self, {
+                    value: segments[2].value,
+                }),
+            });
+        }
+    }
+    return self;
 });
 
 def_optimize(AST_PrefixedTemplateString, function(self) {

--- a/test/compress/template-string.js
+++ b/test/compress/template-string.js
@@ -108,19 +108,19 @@ template_string_with_predefined_constants: {
         var foo = "This is undefined";
         var bar = "This is NaN";
         var baz = "This is null";
-        var foofoo = `This is ${1/0}`;
+        var foofoo = "This is " + 1/0;
         var foobar = "This is ${1/0}";
         var foobaz = 'This is ${1/0}';
         var barfoo = "This is ${NaN}";
         var bazfoo = "This is ${null}";
-        var bazbaz = `This is ${1/0}`;
+        var bazbaz = "This is " + 1/0;
         var barbar = "This is NaN";
         var barbar = "This is ${0/0}";
         var barber = 'This is ${0/0}';
 
         var a = "4194304";
         var b = "16777216"; // Potential for further concatentation
-        var c = `${4**14}`; // Not worth converting
+        var c = "" + 4**14; // Not worth converting
     }
 }
 
@@ -193,7 +193,7 @@ template_concattenating_string: {
     }
     expect: {
         var foo = "Have a nice day. day. day.";
-        var bar = "Have a nice " + `${day()}`;
+        var bar = "Have a nice " + day();
     }
 }
 
@@ -205,10 +205,14 @@ evaluate_nested_templates: {
         quote_style: 0
     }
     input: {
-        var baz = `${`${`${`foo`}`}`}`;
+        var foo = `${`${`${`foo`}`}`}`;
+        var bar = `before ${`innerBefore ${any} innerAfter`} after`;
+        var baz = `1 ${2 + `3 ${any} 4` + 5} 6`;
     }
     expect: {
-        var baz = "foo";
+        var foo = "foo";
+        var bar = `before innerBefore ${any} innerAfter after`;
+        var baz = `1 23 ${any} 45 6`;
     }
 }
 
@@ -259,7 +263,7 @@ enforce_double_quotes_and_evaluate: {
     expect: {
         var foo = "Hello world";
         var bar = "Hello world";
-        var baz = `Hello ${world()}`;
+        var baz = "Hello " + world();
     }
 }
 
@@ -278,7 +282,7 @@ enforce_single_quotes_and_evaluate: {
     expect: {
         var foo = "Hello world";
         var bar = "Hello world";
-        var baz = `Hello ${world()}`;
+        var baz = "Hello " + world();
     }
 }
 
@@ -441,8 +445,8 @@ t${5}`);
         tag`t${4}`;
         console.log("\nt5");
         function f(a) {
-            a &= `t7${a}`;
-            a = `t8${b}` | a;
+            a &= "t7" + a;
+            a = "t8" + b | a;
             a = f`t9${a}` ^ a;
         }
     }
@@ -887,4 +891,84 @@ allow_null_character: {
         `\0${x}`;
     }
     expect_exact: "`\\0`;`\\0${x}`;"
+}
+
+template_literal_plus: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        console.log(`foo${any}baz` + 1);
+        console.log(1 + `foo${any}baz`);
+        console.log(`1${any}2` + `foo${any}baz`);
+    }
+    expect: {
+        console.log(`foo${any}baz1`);
+        console.log(`1foo${any}baz`);
+        console.log(`1${any}2foo${any}baz`);
+    }
+}
+
+template_literal_plus_grouping: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        console.log((`foo${any}baz` + 'middle') + 'test');
+        console.log('test' + ('middle' + `foo${any}baz`));
+        console.log((`1${any}2` + '3') + ('4' + `foo${any}baz`));
+        console.log((1 + `2${any}3` + '4') + ('5' + `foo${any}baz` + 6));
+    }
+    expect: {
+        console.log(`foo${any}bazmiddletest`);
+        console.log(`testmiddlefoo${any}baz`);
+        console.log(`1${any}234foo${any}baz`);
+        console.log(`12${any}345foo${any}baz6`);
+    }
+}
+
+array_join: {
+    options = {
+        evaluate: true,
+        unsafe: true,
+    }
+    input: {
+        var foo = [`1 ${any} 2`].join('');
+        var bar = ["before", `1 ${any} 2`].join('');
+        var baz = [`1 ${any} 2`, "after"].join('');
+        var qux = ["before", `1 ${any} 2`, "after"].join('');
+    }
+    expect: {
+        var foo = `1 ${any} 2`;
+        var bar = `before1 ${any} 2`;
+        var baz = `1 ${any} 2after`;
+        var qux = `before1 ${any} 2after`;
+    }
+}
+
+equality: {
+    options = {
+        evaluate: true,
+        comparisons: true,
+    }
+    input: {
+        var a = `1${any}2` === '12'
+        var b = `1${any}2` === `12`
+    }
+    expect: {
+        var a = "12" == `1${any}2`
+        var b = "12" == `1${any}2`
+    }
+}
+
+coerce_to_string: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        var str = `${any}`;
+    }
+    expect: {
+        var str = '' + any;
+    }
 }


### PR DESCRIPTION
This adds support for template literals inside `+` binary operations. Our babel transforms aren't always the smartest when outputting code, so we'll sometimes get ``` `foo ${expression} bar` + 'baz' ``` expressions that can be joined into a single ``` `foo ${expression} barbaz` ```