### PR TITLE
Add explicit tests for template literal joining with special chars

### DIFF
--- a/test/compress/template-string.js
+++ b/test/compress/template-string.js
@@ -972,3 +972,19 @@ coerce_to_string: {
         var str = '' + any;
     }
 }
+
+special_chars_in_string: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        var str = `foo ${'`;\n`${any}'} bar`;
+        var concat = `foo ${any} bar` + '`;\n`${any}';
+        var template = `foo ${'`;\n`${any}'} ${any} bar`;
+    }
+    expect: {
+        var str="foo `;\n`${any} bar";
+        var concat=`foo ${any} bar\`;\n\`\${any}`;
+        var template=`foo \`;\n\`\${any} ${any} bar`;
+    }
+}


### PR DESCRIPTION
Re: https://github.com/terser/terser/pull/633

This adds explicit tests for joining template literals with strings that chars with special meaning inside template literals. Mainly to ensure I didn't just add a security vulnerability.