### PR TITLE
Improve inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,10 +824,8 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
   occasions the default sequences limit leads to very slow compress times in which
   case a value of `20` or less is recommended.
 
-- `side_effects` (default: `true`) -- Pass `false` to disable potentially dropping
-  function calls marked as "pure".  A function call is marked as "pure" if a comment
-  annotation `/*@__PURE__*/` or `/*#__PURE__*/` immediately precedes the call. For
-  example: `/*@__PURE__*/foo();`
+- `side_effects` (default: `true`) -- Remove expressions which have no side effects
+  and whose results aren't used.
 
 - `switches` (default: `true`) -- de-duplicate and remove unreachable `switch` branches
 

--- a/bin/terser
+++ b/bin/terser
@@ -16,7 +16,7 @@ try {
     require("source-map-support").install();
 } catch (err) {}
 
-const skip_keys = new Set([ "cname", "parent_scope", "scope", "uses_eval", "uses_with", "_var_name_cache" ]);
+const skip_keys = new Set([ "cname", "parent_scope", "scope", "uses_eval", "uses_with" ]);
 var files = {};
 var options = {
     compress: false,

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -356,7 +356,7 @@ var AST_With = DEFNODE("With", "expression", {
 
 /* -----[ scope and functions ]----- */
 
-var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent_scope enclosed cname _var_name_cache", {
+var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent_scope enclosed cname", {
     $documentation: "Base class for all statements introducing a lexical scope",
     $propdoc: {
         variables: "[Map/S] a map of name -> SymbolDef for all variables/functions defined in this scope",

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -374,12 +374,19 @@ var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent
         }
         return self;
     },
-    clone: function(deep) {
+    clone: function(deep, toplevel) {
         var node = this._clone(deep);
-        if (this.variables) node.variables = new Map(this.variables);
-        if (this.functions) node.functions = new Map(this.functions);
-        if (this.enclosed) node.enclosed = this.enclosed.slice();
-        if (this._block_scope) node._block_scope = this._block_scope;
+        if (deep && this.variables && toplevel && !this._block_scope) {
+            node.figure_out_scope({}, {
+                toplevel: toplevel,
+                parent_scope: this.parent_scope
+            });
+        } else {
+            if (this.variables) node.variables = new Map(this.variables);
+            if (this.functions) node.functions = new Map(this.functions);
+            if (this.enclosed) node.enclosed = this.enclosed.slice();
+            if (this._block_scope) node._block_scope = this._block_scope;
+        }
         return node;
     },
     pinned: function() {
@@ -1713,12 +1720,16 @@ export {
     AST_While,
     AST_With,
     AST_Yield,
+
+    // Walkers
     TreeTransformer,
     TreeWalker,
     walk,
     walk_abort,
     walk_body,
     walk_parent,
+
+    // annotations
     _INLINE,
     _NOINLINE,
     _PURE,

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -593,7 +593,6 @@ function is_modified(compressor, tw, node, value, level, immutable) {
         def.escaped = 0;
         def.recursive_refs = 0;
         def.references = [];
-        def.should_replace = undefined;
         def.single_use = undefined;
         if (def.scope.pinned()) {
             def.fixed = false;
@@ -3522,6 +3521,7 @@ const pure_prop_access_globals = new Set([
                 return true;
             }
             if (node instanceof AST_This && this instanceof AST_Arrow) {
+                // TODO check arguments too!
                 result = false;
                 return walk_abort;
             }
@@ -6280,9 +6280,11 @@ function within_array_or_object_literal(compressor) {
 }
 
 def_optimize(AST_SymbolRef, function(self, compressor) {
-    if (!compressor.option("ie8")
+    if (
+        !compressor.option("ie8")
         && is_undeclared_ref(self)
-        && (!self.scope.uses_with || !compressor.find_parent(AST_With))) {
+        && !compressor.find_parent(AST_With)
+    ) {
         switch (self.name) {
           case "undefined":
             return make_node(AST_Undefined, self).optimize(compressor);
@@ -6292,20 +6294,22 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
             return make_node(AST_Infinity, self).optimize(compressor);
         }
     }
-    var parent = compressor.parent();
+
+    const parent = compressor.parent();
     if (compressor.option("reduce_vars") && is_lhs(self, parent) !== self) {
         const def = self.definition();
         if (compressor.top_retain && def.global && compressor.top_retain(def)) {
             def.fixed = false;
-            def.should_replace = false;
             def.single_use = false;
             return self;
         }
-        var fixed = self.fixed_value();
-        var single_use = def.single_use
+
+        let fixed = self.fixed_value();
+        let single_use = def.single_use
             && !(parent instanceof AST_Call
                 && (parent.is_expr_pure(compressor))
                     || has_annotation(parent, _NOINLINE));
+
         if (single_use && (fixed instanceof AST_Lambda || fixed instanceof AST_Class)) {
             if (retain_top_func(fixed, compressor)) {
                 single_use = false;
@@ -6346,8 +6350,8 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
                     prop.may_throw(compressor) || prop.has_side_effects(compressor)
                 );
         }
-        const can_pull_in = single_use && fixed;
-        if (can_pull_in) {
+
+        if (single_use && fixed) {
             if (fixed instanceof AST_DefClass) {
                 set_flag(fixed, SQUEEZED);
                 fixed = make_node(AST_ClassExpression, fixed, fixed);
@@ -6378,57 +6382,46 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
             }
             return fixed.optimize(compressor);
         }
-        if (fixed && def.should_replace === undefined) {
-            let init;
+
+        // multiple uses
+        if (fixed) {
+            let replace;
+
             if (fixed instanceof AST_This) {
                 if (!(def.orig[0] instanceof AST_SymbolFunarg)
                     && def.references.every((ref) =>
                         def.scope === ref.scope
                     )) {
-                    init = fixed;
+                    replace = fixed;
                 }
             } else {
                 var ev = fixed.evaluate(compressor);
-                if (ev !== fixed && (compressor.option("unsafe_regexp") || !(ev instanceof RegExp))) {
-                    init = make_node_from_constant(ev, fixed);
+                if (
+                    ev !== fixed
+                    && (compressor.option("unsafe_regexp") || !(ev instanceof RegExp))
+                ) {
+                    replace = make_node_from_constant(ev, fixed);
                 }
             }
-            if (init) {
-                var value_length = init.optimize(compressor).size();
-                var fn;
-                if (has_symbol_ref(fixed)) {
-                    fn = function() {
-                        var result = init.optimize(compressor);
-                        return result === init ? result.clone(true) : result;
-                    };
-                } else {
-                    value_length = Math.min(value_length, fixed.size());
-                    fn = function() {
-                        var result = best_of_expression(init.optimize(compressor), fixed);
-                        return result === init || result === fixed ? result.clone(true) : result;
-                    };
-                }
-                var name_length = def.name.length;
-                var overhead = 0;
+
+            if (replace) {
+                const name_length = def.name.length;
+                const replace_size = replace.size();
+
+                let overhead = 0;
                 if (compressor.option("unused") && !compressor.exposed(def)) {
-                    overhead = (name_length + 2 + value_length) / (def.references.length - def.assignments);
+                    overhead =
+                        (name_length + 2 + replace_size) /
+                        (def.references.length - def.assignments);
                 }
-                def.should_replace = value_length <= name_length + overhead ? fn : false;
-            } else {
-                def.should_replace = false;
+
+                if (replace_size <= name_length + overhead) {
+                    return replace;
+                }
             }
-        }
-        if (def.should_replace) {
-            return def.should_replace();
         }
     }
     return self;
-
-    function has_symbol_ref(value) {
-        return walk(value, node => {
-            if (node instanceof AST_SymbolRef) return walk_abort;
-        });
-    }
 });
 
 function scope_encloses_variables_in_this_scope(scope, pulled_scope) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5308,9 +5308,12 @@ def_optimize(AST_Call, function(self, compressor) {
             && returned instanceof AST_SymbolRef
             && returned.name === fn.argnames[0].name
         ) {
+            const replacement =
+                (self.args[0] || make_node(AST_Undefined)).optimize(compressor);
+
             let parent;
             if (
-                self.args[0] instanceof AST_PropAccess
+                replacement instanceof AST_PropAccess
                 && (parent = compressor.parent()) instanceof AST_Call
                 && parent.expression === self
             ) {
@@ -5322,13 +5325,14 @@ def_optimize(AST_Call, function(self, compressor) {
 
                 return make_sequence(self, [
                     make_node(AST_Number, self, { value: 0 }),
-                    self.args[0].optimize(compressor)
+                    replacement
                 ]);
             }
             // replace call with first argument or undefined if none passed
-            return (self.args[0] || make_node(AST_Undefined)).optimize(compressor);
+            return replacement;
         }
     }
+
     if (can_inline) {
         var scope, in_loop, level = -1;
         let def;
@@ -5449,48 +5453,6 @@ def_optimize(AST_Call, function(self, compressor) {
         return true;
     }
 
-    function can_inject_args_values() {
-        var arg_vals_outer_refs = new Set();
-        const value_walker = node => {
-            if (node instanceof AST_Scope) {
-                var scope_outer_refs = new Set();
-                node.enclosed.forEach(function(def) {
-                    scope_outer_refs.add(def.name);
-                });
-                node.variables.forEach(function(name) {
-                    scope_outer_refs.delete(name);
-                });
-                scope_outer_refs.forEach(function(name) {
-                    arg_vals_outer_refs.add(name);
-                });
-                return true;
-            }
-        };
-        for (let i = 0; i < self.args.length; i++) {
-            walk(self.args[i], value_walker);
-        }
-        if (arg_vals_outer_refs.size == 0) return true;
-        for (let i = 0, len = fn.argnames.length; i < len; i++) {
-            var arg = fn.argnames[i];
-            if (arg instanceof AST_DefaultAssign && has_flag(arg.left, UNUSED)) continue;
-            if (arg instanceof AST_Expansion && has_flag(arg.expression, UNUSED)) continue;
-            if (has_flag(arg, UNUSED)) continue;
-            if (arg_vals_outer_refs.has(arg.name)) return false;
-        }
-        for (let i = 0, len = fn.body.length; i < len; i++) {
-            var stat = fn.body[i];
-            if (!(stat instanceof AST_Var)) continue;
-            for (var j = stat.definitions.length; --j >= 0;) {
-                var name = stat.definitions[j].name;
-                if (name instanceof AST_Destructuring
-                    || arg_vals_outer_refs.has(name.name)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
     function can_inject_vars(block_scoped, safe_to_inject) {
         var len = fn.body.length;
         for (var i = 0; i < len; i++) {
@@ -5538,7 +5500,6 @@ def_optimize(AST_Call, function(self, compressor) {
         var inline = compressor.option("inline");
         if (!can_inject_vars(block_scoped, inline >= 3 && safe_to_inject)) return false;
         if (!can_inject_args(block_scoped, inline >= 2 && safe_to_inject)) return false;
-        if (!can_inject_args_values()) return false;
         return !in_loop || in_loop.length == 0 || !is_reachable(fn, in_loop);
     }
 
@@ -6315,6 +6276,7 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
     const parent = compressor.parent();
     if (compressor.option("reduce_vars") && is_lhs(self, parent) !== self) {
         const def = self.definition();
+        const nearest_scope = find_scope(compressor);
         if (compressor.top_retain && def.global && compressor.top_retain(def)) {
             def.fixed = false;
             def.single_use = false;
@@ -6350,13 +6312,12 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
             }
         }
         if (single_use && fixed instanceof AST_Lambda) {
-            const block_scope = find_scope(compressor);
             single_use =
                 def.scope === self.scope
-                    && !scope_encloses_variables_in_this_scope(block_scope, fixed)
+                    && !scope_encloses_variables_in_this_scope(nearest_scope, fixed)
                 || parent instanceof AST_Call
                     && parent.expression === self
-                    && !scope_encloses_variables_in_this_scope(block_scope, fixed);
+                    && !scope_encloses_variables_in_this_scope(nearest_scope, fixed);
         }
         if (single_use && fixed instanceof AST_Class) {
             const extends_inert = !fixed.extends
@@ -6394,8 +6355,13 @@ def_optimize(AST_SymbolRef, function(self, compressor) {
                     }
                 });
             }
-            if (fixed instanceof AST_Lambda || fixed instanceof AST_Class) {
-                find_scope(compressor).add_child_scope(fixed);
+            if (
+                (fixed instanceof AST_Lambda || fixed instanceof AST_Class)
+                && fixed.parent_scope !== nearest_scope
+            ) {
+                fixed = fixed.clone(true, compressor.get_toplevel());
+
+                nearest_scope.add_child_scope(fixed);
             }
             return fixed.optimize(compressor);
         }
@@ -6530,10 +6496,11 @@ function is_reachable(self, defs) {
     return walk_parent(self, (node, info) => {
         if (node instanceof AST_Scope && node !== self) {
             var parent = info.parent();
+
             if (parent instanceof AST_Call && parent.expression === node) return;
-            if (walk(node, find_ref)) {
-                return walk_abort;
-            }
+
+            if (walk(node, find_ref)) return walk_abort;
+
             return true;
         }
     });

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -167,12 +167,14 @@ import {
     AST_While,
     AST_With,
     AST_Yield,
+
     TreeTransformer,
     TreeWalker,
     walk,
     walk_abort,
     walk_body,
     walk_parent,
+
     _INLINE,
     _NOINLINE,
     _PURE
@@ -322,6 +324,7 @@ class Compressor extends TreeWalker {
         this.sequences_limit = sequences == 1 ? 800 : sequences | 0;
         this.warnings_produced = {};
         this.evaluated_regexps = new Map();
+        this._toplevel = undefined;
     }
 
     option(key) {
@@ -365,28 +368,33 @@ class Compressor extends TreeWalker {
         }
     }
 
+    get_toplevel() {
+        return this._toplevel;
+    }
+
     compress(toplevel) {
         toplevel = toplevel.resolve_defines(this);
+        this._toplevel = toplevel;
         if (this.option("expression")) {
-            toplevel.process_expression(true);
+            this._toplevel.process_expression(true);
         }
         var passes = +this.options.passes || 1;
         var min_count = 1 / 0;
         var stopping = false;
         var mangle = { ie8: this.option("ie8") };
         for (var pass = 0; pass < passes; pass++) {
-            toplevel.figure_out_scope(mangle);
+            this._toplevel.figure_out_scope(mangle);
             if (pass === 0 && this.option("drop_console")) {
                 // must be run before reduce_vars and compress pass
-                toplevel = toplevel.drop_console();
+                this._toplevel = this._toplevel.drop_console();
             }
             if (pass > 0 || this.option("reduce_vars")) {
-                toplevel.reset_opt_flags(this);
+                this._toplevel.reset_opt_flags(this);
             }
-            toplevel = toplevel.transform(this);
+            this._toplevel = this._toplevel.transform(this);
             if (passes > 1) {
                 let count = 0;
-                walk(toplevel, () => { count++; });
+                walk(this._toplevel, () => { count++; });
                 this.info("pass " + pass + ": last_count: " + min_count + ", count: " + count);
                 if (count < min_count) {
                     min_count = count;
@@ -399,8 +407,10 @@ class Compressor extends TreeWalker {
             }
         }
         if (this.option("expression")) {
-            toplevel.process_expression(false);
+            this._toplevel.process_expression(false);
         }
+        toplevel = this._toplevel;
+        this._toplevel = undefined;
         return toplevel;
     }
 
@@ -2434,11 +2444,13 @@ function get_value(key) {
 }
 
 function is_undefined(node, compressor) {
-    return has_flag(node, UNDEFINED)
+    return (
+        has_flag(node, UNDEFINED)
         || node instanceof AST_Undefined
         || node instanceof AST_UnaryPrefix
             && node.operator == "void"
-            && !node.expression.has_side_effects(compressor);
+            && !node.expression.has_side_effects(compressor)
+    );
 }
 
 // may_throw_on_access()
@@ -2496,7 +2508,7 @@ function is_undefined(node, compressor) {
         return this.tail_node()._dot_throw(compressor);
     });
     def_may_throw_on_access(AST_SymbolRef, function(compressor) {
-        if (has_flag(this, UNDEFINED)) return true;
+        if (is_undefined(this, compressor)) return true;
         if (!is_strict(compressor)) return false;
         if (is_undeclared_ref(this) && this.is_declared(compressor)) return false;
         if (this.is_immutable()) return false;
@@ -4962,6 +4974,7 @@ def_optimize(AST_Call, function(self, compressor) {
     var simple_args = self.args.every((arg) =>
         !(arg instanceof AST_Expansion)
     );
+
     if (compressor.option("reduce_vars")
         && fn instanceof AST_SymbolRef
         && !has_annotation(self, _NOINLINE)
@@ -4971,7 +4984,9 @@ def_optimize(AST_Call, function(self, compressor) {
             fn = fixed;
         }
     }
+
     var is_func = fn instanceof AST_Lambda;
+
     if (compressor.option("unused")
         && simple_args
         && is_func
@@ -5009,6 +5024,7 @@ def_optimize(AST_Call, function(self, compressor) {
         }
         self.args.length = last;
     }
+
     if (compressor.option("unsafe")) {
         if (is_undeclared_ref(exp)) switch (exp.name) {
           case "Array":
@@ -5211,6 +5227,7 @@ def_optimize(AST_Call, function(self, compressor) {
             break;
         }
     }
+
     if (compressor.option("unsafe_Function")
         && is_undeclared_ref(exp)
         && exp.name == "Function") {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5507,7 +5507,6 @@ def_optimize(AST_Call, function(self, compressor) {
         var def = name.definition();
 
         // Name already exists, only when a function argument had the same name
-        // TODO do not do this at all, instead always create new names
         const already_appended = scope.variables.has(name.name);
         if (!already_appended) {
             scope.variables.set(name.name, def);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4188,15 +4188,6 @@ AST_Scope.DEFMETHOD("hoist_declarations", function(compressor) {
     return self;
 });
 
-AST_Scope.DEFMETHOD("make_var_name", function(prefix) {
-    var var_names = this.var_names();
-    prefix = prefix.replace(/(?:^[^a-z_$]|[^a-z0-9_$])/ig, "_");
-    var name = prefix;
-    for (var i = 0; var_names.has(name); i++) name = prefix + "$" + i;
-    this.add_var_name(name);
-    return name;
-});
-
 AST_Scope.DEFMETHOD("hoist_properties", function(compressor) {
     var self = this;
     if (!compressor.option("hoist_props") || compressor.has_directive("use asm")) return self;
@@ -4218,15 +4209,23 @@ AST_Scope.DEFMETHOD("hoist_properties", function(compressor) {
                 && !top_retain(def)
                 && (value = sym.fixed_value()) === node.value
                 && value instanceof AST_Object
-                && value.properties.every(prop => typeof prop.key === "string")
+                && !value.properties.some(prop => prop.computed_key())
             ) {
                 descend(node, this);
                 const defs = new Map();
                 const assignments = [];
-                value.properties.forEach(function(prop) {
+                value.properties.forEach(({ key, value }) => {
+                    const symbol = self.create_symbol(sym.CTOR, {
+                        source: sym,
+                        scope: find_scope(hoister),
+                        tentative_name: sym.name + "_" + key
+                    });
+
+                    defs.set(String(key), symbol.definition());
+
                     assignments.push(make_node(AST_VarDef, node, {
-                        name: make_sym(sym, prop.key, defs),
-                        value: prop.value
+                        name: symbol,
+                        value
                     }));
                 });
                 defs_by_id.set(def.id, defs);
@@ -4246,17 +4245,6 @@ AST_Scope.DEFMETHOD("hoist_properties", function(compressor) {
                 sym.reference({});
                 return sym;
             }
-        }
-
-        function make_sym(sym, key, defs) {
-            const new_var = make_node(sym.CTOR, sym, {
-                name: self.make_var_name(sym.name + "_" + key),
-                scope: self
-            });
-            const def = self.def_variable(new_var);
-            defs.set(String(key), def);
-            self.enclosed.push(def);
-            return new_var;
         }
     });
     return self.transform(hoister);
@@ -5539,15 +5527,19 @@ def_optimize(AST_Call, function(self, compressor) {
 
     function append_var(decls, expressions, name, value) {
         var def = name.definition();
-        scope.variables.set(name.name, def);
-        scope.enclosed.push(def);
-        if (!scope.var_names().has(name.name)) {
-            scope.add_var_name(name.name);
+
+        // Name already exists, only when a function argument had the same name
+        // TODO do not do this at all, instead always create new names
+        const already_appended = scope.variables.has(name.name);
+        if (!already_appended) {
+            scope.variables.set(name.name, def);
+            scope.enclosed.push(def);
             decls.push(make_node(AST_VarDef, name, {
                 name: name,
                 value: null
             }));
         }
+
         var sym = make_node(AST_SymbolRef, name, name);
         def.references.push(sym);
         if (value) expressions.push(make_node(AST_Assign, self, {
@@ -7074,12 +7066,12 @@ def_optimize(AST_Sub, function(self, compressor) {
             }
         } else if (!argname && !compressor.option("keep_fargs") && index < fn.argnames.length + 5) {
             while (index >= fn.argnames.length) {
-                argname = make_node(AST_SymbolFunarg, fn, {
-                    name: fn.make_var_name("argument_" + fn.argnames.length),
-                    scope: fn
+                argname = fn.create_symbol(AST_SymbolFunarg, {
+                    source: fn,
+                    scope: fn,
+                    tentative_name: "argument_" + fn.argnames.length,
                 });
                 fn.argnames.push(argname);
-                fn.enclosed.push(fn.def_variable(argname));
             }
         }
         if (argname) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5445,7 +5445,7 @@ def_optimize(AST_Call, function(self, compressor) {
             if (!safe_to_inject
                 || block_scoped.has(arg.name)
                 || identifier_atom.has(arg.name)
-                || scope.var_names().has(arg.name)) {
+                || scope.conflicting_def(arg.name)) {
                 return false;
             }
             if (in_loop) in_loop.push(arg.definition());
@@ -5464,7 +5464,7 @@ def_optimize(AST_Call, function(self, compressor) {
                 if (name instanceof AST_Destructuring
                     || block_scoped.has(name.name)
                     || identifier_atom.has(name.name)
-                    || scope.var_names().has(name.name)) {
+                    || scope.conflicting_def(name.name)) {
                     return false;
                 }
                 if (in_loop) in_loop.push(name.definition());
@@ -5534,7 +5534,7 @@ def_optimize(AST_Call, function(self, compressor) {
         for (i = len; --i >= 0;) {
             var name = fn.argnames[i];
             var value = self.args[i];
-            if (has_flag(name, UNUSED) || !name.name || scope.var_names().has(name.name)) {
+            if (has_flag(name, UNUSED) || !name.name || scope.conflicting_def(name.name)) {
                 if (value) expressions.push(value);
             } else {
                 var symbol = make_node(AST_SymbolVar, name, name);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2134,7 +2134,7 @@ function parse($TEXT, options) {
         return ret;
     }
 
-    function to_fun_args(ex, _, __, default_seen_above) {
+    function to_fun_args(ex, default_seen_above) {
         var insert_default = function(ex, default_value) {
             if (default_value) {
                 return new AST_DefaultAssign({
@@ -2152,15 +2152,15 @@ function parse($TEXT, options) {
                 start: ex.start,
                 end: ex.end,
                 is_array: false,
-                names: ex.properties.map(to_fun_args)
+                names: ex.properties.map(prop => to_fun_args(prop))
             }), default_seen_above);
         } else if (ex instanceof AST_ObjectKeyVal) {
-            ex.value = to_fun_args(ex.value, 0, [ex.key]);
+            ex.value = to_fun_args(ex.value);
             return insert_default(ex, default_seen_above);
         } else if (ex instanceof AST_Hole) {
             return ex;
         } else if (ex instanceof AST_Destructuring) {
-            ex.names = ex.names.map(to_fun_args);
+            ex.names = ex.names.map(name => to_fun_args(name));
             return insert_default(ex, default_seen_above);
         } else if (ex instanceof AST_SymbolRef) {
             return insert_default(new AST_SymbolFunarg({
@@ -2176,12 +2176,12 @@ function parse($TEXT, options) {
                 start: ex.start,
                 end: ex.end,
                 is_array: true,
-                names: ex.elements.map(to_fun_args)
+                names: ex.elements.map(elm => to_fun_args(elm))
             }), default_seen_above);
         } else if (ex instanceof AST_Assign) {
-            return insert_default(to_fun_args(ex.left, undefined, undefined, ex.right), default_seen_above);
+            return insert_default(to_fun_args(ex.left, ex.right), default_seen_above);
         } else if (ex instanceof AST_DefaultAssign) {
-            ex.left = to_fun_args(ex.left, 0, [ex.left]);
+            ex.left = to_fun_args(ex.left);
             return ex;
         } else {
             croak("Invalid function parameter", ex.start.line, ex.start.col);
@@ -2204,7 +2204,7 @@ function parse($TEXT, options) {
                 if (async && !allow_calls) break;
                 var exprs = params_or_seq_(allow_arrows, !async);
                 if (allow_arrows && is("arrow", "=>")) {
-                    return arrow_function(start, exprs.map(to_fun_args), !!async);
+                    return arrow_function(start, exprs.map(e => to_fun_args(e)), !!async);
                 }
                 var ex = async ? new AST_Call({
                     expression: async,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -485,9 +485,9 @@ AST_Scope.DEFMETHOD("init_scope_vars", function(parent_scope) {
     this.cname = -1;                    // the current index for mangling functions/variables
 });
 
-AST_Scope.DEFMETHOD("var_name_conflicts", function (name) {
+AST_Scope.DEFMETHOD("conflicting_def", function (name) {
     return (
-        this.enclosed.some(def => def.name === name)
+        this.enclosed.find(def => def.name === name)
         || this.find_variable(name)
     );
 });
@@ -556,7 +556,7 @@ AST_Scope.DEFMETHOD("create_symbol", function(SymClass, {
             tentative_name.replace(/(?:^[^a-z_$]|[^a-z0-9_$])/ig, "_");
 
         let i = 0;
-        while (this.var_name_conflicts(symbol_name)) {
+        while (this.conflicting_def(symbol_name)) {
             symbol_name = tentative_name + "$" + i++;
         }
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -48,6 +48,7 @@ import {
     keep_name,
     mergeSort,
     push_uniq,
+    make_node,
     return_false,
     return_this,
     return_true,
@@ -482,56 +483,40 @@ AST_Scope.DEFMETHOD("init_scope_vars", function(parent_scope) {
     this.parent_scope = parent_scope;   // the parent scope
     this.enclosed = [];                 // a list of variables from this or outer scope(s) that are referenced from this or inner scopes
     this.cname = -1;                    // the current index for mangling functions/variables
-    this._var_name_cache = null;
+});
+
+AST_Scope.DEFMETHOD("var_name_conflicts", function (name) {
+    return (
+        this.enclosed.some(def => def.name === name)
+        || this.find_variable(name)
+    );
 });
 
 AST_Scope.DEFMETHOD("var_names", function varNames() {
-    var var_names = this._var_name_cache;
-    if (!var_names) {
-        this._var_name_cache = var_names = new Set(
-            this.parent_scope ? varNames.call(this.parent_scope) : null
-        );
-        if (this._added_var_names) {
-            this._added_var_names.forEach(name => { var_names.add(name); });
-        }
-        this.enclosed.forEach(function(def) {
-            var_names.add(def.name);
-        });
-        this.variables.forEach(function(def, name) {
-            var_names.add(name);
-        });
-    }
+    // TODO deprecate me
+    var var_names = this.parent_scope ? varNames.call(this.parent_scope) : new Set();
+
+    this.enclosed.forEach(function(def) {
+        var_names.add(def.name);
+    });
+
+    this.variables.forEach(function(def, name) {
+        var_names.add(name);
+    });
+
     return var_names;
 });
 
-AST_Scope.DEFMETHOD("add_var_name", function (name) {
-    // TODO change enclosed too
-    if (!this._added_var_names) {
-        // TODO stop adding var names entirely
-        this._added_var_names = new Set();
-    }
-    this._added_var_names.add(name);
-    if (!this._var_name_cache) this.var_names();  // regen cache
-    this._var_name_cache.add(name);
-});
-
-// TODO create function that asks if we can inline
-
 AST_Scope.DEFMETHOD("add_child_scope", function (scope) {
-    // `scope` is going to be moved into wherever the compressor is
-    // right now. Update the required scopes' information
+    // `scope` is going to be moved into `this` right now.
+    // Update the required scopes' information
 
     if (scope.parent_scope === this) return;
 
     scope.parent_scope = this;
-    scope._var_name_cache = null;
-    if (scope._added_var_names) {
-        scope._added_var_names.forEach(name => scope.add_var_name(name));
-    }
 
     // TODO uses_with, uses_eval, etc
 
-    const new_scope_enclosed_set = new Set(scope.enclosed);
     const scope_ancestry = (() => {
         const ancestry = [];
         let cur = this;
@@ -542,6 +527,7 @@ AST_Scope.DEFMETHOD("add_child_scope", function (scope) {
         return ancestry;
     })();
 
+    const new_scope_enclosed_set = new Set(scope.enclosed);
     const to_enclose = [];
     for (const scope_topdown of scope_ancestry) {
         to_enclose.forEach(e => push_uniq(scope_topdown.enclosed, e));
@@ -553,6 +539,44 @@ AST_Scope.DEFMETHOD("add_child_scope", function (scope) {
         }
     }
 });
+
+// Creates a symbol during compression
+AST_Scope.DEFMETHOD("create_symbol", function(SymClass, {
+    source,
+    tentative_name,
+    scope,
+    init = null
+} = {}) {
+    let symbol_name;
+
+    if (tentative_name) {
+        // Implement hygiene (no new names are conflicting with existing names)
+        tentative_name =
+            symbol_name =
+            tentative_name.replace(/(?:^[^a-z_$]|[^a-z0-9_$])/ig, "_");
+
+        let i = 0;
+        while (this.var_name_conflicts(symbol_name)) {
+            symbol_name = tentative_name + "$" + i++;
+        }
+    }
+
+    if (!symbol_name) {
+        throw new Error("No symbol name could be generated in create_symbol()");
+    }
+
+    const symbol = make_node(SymClass, source, {
+        name: symbol_name,
+        scope
+    });
+
+    this.def_variable(symbol, init || null);
+
+    symbol.mark_enclosed();
+
+    return symbol;
+});
+
 
 AST_Node.DEFMETHOD("is_block_scope", return_false);
 AST_Class.DEFMETHOD("is_block_scope", return_false);

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -488,23 +488,9 @@ AST_Scope.DEFMETHOD("init_scope_vars", function(parent_scope) {
 AST_Scope.DEFMETHOD("conflicting_def", function (name) {
     return (
         this.enclosed.find(def => def.name === name)
-        || this.find_variable(name)
+        || this.variables.has(name)
+        || (this.parent_scope && this.parent_scope.conflicting_def(name))
     );
-});
-
-AST_Scope.DEFMETHOD("var_names", function varNames() {
-    // TODO deprecate me
-    var var_names = this.parent_scope ? varNames.call(this.parent_scope) : new Set();
-
-    this.enclosed.forEach(function(def) {
-        var_names.add(def.name);
-    });
-
-    this.variables.forEach(function(def, name) {
-        var_names.add(name);
-    });
-
-    return var_names;
 });
 
 AST_Scope.DEFMETHOD("add_child_scope", function (scope) {

--- a/lib/size.js
+++ b/lib/size.js
@@ -58,6 +58,7 @@ import {
     AST_SymbolExportForeign,
     AST_SymbolImportForeign,
     AST_SymbolRef,
+    AST_SymbolDeclaration,
     AST_TemplateSegment,
     AST_TemplateString,
     AST_This,
@@ -384,7 +385,7 @@ AST_SymbolClassProperty.prototype._size = function () {
     return this.name.length;
 };
 
-AST_SymbolRef.prototype._size = function () {
+AST_SymbolRef.prototype._size = AST_SymbolDeclaration.prototype._size = function () {
     const { name, thedef } = this;
 
     if (thedef && thedef.global) return name.length;

--- a/test/compress.js
+++ b/test/compress.js
@@ -245,7 +245,7 @@ function run_compress_tests() {
                 });
                 return false;
             }
-            if (test.expect_warnings) {
+            if (test.expect_warnings && !process.env.TEST_NO_COMPARE) {
                 U.AST_Node.warn_function = original_warn_function;
                 var expected_warnings = make_code(test.expect_warnings, {
                     beautify: false,

--- a/test/compress/block-scope.js
+++ b/test/compress/block-scope.js
@@ -257,8 +257,9 @@ issue_334: {
         }
     }
     expect: {
-        var A;
-        (A="Hello World!").x || console.log(A);
+        (function (A) {
+            A.x || console.log(A)
+        }("Hello World!"));
     }
     expect_stdout: "Hello World!";
 }

--- a/test/compress/collapse_vars.js
+++ b/test/compress/collapse_vars.js
@@ -3791,8 +3791,8 @@ issue_2437: {
                 return Object.defineProperty(XMLHttpRequest.prototype, "onreadystatechange", xhrDesc || {}),
                     result;
             }
-            var req = new XMLHttpRequest, detectFunc = function() {};
-            req.onreadystatechange = detectFunc,
+            var req, detectFunc = function() {};
+            (req = new XMLHttpRequest).onreadystatechange = detectFunc,
                 result = req[SYMBOL_FAKE_ONREADYSTATECHANGE_1] === detectFunc,
                 req.onreadystatechange = null;
         }();

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -930,8 +930,8 @@ issue_1583: {
             (function(e) {
                 (function() {
                     return (function(a) {
-                        return function(a) {};
-                    })();
+                        return a;
+                    })(function(a) {});
                 })();
             })();
         }

--- a/test/compress/inline.js
+++ b/test/compress/inline.js
@@ -371,3 +371,27 @@ dont_inline_funcs_into_default_param: {
 
     expect_stdout: "PASS"
 }
+
+dont_inline_funcs_into_default_param_2: {
+    options = {
+        toplevel: true
+    }
+
+    input: {
+        "use strict";
+
+        const foo = () => 42;
+
+        const getData = (val) => {
+            return {val}
+        }
+
+        const print = (data = getData(foo())) => {
+            data.val === 42 && pass();
+        }
+
+        print();
+    }
+
+    expect_stdout: "PASS"
+}

--- a/test/compress/issue-t292.js
+++ b/test/compress/issue-t292.js
@@ -28,14 +28,16 @@ no_flatten_with_arg_colliding_with_arg_value_inner_scope: {
         console.log(c("a"));
     }
     expect: {
-        var g=["a"];
+        var g = [ "a" ];
+
         function problem(arg) {
-            return g.indexOf(arg)
+            return g.indexOf(arg);
         }
+
         console.log(function(problem) {
-            return g[problem]
+            return g[problem];
         }(function(arg) {
-            return problem(arg)
+            return problem(arg);
         }("a")));
     }
     expect_stdout: "a"
@@ -73,9 +75,18 @@ no_flatten_with_var_colliding_with_arg_value_inner_scope: {
         console.log(c("a"));
     }
     expect: {
-        var g=["a"];
-        function problem(arg){return g.indexOf(arg)}
-        console.log(function(test){var problem=2*test;return console.log(problem),g[problem]}(function(arg){return problem(arg)}("a")));
+        var g = [ "a" ];
+
+        function problem(arg) {
+            return g.indexOf(arg);
+        }
+
+        console.log(function(test) {
+            var problem = 2 * test;
+            return console.log(problem), g[problem];
+        }(function(arg) {
+            return problem(arg);
+        }("a")));
     }
     expect_stdout: [
         "0",

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -2363,7 +2363,7 @@ booleans: {
     expect: {
         console.log(function(a) {
             if (0);
-            switch (!1) {
+            switch (a) {
               case 0:
                 return "FAIL";
               case !1:

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -6972,7 +6972,14 @@ variables_collision_in_immediately_invoked_func: {
     expect: {
         !function () {
             window.used = function () {
-                return window.foo,function(A,c){return-1===c?A:$(A,c)}(window.bar,window.foobar)
+                return (
+                    window.foo,
+                    function (A, c) {
+                        return -1 === c
+                            ? A
+                            : $(A,c)
+                    }(window.bar, window.foobar)
+                );
             }.call(this);
         }();
     }
@@ -7217,4 +7224,33 @@ issue_581_2: {
         }).call({ message: 'PASS' })
     }
     expect_stdout: "PASS"
+}
+
+issue_639: {
+    input: {
+        const path = id({ extname: (name) => { console.log('PASS:' + name) } })
+
+        global.getExtFn = function getExtFn() {
+          return function(path) {
+            return getExt(path);
+          }
+        }
+
+        function getExt(name) {
+          let ext;
+          if (!ext) {
+            ext = getExtInner(name);
+          }
+          return ext;
+        }
+
+        function getExtInner(name) {
+          return path.extname(name);
+        }
+
+        getExtFn()('name')
+    }
+    expect_stdout: [
+        "PASS:name"
+    ]
 }


### PR DESCRIPTION
I believe I've improved some aspects of inlining. It became a bit simpler than before. Also, inlining something updates more scope of the parent scope's information than before, fixing #639.

My original goal was to make it so new, unique variable names were always created, and checking for collisions didn't need to happen, but it turns out that generating new names didn't fix all the problems, and people would probably be upset or confused if their variable names were changed without them using the mangle option.

Then I tacked on a change I was interested in, which was to start measuring symbols differently depending on whether mangling was enabled, fixing #321.