### PR TITLE
es module build for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "repository": "https://github.com/terser/terser",
   "main": "dist/bundle.min.js",
   "module": "main.js",
+  "exports": {
+    "import": "main.js",
+    "require": "dist/bundle.min.js"
+  },
   "types": "tools/terser.d.ts",
   "bin": {
     "terser": "bin/terser"
@@ -21,6 +25,7 @@
   "files": [
     "bin",
     "dist",
+    "lib",
     "tools",
     "LICENSE",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "repository": "https://github.com/terser/terser",
   "main": "dist/bundle.min.js",
+  "module": "main.js",
   "types": "tools/terser.d.ts",
   "bin": {
     "terser": "bin/terser"


### PR DESCRIPTION
Terser is a minifier for ES6 so it would be nice to provide an option to import it as an es module. This PR adds an es module output to the rollup configuration. With this change terser can be imported directly into a web browser!