### PR TITLE
Add numeric separators support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   include:
     - name: Functional tests
       script: test/functional.sh
-      node_js: 14
+      node_js: 12
       cache:
         directories:
           - node_modules

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -539,8 +539,10 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             parse_error("Legacy octal literals are not allowed in strict mode");
         }
         if (numeric_separator) {
-            if(num.endsWith("_") || num.includes("__")) {
-                parse_error("Invalid numeric separator(s)");
+            if (num.endsWith("_")) {
+                parse_error("Numeric separators are not allowed at the end of numeric literals");
+            } else if (num.includes("__")) {
+                parse_error("Only one underscore is allowed as numeric separator");
             }
             num = num.replace(/_/g, "");
         }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -503,12 +503,14 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     }
 
     function read_num(prefix) {
-        var has_e = false, after_e = false, has_x = false, has_dot = prefix == ".", is_big_int = false;
+        var has_e = false, after_e = false, has_x = false, has_dot = prefix == ".", is_big_int = false, numeric_separator = false;
         var num = read_while(function(ch, i) {
             if (is_big_int) return false;
 
             var code = ch.charCodeAt(0);
             switch (code) {
+              case 95: // _
+                return (numeric_separator = true);
               case 98: case 66: // bB
                 return (has_x = true); // Can occur in hex sequence, don't return false yet
               case 111: case 79: // oO
@@ -535,6 +537,12 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         if (prefix) num = prefix + num;
         if (RE_OCT_NUMBER.test(num) && next_token.has_directive("use strict")) {
             parse_error("Legacy octal literals are not allowed in strict mode");
+        }
+        if (numeric_separator) {
+            if(num.endsWith("_") || num.includes("__")) {
+                parse_error("Invalid numeric separator(s)");
+            }
+            num = num.replace(/_/g, "");
         }
         if (num.endsWith("n")) {
             const without_n = num.slice(0, -1);

--- a/test/compress/numbers.js
+++ b/test/compress/numbers.js
@@ -291,7 +291,7 @@ numeric_separator_trailing_underscore: {
     input: `const trailing = 1000_`
     expect_error: ({
         name: "SyntaxError",
-        message: "Invalid numeric separator(s)"
+        message: "Numeric separators are not allowed at the end of numeric literals"
     })
 }
 
@@ -299,6 +299,6 @@ numeric_separator_double_underscore: {
     input: `const double = 1__000`
     expect_error: ({
         name: "SyntaxError",
-        message: "Invalid numeric separator(s)"
+        message: "Only one underscore is allowed as numeric separator"
     })
 }

--- a/test/compress/numbers.js
+++ b/test/compress/numbers.js
@@ -258,8 +258,9 @@ keep_numbers: {
         const huge = 1000000000001;
         const big = 100000000001;
         const fractional = 100.2300200;
+        const numeric_separators = 1_000_000_000_000;
     }
-    expect_exact: "const exp=1000000000000;const negativeExp=0.00000001;const huge=1000000000001;const big=100000000001;const fractional=100.2300200;"
+    expect_exact: "const exp=1000000000000;const negativeExp=0.00000001;const huge=1000000000001;const big=100000000001;const fractional=100.2300200;const numeric_separators=1_000_000_000_000;"
 }
 
 keep_numbers_in_properties_as_is: {
@@ -270,4 +271,34 @@ keep_numbers_in_properties_as_is: {
         var Foo = { 1000000: 80000000000 }
     }
     expect_exact: "var Foo={1000000:80000000000};"
+}
+
+numeric_separators: {
+    input: {
+        const one = 1_000;
+        const two = 1_000_000;
+        const bin = 0b0101_0101;
+        const oct = 0o0123_4567;
+        const hex = 0xDEAD_BEEF;
+        const fractional = 1_000.000_100;
+        const identifier = _1000;
+        const negate_identifier = -_1000;
+    }
+    expect_exact: "const one=1e3;const two=1e6;const bin=85;const oct=342391;const hex=3735928559;const fractional=1000.0001;const identifier=_1000;const negate_identifier=-_1000;"
+}
+
+numeric_separator_trailing_underscore: {
+    input: `const trailing = 1000_`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Invalid numeric separator(s)"
+    })
+}
+
+numeric_separator_double_underscore: {
+    input: `const double = 1__000`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Invalid numeric separator(s)"
+    })
 }


### PR DESCRIPTION
Adds support for [Stage 3 Numeric Separators](https://github.com/tc39/proposal-numeric-separator).
Numeric separators are available in V8, SpiderMonkey, JavaScriptCore and ChakraCore (see [here](https://github.com/tc39/proposal-numeric-separator/issues/43#issue-426539288)).

Considerations:
- As a stage 3 feature does this need special treatment, such as a flag?
  - I notice that class fields do not
- How far should terser go to ensure parse-correctness? This currently "allows" the following, which could be caught with additional logic:
    - `1_e_1`
    - `0_x_123`

Fixes #632