### PR TITLE
add ls-lint

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,8 @@
+ls:
+    '{lib, tools}':
+        .js: kebab-case
+        .ts: kebab-case
+        .d.ts: kebab-case
+
+ignore:
+    - lib/utils/first_in_statement.js

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,8 +1,12 @@
 ls:
-    '{lib, tools}':
+    '{lib,tools,test}':
         .js: kebab-case
         .ts: kebab-case
         .d.ts: kebab-case
+        .html: kebab-case
+        .json: kebab-case
 
 ignore:
+    - test/input
+    - test/compress
     - lib/utils/first_in_statement.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@ls-lint/ls-lint": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@ls-lint/ls-lint/-/ls-lint-1.9.2.tgz",
+      "integrity": "sha512-sugEjWjSSy9OHF6t1ZBLZCAROj52cZthB9dIePmzZzzMwmWwy3qAEMSdJheHeS1FOwDZI7Ipm1H/bWgzJNnSAw==",
+      "dev": true
+    },
     "@types/murmurhash": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@types/murmurhash/-/murmurhash-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "source-map-support": "~0.5.12"
   },
   "devDependencies": {
+    "@ls-lint/ls-lint": "^1.9.2",
     "acorn": "^7.1.1",
     "astring": "^1.4.1",
     "eslint": "^6.3.0",
@@ -50,6 +51,7 @@
     "test:mocha": "npm run build -- --configTest && node test/mocha.js",
     "lint": "eslint lib",
     "lint-fix": "eslint --fix lib",
+    "ls-lint": "ls-lint",
     "build": "rimraf dist/* && rollup --config --silent",
     "prepare": "npm run build",
     "postversion": "echo 'Remember to update the changelog!'"
@@ -123,6 +125,7 @@
   },
   "pre-commit": [
     "lint-fix",
+    "ls-lint",
     "test"
   ]
 }


### PR DESCRIPTION
Hey @fabiosantoscode,

added [ls-lint](https://github.com/loeffel-io/ls-lint) as discussed. 

Just let me know if you are happy with the current configuration: 

```yaml
ls:
    '{lib,tools,test}':
        .js: kebab-case
        .ts: kebab-case
        .d.ts: kebab-case
        .html: kebab-case
        .json: kebab-case

ignore:
    - test/input
    - test/compress
    - lib/utils/first_in_statement.js
```

Merge of the [terser-functional-tests pr](https://github.com/terser/terser-functional-tests/pull/103/files) is required