### PR TITLE
fix typings

### DIFF
--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -98,7 +98,7 @@ export interface FormatOptions {
     ascii_only?: boolean;
     beautify?: boolean;
     braces?: boolean;
-    comments?: boolean | 'all' | 'some' | RegExp | ( (node: AST_Node, comment: {
+    comments?: boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
         value: string,
         type: 'comment1' | 'comment2' | 'comment3' | 'comment4',
         pos: number,
@@ -151,7 +151,6 @@ export interface MinifyOptions {
 }
 
 export interface MinifyOutput {
-    ast?: AST_Node;
     code?: string;
     map?: RawSourceMap | string;
 }
@@ -165,4 +164,4 @@ export interface SourceMapOptions {
     url?: string | 'inline';
 }
 
-export async function minify(files: string | string[] | { [file: string]: string }, options?: MinifyOptions): Promise<MinifyOutput>;
+export function minify(files: string | string[] | { [file: string]: string }, options?: MinifyOptions): Promise<MinifyOutput>;


### PR DESCRIPTION
Resolves #777 
- Removed `AST_Node` references
- Changed `comments(node, comment)` option so `node` is an any
- Removed `ast` property from `MinifyOutput`
- Removed `async` modifier
