### PR TITLE
feat: support private class fields

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1921,7 +1921,7 @@ function OutputStream(options) {
         output.print("new.target");
     });
 
-    function print_property_name(key, quote, output) {
+    function print_property_name(key, quote, output, is_class_property) {
         if (output.option("quote_keys")) {
             return output.print_string(key);
         }
@@ -1936,7 +1936,7 @@ function OutputStream(options) {
             : (
                 output.option("ecma") < 2015
                     ? !is_basic_identifier_string(key)
-                    : !is_identifier_string(key, true)
+                    : !is_identifier_string(key, true, is_class_property)
             );
         if (print_string || (quote && output.option("keep_quoted_props"))) {
             return output.print_string(key, quote);
@@ -1989,7 +1989,7 @@ function OutputStream(options) {
         }
 
         if (self.key instanceof AST_SymbolClassProperty) {
-            print_property_name(self.key.name, self.quote, output);
+            print_property_name(self.key.name, self.quote, output, true);
         } else {
             output.print("[");
             self.key.print(output);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -313,7 +313,10 @@ function is_basic_identifier_string(str) {
     return /^[a-z_$][a-z0-9_$]*$/i.test(str);
 }
 
-function is_identifier_string(str, allow_surrogates) {
+function is_identifier_string(str, allow_surrogates, is_class_property) {
+    if (is_class_property && str.startsWith("#")) {
+        str = str.slice(1);
+    }
     if (/^[a-z_$][a-z0-9_$]*$/i.test(str)) {
         return true;
     }
@@ -746,7 +749,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             if (!is_identifier_start(name)) {
                 parse_error("First identifier char is an invalid identifier char");
             }
-        } else if (is_identifier_start(name)) {
+        } else if (is_identifier_start(name) || name.charCodeAt(0) === 35) {
             next();
         } else {
             return "";
@@ -925,7 +928,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             if (is_digit(code)) return read_num();
             if (PUNC_CHARS.has(ch)) return token("punc", next());
             if (OPERATOR_CHARS.has(ch)) return read_operator();
-            if (code == 92 || is_identifier_start(ch)) return read_word();
+            if (code == 92 || code === 35 || is_identifier_start(ch)) return read_word();
             break;
         }
         parse_error("Unexpected character '" + ch + "'");

--- a/test/compress/class-properties.js
+++ b/test/compress/class-properties.js
@@ -246,3 +246,32 @@ mangle_class_properties_keep_quoted: {
         }
     }
 }
+
+private_class_properties: {
+    no_mozilla_ast = true;
+    node_version = ">=12";
+    options = {
+        ecma: 2015
+    }
+    input: {
+        class Foo {
+            #bar = "FooBar"
+
+            get bar() {
+                return this.#bar;
+            }
+        }
+        console.log(new Foo().bar)
+    }
+    expect: {
+        class Foo {
+            #bar = "FooBar"
+
+            get bar() {
+                return this.#bar;
+            }
+        }
+        console.log(new Foo().bar)
+    }
+    expect_stdout: "FooBar"
+}

--- a/test/compress/classes.js
+++ b/test/compress/classes.js
@@ -23,7 +23,7 @@ class_recursive_refs: {
         }
     }
     expect: {
-        
+
     }
 }
 
@@ -94,4 +94,32 @@ pure_prop_assignment_for_classes: {
         B.staticProp = ""
     }
     expect: { }
+}
+
+private_class_methods: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    input: {
+        class A {
+            #method() {
+                return "I'm private"
+            }
+            print() {
+                console.log(this.#method());
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            #method() {
+                return "I'm private"
+            }
+            print() {
+                console.log(this.#method());
+            }
+        }
+        new A().print();
+    }
+    expect_stdout: "I'm private"
 }


### PR DESCRIPTION
Added parser support for private class properties and methods, not really sure how to make parser throw error when property starts with "#" not in classes.

~Also need to update output.js to avoid quotes for private fields: `class A { #field }` becomes `class A { "#field"; }` (this is ok but suboptimal)~

upd: fixed output

Related issues: #349 #702 