### PR TITLE
Add `module` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "repository": "https://github.com/terser/terser",
   "main": "dist/bundle.min.js",
   "type": "module",
+  "module": "./main.js",
   "exports": {
     ".": {
       "import": "./main.js",


### PR DESCRIPTION
Hi! Super excited that v5 supports ESM!

[Rollup doesn't yet support `pkg.exports`](https://github.com/rollup/plugins/issues/362). If I want rollup to include terser in my bundle (without commonjs shims), then the `module` field is needed in `package.json`. So now if I make a rollup bundle with this:

```
import {minify} from 'terser'

...
```

Then terser will get added correctly to my bundle.