### PR TITLE
add minifySync

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -61,6 +61,10 @@ function cache_to_json(cache) {
 }
 
 async function minify(files, options) {
+    return minifySync(files, options);
+}
+
+function minifySync(files, options) {
     options = defaults(options, {
         compress: {},
         ecma: undefined,
@@ -264,5 +268,6 @@ async function minify(files, options) {
 
 export {
   minify,
+  minifySync,
   to_ascii,
 };

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 import "./lib/transform.js";
 import "./lib/mozilla-ast.js";
-import { minify } from "./lib/minify.js";
+import { minify, minifySync } from "./lib/minify.js";
 
-export { minify } from "./lib/minify.js";
+export { minify, minifySync } from "./lib/minify.js";
 export { run_cli as _run_cli } from "./lib/cli.js";
 
 export async function _default_options() {


### PR DESCRIPTION
please deliver us from issue #801 

test?

```js
const terser = require('terser');
const cfg = {};
const inn = `
  let f = (a) => {
    console.log('minify me');
  };
  f(1);
`;

const resSync = terser.minifySync(inn, cfg);
const resAsync = terser.minify(inn, cfg);

function assert(cond) {
  console.log(cond ? 'pass' : 'fail');
}

assert(resSync.constructor.name == 'Object');
assert(resAsync.constructor.name == 'Promise');

resAsync.then((value) => {
  assert(value.code == resSync.code);
});
```

as alternative, we could patch the bundle file, see [ds300/patch-package](https://github.com/ds300/patch-package)
but then the sourcemap is wrong

```diff
--- a/dist/bundle.min.js	2020-09-05 08:21:00.546912714 +0200
+++ b/dist/bundle.min.js	2020-09-05 08:21:15.143652480 +0200
@@ -25914,6 +25914,10 @@
 }
 
 async function minify(files, options) {
+    return minifySync(files, options);
+}
+
+function minifySync(files, options) {
     options = defaults(options, {
         compress: {},
         ecma: undefined,
@@ -26605,6 +26609,7 @@
 exports._default_options = _default_options;
 exports._run_cli = run_cli;
 exports.minify = minify;
+exports.minifySync = minifySync;
 
 })));
 //# sourceMappingURL=bundle.min.js.map
```
