### PR TITLE
Issue 829 - configuration regex options are not being parsed as RegExp instances

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -117,6 +117,12 @@ async function minify(files, options) {
             safari10: false,
             toplevel: false,
         }, true);
+        if (typeof options.mangle.keep_classnames === "string") {
+            options.mangle.keep_classnames = new RegExp(options.mangle.keep_classnames);
+        }
+        if (typeof options.mangle.keep_fnames === "string") {
+        	options.mangle.keep_fnames = new RegExp(options.mangle.keep_fnames);
+        }
         if (options.mangle.properties) {
             if (typeof options.mangle.properties != "object") {
                 options.mangle.properties = {};


### PR DESCRIPTION
As discussed in [Issue 829](https://github.com/terser/terser/issues/829) configuration file options which holds regex values were not treated as RegExp instances.
This is just a quick-fix for mangle options, proper fix needs to be able to handle any regex option.