### PR TITLE
Add @deprecated output field to MinifyOptions type

### DIFF
--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -105,6 +105,7 @@ export interface FormatOptions {
         line: number,
         col: number,
     }) => boolean );
+    ecma?: ECMA;
     ie8?: boolean;
     indent_level?: number;
     indent_start?: number;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -94,17 +94,19 @@ export interface ManglePropertiesOptions {
     reserved?: string[];
 }
 
+export type CommentsOption = boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
+    value: string,
+    type: 'comment1' | 'comment2' | 'comment3' | 'comment4',
+    pos: number,
+    line: number,
+    col: number,
+}) => boolean );
+
 export interface FormatOptions {
     ascii_only?: boolean;
     beautify?: boolean;
     braces?: boolean;
-    comments?: boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
-        value: string,
-        type: 'comment1' | 'comment2' | 'comment3' | 'comment4',
-        pos: number,
-        line: number,
-        col: number,
-    }) => boolean );
+    comments?: CommentsOption;
     ecma?: ECMA;
     ie8?: boolean;
     indent_level?: number;
@@ -135,6 +137,7 @@ export enum OutputQuoteStyle {
 }
 
 export interface MinifyOptions {
+    comments?: CommentsOptions;
     compress?: boolean | CompressOptions;
     ecma?: ECMA;
     ie8?: boolean;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -94,20 +94,17 @@ export interface ManglePropertiesOptions {
     reserved?: string[];
 }
 
-export type CommentsOption = boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
-    value: string,
-    type: 'comment1' | 'comment2' | 'comment3' | 'comment4',
-    pos: number,
-    line: number,
-    col: number,
-}) => boolean );
-
 export interface FormatOptions {
     ascii_only?: boolean;
     beautify?: boolean;
     braces?: boolean;
-    comments?: CommentsOption;
-    ecma?: ECMA;
+    comments?: boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
+        value: string,
+        type: 'comment1' | 'comment2' | 'comment3' | 'comment4',
+        pos: number,
+        line: number,
+        col: number,
+    }) => boolean );
     ie8?: boolean;
     indent_level?: number;
     indent_start?: number;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -147,6 +147,8 @@ export interface MinifyOptions {
     module?: boolean;
     nameCache?: object;
     format?: FormatOptions;
+    /** @deprecated */
+    output?: FormatOptions;
     parse?: ParseOptions;
     safari10?: boolean;
     sourceMap?: boolean | SourceMapOptions;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -137,7 +137,6 @@ export enum OutputQuoteStyle {
 }
 
 export interface MinifyOptions {
-    comments?: CommentsOptions;
     compress?: boolean | CompressOptions;
     ecma?: ECMA;
     ie8?: boolean;


### PR DESCRIPTION
Although `output` option is deprecated, it still works. TypeScript 4 supports the `@deprecated` jsdoc flag, which will identify the field as deprecated in the IDE

Fixes #835