### PR TITLE
fix: fix incorrect node engine semver versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-2-Clause",
   "version": "5.3.6",
   "engines": {
-    "node": "^10.0.0,^11.0.0,^12.0.0,>=14.0.0"
+    "node": "^10.0.0 || ^11.0.0 || ^12.0.0 || >=14.0.0"
   },
   "maintainers": [
     "Fábio Santos <fabiosantosart@gmail.com>"


### PR DESCRIPTION
Currently this shows error terser@5.3.6: The engine "node" is incompatible with this module. Expected version "^10.0.0,^11.0.0,^12.0.0,>=14.0.0". Got "12.18.4"

Closes: https://github.com/terser/terser/issues/854