### PR TITLE
fix: use `||` to separate semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "BSD-2-Clause",
   "version": "5.3.6",
   "engines": {
-    "node": "^10.0.0,^11.0.0,^12.0.0,>=14.0.0"
+    "node": "^10.0.0 || ^11.0.0 || ^12.0.0 || >=14.0.0"
   },
   "maintainers": [
     "Fábio Santos <fabiosantosart@gmail.com>"


### PR DESCRIPTION
See https://docs.npmjs.com/misc/semver#ranges
Comma is not a valid semver range separator.
The invalid range breaks yarn installations as yarn [does strict `engines` check](https://github.com/yarnpkg/yarn/issues/6627).