### PR TITLE
fix: sourcemap inline dist code, caused jest oom

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default () => {
                 "source-map": "sourceMap",
             },
             name: "Terser",
-            sourcemap: true,
+            sourcemap: false,
             sourcemapExcludeSources: true,
             esModule: false,
             indent: false


### PR DESCRIPTION
repo: [ycjcl868/jest-terser-oom](https://github.com/ycjcl868/jest-terser-oom)
ref: https://github.com/facebook/jest/pull/10534, https://github.com/webpack-contrib/terser-webpack-plugin/issues/143
Close: https://github.com/terser/terser/issues/164#issuecomment-725313998

If I removed the `sourceMappingURL`, the test case passed or caused out of memory.

![image](https://user-images.githubusercontent.com/13595509/98803818-28372280-23ca-11eb-8224-c251c94a9941.png)

If  I removed the `domprops`, the test case passed too.

![image](https://user-images.githubusercontent.com/13595509/98806651-5b7bb080-23ce-11eb-8451-dff20b040bc6.png)
