### PR TITLE
Remove the beautify option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,7 +42,6 @@ export async function run_cli({ program, packageJson, fs, path }) {
     program.option("-m, --mangle [options]", "Mangle names/specify mangler options.", parse_js());
     program.option("--mangle-props [options]", "Mangle properties/specify mangler options.", parse_js());
     program.option("-f, --format [options]", "Format options.", parse_js());
-    program.option("-b, --beautify [options]", "Alias for --format beautify=true.", parse_js());
     program.option("-o, --output <file>", "Output file (default STDOUT).");
     program.option("--comments [filter]", "Preserve copyright comments in the output.");
     program.option("--config-file <file>", "Read minify() options from JSON file.");
@@ -93,19 +92,8 @@ export async function run_cli({ program, packageJson, fs, path }) {
         else
             options.ecma = ecma;
     }
-    if (program.beautify || program.format) {
-        if (program.beautify && program.format) {
-            fatal("Please only specify one of --beautify or --format");
-        }
-        if (program.beautify) {
-            options.format = typeof program.beautify == "object" ? program.beautify : {};
-            if (!("beautify" in options.format)) {
-                options.format.beautify = true;
-            }
-        }
-        if (program.format) {
-            options.format = typeof program.format == "object" ? program.format : {};
-        }
+    if (program.format) {
+        options.format = typeof program.format == "object" ? program.format : {};
     }
     if (program.comments) {
         if (typeof options.format != "object") options.format = {};

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,6 +42,7 @@ export async function run_cli({ program, packageJson, fs, path }) {
     program.option("-m, --mangle [options]", "Mangle names/specify mangler options.", parse_js());
     program.option("--mangle-props [options]", "Mangle properties/specify mangler options.", parse_js());
     program.option("-f, --format [options]", "Format options.", parse_js());
+    program.option("-b, --beautify [options]", "Alias for --format.", parse_js());
     program.option("-o, --output <file>", "Output file (default STDOUT).");
     program.option("--comments [filter]", "Preserve copyright comments in the output.");
     program.option("--config-file <file>", "Read minify() options from JSON file.");
@@ -92,8 +93,9 @@ export async function run_cli({ program, packageJson, fs, path }) {
         else
             options.ecma = ecma;
     }
-    if (program.format) {
-        options.format = typeof program.format == "object" ? program.format : {};
+    if (program.format || program.beautify) {
+        const chosenOption = program.format || program.beautify;
+        options.format = typeof chosenOption === "object" ? chosenOption : {};
     }
     if (program.comments) {
         if (typeof options.format != "object") options.format = {};

--- a/test/mocha/cli-2.js
+++ b/test/mocha/cli-2.js
@@ -64,7 +64,7 @@ describe("bin/terser (2)", function() {
         });
     });
     it("Should print supported options on invalid option syntax", function(done) {
-        var command = tersercmd + " test/input/comments/filter.js -b ascii-only";
+        var command = tersercmd + " test/input/comments/filter.js -f ascii-only";
         exec(command, function (err, stdout, stderr) {
             assert.ok(err);
             assert.strictEqual(stdout, "");

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -150,46 +150,6 @@ describe("bin/terser", function() {
             done();
         });
     });
-    it("Should work with `--beautify`", function(done) {
-        var command = tersercmd + ' test/input/issue-1482/input.js -b';
-
-        exec(command, function (err, stdout) {
-            if (err) throw err;
-
-            assert.strictEqual(stdout, read("test/input/issue-1482/default.js"));
-            done();
-        });
-    });
-    it("Should work with `--beautify braces`", function(done) {
-        var command = tersercmd + ' test/input/issue-1482/input.js -b braces';
-
-        exec(command, function (err, stdout) {
-            if (err) throw err;
-
-            assert.strictEqual(stdout, read("test/input/issue-1482/braces.js"));
-            done();
-        });
-    });
-    it("Should work with `--format beautify=true`", function (done) {
-        var command = tersercmd + ' test/input/issue-1482/input.js -f beautify=true';
-
-        exec(command, function (err, stdout) {
-            if (err) throw err;
-
-            assert.strictEqual(stdout, read("test/input/issue-1482/default.js"));
-            done();
-        });
-    });
-    it("Should work with `--format beautify=true,braces`", function (done) {
-        var command = tersercmd + ' test/input/issue-1482/input.js -f beautify=true,braces';
-
-        exec(command, function (err, stdout) {
-            if (err) throw err;
-
-            assert.strictEqual(stdout, read("test/input/issue-1482/braces.js"));
-            done();
-        });
-    });
     it("Should process inline source map", function(done) {
         var command = tersercmd + " test/input/issue-520/input.js -mc toplevel --source-map content=inline,url=inline";
 

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -150,6 +150,21 @@ describe("bin/terser", function() {
             done();
         });
     });
+    it("Should alias `--beautify` with `--format`", function(done) {
+        var command1 = tersercmd + ' test/input/enclose/input.js --beautify preamble=oops';
+        var command2 = tersercmd + ' test/input/enclose/input.js --format preamble=oops';
+
+        exec(command1, function (err, stdout1) {
+            if (err) throw err;
+            exec(command2, function(err, stdout2) {
+                if (err) throw err;
+                assert.strictEqual(stdout1, stdout2);
+                done();
+            });
+
+
+        });
+    });
     it("Should process inline source map", function(done) {
         var command = tersercmd + " test/input/issue-520/input.js -mc toplevel --source-map content=inline,url=inline";
 

--- a/test/mocha/release.js
+++ b/test/mocha/release.js
@@ -29,6 +29,7 @@ describe('release', () => {
             it("Should pass with options " + options, function(done) {
                 var args = options.split(/ /);
                 args.unshift("test/benchmark.cjs");
+                args.push("-f", "webkit");
                 run(process.argv[0], args, done);
             });
         });

--- a/test/mocha/release.js
+++ b/test/mocha/release.js
@@ -43,7 +43,6 @@ describe('release', () => {
             it("Should pass with options " + options, function(done) {
                 var args = options.split(/ /);
                 args.unshift("test/jetstream.cjs");
-                args.push("-b", "beautify=false,webkit");
                 run(process.argv[0], args, done);
             });
         });

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -96,6 +96,8 @@ export interface ManglePropertiesOptions {
 
 export interface FormatOptions {
     ascii_only?: boolean;
+    /** @deprecated Not implemented anymore */
+    beautify?: boolean;
     braces?: boolean;
     comments?: boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
         value: string,

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -96,7 +96,6 @@ export interface ManglePropertiesOptions {
 
 export interface FormatOptions {
     ascii_only?: boolean;
-    beautify?: boolean;
     braces?: boolean;
     comments?: boolean | 'all' | 'some' | RegExp | ( (node: any, comment: {
         value: string,


### PR DESCRIPTION
Hi. Tests are passing and I think everything is ok here. The beautify functionality was only removed for CLI. Why not entirely? Because you use it with tests.
Closes #214 