### PR TITLE
Test private fields as accessors

### DIFF
--- a/test/compress/classes.js
+++ b/test/compress/classes.js
@@ -135,3 +135,53 @@ private_class_methods: {
     }
     // expect_stdout: "PASS" // < tested in chrome, fails with nodejs 14 (current LTS)
 }
+
+private_class_accessors: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    input: {
+        class A {
+            #accessorInternal = "FAIL"
+            get #accessor() {
+                return this.#accessorInternal
+            }
+            set #accessor(v) {
+                this.#accessorInternal = v;
+            }
+            static get #accessor2() {
+                return "S"
+            }
+            get ["#accessor"]() {
+                return "S"
+            }
+            async print() {
+                this.#accessor = "PA"
+                console.log(this.#accessor + A.#accessor2 + this["#accessor"]);
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            #accessorInternal = "FAIL"
+            get #accessor() {
+                return this.#accessorInternal
+            }
+            set #accessor(v) {
+                this.#accessorInternal = v;
+            }
+            static get #accessor2() {
+                return "S"
+            }
+            get ["#accessor"]() {
+                return "S"
+            }
+            async print() {
+                this.#accessor = "PA"
+                console.log(this.#accessor + A.#accessor2 + this["#accessor"]);
+            }
+        }
+        new A().print();
+    }
+    // expect_stdout: "PASS" // < tested in chrome, fails with nodejs 14 (current LTS)
+}


### PR DESCRIPTION
This is a followup to https://github.com/terser/terser/pull/913. @robpalme suggested that we test accessors as we've seen other projects handle them sub-optimally: thankfully terser seems to be ok with them!