### PR TITLE
domprops.js: add `exports`

### DIFF
--- a/tools/domprops.js
+++ b/tools/domprops.js
@@ -4120,6 +4120,7 @@ export var domprops = [
     "exponent",
     "exponentialRampToValueAtTime",
     "exportKey",
+    "exports",
     "extend",
     "extensions",
     "extentNode",


### PR DESCRIPTION
Add `exports` attribute to domprops.js

See: https://webassembly.github.io/spec/js-api/#dom-instance-exports