### PR TITLE
fix: add backwards compatible change for require.resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "./dist/bundle.min.js"
     ],
     "./package": "./package.json",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./bin/terser": "./bin/terser"
   },
   "types": "tools/terser.d.ts",
   "bin": {


### PR DESCRIPTION
We have code that relied on `require.resolve` to properly respect the path we provide it https://github.com/bazelbuild/rules_nodejs/blob/stable/packages/terser/index.js#L166

However, under Node 12/14, `require` will respect `exports` over what we were relying on. Per the docs, NodeJS recommends exposing old paths to avoid being breaking by accident

```
Warning: Introducing the "exports" field prevents consumers of a package from using any entry points that are not defined, including the package.json (e.g. require('your-package/package.json'). This will likely be a breaking change.

To make the introduction of "exports" non-breaking, ensure that every previously supported entry point is exported. It is best to explicitly specify entry points so that the package’s public API is well-defined. For example, a project that previous exported main, lib, feature, and the package.json could use the following package.exports:
```
https://nodejs.org/api/packages.html#packages_package_entry_points

This change allows folks to still do `require.resolve('terser/bin/terser')` if they were relying on it without breaking them due to Terser 5 + Node 14. Note, this does not impact Terser 4 because there is no `exports` field

Here is the output from the `node` repl locally after I added the package change

```sh
➜ node
Welcome to Node.js v14.15.5.
Type ".help" for more information.
> require.resolve('terser/bin/terser')
'/private/var/tmp/_bazel_david.aghassi/a7bb26caa05a7d74fdb20e24a0f896f3/external/rh_web_deps/_/node_modules/terser/bin/terser'
```

Without this change
```
> require.resolve('terser/bin/terser')
Uncaught:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './bin/terser' is not defined by "exports" in /private/var/tmp/_bazel_david.aghassi/a7bb26caa05a7d74fdb20e24a0f896f3/external/rh_web_deps/node_modules/terser/package.json
    at throwExportsNotFound (internal/modules/esm/resolve.js:290:9)
    at packageExportsResolve (internal/modules/esm/resolve.js:513:3)
    at resolveExports (internal/modules/cjs/loader.js:432:36)
    at Function.Module._findPath (internal/modules/cjs/loader.js:472:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:867:27)
    at Function.resolve (internal/modules/cjs/helpers.js:94:19)
    at REPL2:1:9
    at Script.runInThisContext (vm.js:133:18)
    at REPLServer.defaultEval (repl.js:484:29)
    at bound (domain.js:413:15) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```