### PR TITLE
Add `spidermonkey` options to `minify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ try {
     module: false,
     nameCache: null, // or specify a name cache object
     safari10: false,
-    toplevel: false,
+    toplevel: false
 }
 ```
 
@@ -668,6 +668,8 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `html5_comments` (default `true`)
 
 - `shebang` (default `true`) -- support `#!command` as the first line
+
+- `spidermonkey` (default `false`) -- accept a Spidermonkey (Mozilla) AST
 
 ## Compress options
 
@@ -848,7 +850,7 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `unsafe_math` (default: `false`) -- optimize numerical expressions like
   `2 * x * 3` into `6 * x`, which may give imprecise floating point results.
 
-- `unsafe_symbols` (default: `false`) -- removes keys from native Symbol 
+- `unsafe_symbols` (default: `false`) -- removes keys from native Symbol
   declarations, e.g `Symbol("kDog")` becomes `Symbol()`.
 
 - `unsafe_methods` (default: false) -- Converts `{ m: function(){} }` to
@@ -1017,6 +1019,8 @@ as "output options".
   gzip could be smaller; size after gzip insignificantly larger).
 
 - `shebang` (default `true`) -- preserve shebang `#!` in preamble (bash scripts)
+
+- `spidermonkey` (default `false`) -- produce a Spidermonkey (Mozilla) AST
 
 - `webkit` (default `false`) -- enable workarounds for WebKit bugs.
   PhantomJS users should set this option to `true`.
@@ -1188,6 +1192,9 @@ The `-p spidermonkey` option tells Terser that all input files are not
 JavaScript, but JS code described in SpiderMonkey AST in JSON.  Therefore we
 don't use our own parser in this case, but just transform that AST into our
 internal AST.
+
+`spidermonkey` is also available in `minify` as `parse` and `format` options to
+accept and/or produce a spidermonkey AST.
 
 ### Use Acorn for parsing
 

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -7,7 +7,7 @@ import {
     map_to_object,
     HOP,
 } from "./utils/index.js";
-import { AST_Toplevel } from "./ast.js";
+import { AST_Toplevel, AST_Node } from "./ast.js";
 import { parse } from "./parse.js";
 import { OutputStream } from "./output.js";
 import { Compressor } from "./compress/index.js";
@@ -77,6 +77,7 @@ async function minify(files, options) {
         rename: undefined,
         safari10: false,
         sourceMap: false,
+        spidermonkey: false,
         timings: false,
         toplevel: false,
         warnings: false,
@@ -148,20 +149,32 @@ async function minify(files, options) {
     if (files instanceof AST_Toplevel) {
         toplevel = files;
     } else {
-        if (typeof files == "string") {
+        if (typeof files == "string" || (options.parse.spidermonkey && !Array.isArray(files))) {
             files = [ files ];
         }
         options.parse = options.parse || {};
         options.parse.toplevel = null;
-        for (var name in files) if (HOP(files, name)) {
-            options.parse.filename = name;
-            options.parse.toplevel = parse(files[name], options.parse);
-            if (options.sourceMap && options.sourceMap.content == "inline") {
-                if (Object.keys(files).length > 1)
-                    throw new Error("inline source map only works with singular input");
-                options.sourceMap.content = read_source_map(files[name]);
+
+        if (options.parse.spidermonkey) {
+            options.parse.toplevel = AST_Node.from_mozilla_ast(Object.keys(files).reduce(function(toplevel, name) {
+                if (!toplevel) return files[name];
+                toplevel.body = toplevel.body.concat(files[name].body);
+                return toplevel;
+            }, null));
+        } else {
+            delete options.parse.spidermonkey;
+
+            for (var name in files) if (HOP(files, name)) {
+                options.parse.filename = name;
+                options.parse.toplevel = parse(files[name], options.parse);
+                if (options.sourceMap && options.sourceMap.content == "inline") {
+                    if (Object.keys(files).length > 1)
+                        throw new Error("inline source map only works with singular input");
+                    options.sourceMap.content = read_source_map(files[name]);
+                }
             }
         }
+
         toplevel = options.parse.toplevel;
     }
     if (quoted_props && options.mangle.properties.keep_quoted !== "strict") {
@@ -203,6 +216,9 @@ async function minify(files, options) {
     if (options.format.ast) {
         result.ast = toplevel;
     }
+    if (options.format.spidermonkey) {
+        result.ast = toplevel.to_mozilla_ast();
+    }
     if (!HOP(options.format, "code") || options.format.code) {
         if (options.sourceMap) {
             options.format.source_map = await SourceMap({
@@ -220,6 +236,7 @@ async function minify(files, options) {
         }
         delete options.format.ast;
         delete options.format.code;
+        delete options.format.spidermonkey;
         var stream = OutputStream(options.format);
         toplevel.print(stream);
         result.code = stream.get();

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -114,12 +114,23 @@ describe("spidermonkey export/import sanity test", function() {
     it("should be capable of importing from acorn", async function() {
         var code = fs.readFileSync("test/input/spidermonkey/input.js", "utf-8");
         var terser_ast = parse(code);
-        var moz_ast = acornParse(code, {sourceType: 'module', ecmaVersion: 2020});
+        var moz_ast = acornParse(code, {sourceType: "module", ecmaVersion: 2020});
         var from_moz_ast = AST.AST_Node.from_mozilla_ast(moz_ast);
         assert.strictEqual(
             from_moz_ast.print_to_string(),
             terser_ast.print_to_string()
         );
+    });
+
+    it("should accept a spidermonkey AST w/ `parse.spidermonkey: true`", async function() {
+        var moz_ast = acornParse("var a = 1 + 2", {sourceType: "module", ecmaVersion: 2020});
+        var result = await minify(moz_ast, {ecma: 2015, parse: {spidermonkey: true}});
+        assert.deepStrictEqual(result.code, "var a=3;");
+    });
+
+    it("should produce a spidermonkey AST w/ `format.spidermonkey: true`", async function() {
+        var result = await minify("var a = 1 + 2", {ecma: 2015, format: {spidermonkey: true}});
+        assert.deepStrictEqual(astringGenerate(result.ast), "var a = 3;\n");
     });
 
     it("should correctly minify AST from from_moz_ast with default destructure", async () => {


### PR DESCRIPTION
This commit adds a `spidermonkey` option, similar to the CLI, to the `minify` API.
`spidermonkey` is a shortcut for setting that option as both a `parse` and `format` option.
These options, defaulting to false, when set to true, result in accepting and/or producing a Spidermonkey (Mozilla, ESTree) AST.

Closes GH-973.

//cc @fabiosantoscode