### PR TITLE
Compress more nullish checks into nullish coalescing

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6810,10 +6810,11 @@ function is_nullish_check(check, consequent, alternative, compressor) {
         )
     ) {
         const test_subject = nullish_side === check.left ? check.right : check.left;
-        if (test_subject.may_throw(compressor)) return false;
+        if (test_subject.may_throw(compressor)) return null;
 
         const check_subject = check.operator == "==" ? alternative : consequent;
-        if (test_subject.equivalent_to(check_subject)) return true;
+        if (!test_subject.equivalent_to(check_subject)) return null;
+        return check.operator == "==" ? [alternative, consequent] : [consequent, alternative];
     }
 
     // foo === null || foo === undefined
@@ -6877,15 +6878,15 @@ function is_nullish_check(check, consequent, alternative, compressor) {
             return true;
         };
 
-        if (!find_comparison(check.left)) return false;
-        if (!find_comparison(check.right)) return false;
+        if (!find_comparison(check.left)) return null;
+        if (!find_comparison(check.right)) return null;
 
         if (null_cmp && undefined_cmp && null_cmp !== undefined_cmp) {
-            return true;
+            return OR ? [alternative, consequent] : [consequent, alternative];
         }
     }
 
-    return false;
+    return null;
 }
 
 def_optimize(AST_Conditional, function(self, compressor) {
@@ -6985,15 +6986,15 @@ def_optimize(AST_Conditional, function(self, compressor) {
 
     // a == null ? b : a -> a ?? b
     // a != null ? a : b -> a ?? b
+    let nullish_check;
     if (
         compressor.option("ecma") >= 2020 &&
-        is_nullish_check(condition, consequent, alternative, compressor)
+        (nullish_check = is_nullish_check(condition, consequent, alternative, compressor))
     ) {
-        let left = condition.operator == "==" || condition.operator == "||" ? alternative : consequent;
         return make_node(AST_Binary, self, {
             operator: "??",
-            left: left,
-            right: left == alternative ? consequent : alternative,
+            left: nullish_check[0],
+            right: nullish_check[1],
         }).optimize(compressor);
     }
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -6795,40 +6795,47 @@ function is_nullish(node) {
     );
 }
 
-function is_nullish_check(check, check_subject, compressor) {
-    if (check_subject.may_throw(compressor)) return false;
-
+function is_nullish_check(check, consequent, alternative, compressor) {
     let nullish_side;
 
     // foo == null
+    // foo != null
     if (
         check instanceof AST_Binary
-        && check.operator === "=="
+        && (check.operator === "==" || check.operator === "!=")
         // which side is nullish?
         && (
             (nullish_side = is_nullish(check.left) && check.left)
             || (nullish_side = is_nullish(check.right) && check.right)
         )
-        // is the other side the same as the check_subject
-        && (
-            nullish_side === check.left
-                ? check.right
-                : check.left
-        ).equivalent_to(check_subject)
     ) {
-        return true;
+        const test_subject = nullish_side === check.left ? check.right : check.left;
+        if (test_subject.may_throw(compressor)) return false;
+
+        const check_subject = check.operator == "==" ? alternative : consequent;
+        if (test_subject.equivalent_to(check_subject)) return true;
     }
 
     // foo === null || foo === undefined
-    if (check instanceof AST_Binary && check.operator === "||") {
+    // foo !== null && foo !== undefined
+    if (
+        check instanceof AST_Binary
+        && (check.operator === "||" || check.operator === "&&")
+    ) {
         let null_cmp;
         let undefined_cmp;
 
+        const OR = check.operator == "||";
+
         const find_comparison = cmp => {
-            if (!(
-                cmp instanceof AST_Binary
-                && (cmp.operator === "===" || cmp.operator === "==")
-            )) {
+            if (!(cmp instanceof AST_Binary)) {
+                return false;
+            }
+            if (
+                OR
+                    ? !(cmp.operator === "===" || cmp.operator === "==")
+                    : !(cmp.operator === "!==" || cmp.operator === "!=")
+            ) {
                 return false;
             }
 
@@ -6860,7 +6867,10 @@ function is_nullish_check(check, check_subject, compressor) {
                 return false;
             }
 
-            if (!defined_side.equivalent_to(check_subject)) {
+            if (
+                defined_side.may_throw(compressor)
+                || !defined_side.equivalent_to(OR ? alternative : consequent)
+            ) {
                 return false;
             }
 
@@ -6974,14 +6984,16 @@ def_optimize(AST_Conditional, function(self, compressor) {
     }
 
     // a == null ? b : a -> a ?? b
+    // a != null ? a : b -> a ?? b
     if (
         compressor.option("ecma") >= 2020 &&
-        is_nullish_check(condition, alternative, compressor)
+        is_nullish_check(condition, consequent, alternative, compressor)
     ) {
+        let left = condition.operator == "==" || condition.operator == "||" ? alternative : consequent;
         return make_node(AST_Binary, self, {
             operator: "??",
-            left: alternative,
-            right: consequent
+            left: left,
+            right: left == alternative ? consequent : alternative,
         }).optimize(compressor);
     }
 

--- a/test/compress/nullish.js
+++ b/test/compress/nullish.js
@@ -10,16 +10,18 @@ conditional_to_nullish_coalescing: {
         const foo = id('something');
 
         leak(foo == null ? bar : foo);
+        leak(foo != null ? foo : bar);
     }
 
     expect: {
         const foo = id('something');
 
         leak(foo ?? bar);
+        leak(foo ?? bar);
     }
 }
 
-conditional_to_nullish_coalescing_2: {
+conditional_to_nullish_coalescing_strict: {
     options = {
         ecma: 2020,
         toplevel: true,
@@ -29,31 +31,71 @@ conditional_to_nullish_coalescing_2: {
     input: {
         const foo = id('something')
 
-        console.log('negative cases')
-        foo === null || foo === null ? bar : foo;
-        foo === undefined || foo === undefined ? bar : foo;
-        foo === null || foo === undefined ? foo : bar;
-        some_global === null || some_global === undefined ? bar : some_global;
-
-        console.log('positive cases')
-        foo === null || foo === void 0 ? bar : foo;
         foo === null || foo === undefined ? bar : foo;
         foo === undefined || foo === null ? bar : foo;
+        foo !== null && foo !== undefined ? foo : bar;
+        foo !== undefined && foo !== null ? foo : bar;
     }
 
     expect: {
         const foo = id('something')
 
-        console.log('negative cases')
+        foo ?? bar;
+        foo ?? bar;
+        foo ?? bar;
+        foo ?? bar;
+    }
+}
+
+conditional_to_nullish_coalescing_strict_negative: {
+    options = {
+        ecma: 2020,
+        toplevel: true,
+        conditionals: true
+    }
+
+    input: {
+        const foo = id('something')
+
+        foo === null || foo === null ? bar : foo;
+        foo === undefined || foo === undefined ? bar : foo;
+        foo === null || foo === undefined ? foo : bar;
+        foo !== null && foo !== null ? foo : bar;
+        foo !== undefined && foo !== undefined ? foo : bar;
+        foo !== null && foo !== undefined ? bar : foo;
+    }
+
+    expect: {
+        const foo = id('something')
+
         null === foo || null === foo ? bar : foo;
         void 0 === foo || void 0 === foo ? bar : foo;
         null === foo || void 0 === foo ? foo : bar;
-        null === some_global || void 0 === some_global ? bar : some_global;
+        null !== foo && null !== foo ? foo : bar ;
+        void 0 !== foo && void 0 !== foo ? foo : bar ;
+        null !== foo && void 0 !== foo ? bar : foo ;
+    }
+}
 
-        console.log('positive cases')
-        foo ?? bar;
-        foo ?? bar;
-        foo ?? bar;
+conditional_to_nullish_coalescing_global: {
+    options = {
+        ecma: 2020,
+        toplevel: true,
+        conditionals: true
+    }
+
+    input: {
+        some_global == null ? bar : some_global;
+        some_global != null ? some_global : bar;
+        some_global === null || some_global === undefined ? bar : some_global;
+        some_global !== null && some_global !== undefined ? some_global : bar;
+    }
+
+    expect: {
+        null == some_global ? bar : some_global;
+        null != some_global ? some_global : bar;
+        null === some_global || void 0 === some_global ? bar : some_global;
+        null !== some_global && void 0 !== some_global ? some_global : bar;
     }
 }
 


### PR DESCRIPTION
This adds support for `foo != null ? foo : bar` (and the respective `!==` checks). This is particularly important because Babel outputs this form of nullish coalescing.