### PR TITLE
fix: missing compressor arg in optimize AST_VarDef

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -5102,11 +5102,11 @@ def_optimize(AST_Definitions, function(self) {
     return self;
 });
 
-def_optimize(AST_VarDef, function(self) {
+def_optimize(AST_VarDef, function(self, compressor) {
     if (
         self.name instanceof AST_SymbolLet
         && self.value != null
-        && is_undefined(self.value)
+        && is_undefined(self.value, compressor)
     ) {
         self.value = null;
     }

--- a/test/compress/issue-1006.js
+++ b/test/compress/issue-1006.js
@@ -1,0 +1,24 @@
+issue_1006: {
+    options = {
+        defaults: true,
+    }
+    input: {
+        function func(foo) {
+            function bar() {
+                return;
+            }
+            let baz = foo();
+            if (baz !== undefined) {
+                let qux = bar(baz.qux);
+            }
+        }
+    }
+    expect: {
+        function func(foo) {
+            let baz = foo();
+            if (void 0 !== baz) {
+                baz.qux;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1006 

----

I've been running into the same issue as #1006 while trying to minify my app's vendor code chunk via webpack5 (after upgrading from webpack4) and using its vanilla optimization config in production mode.

```
ERROR in vendor.js from Terser
TypeError: Cannot read property 'option' of undefined
    at AST_SymbolRef.may_throw_on_access (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:12979:28)
    at AST_Dot.has_side_effects (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:13918:50)
    at is_undefined (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:12971:33)
    at /home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:15552:12
    at AST_VarDef.optimize (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:10892:19)
    at Compressor.before (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:10877:24)
    at AST_VarDef.transform (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:5395:41)
    at /home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:5411:21
    at doit (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:112:23)
    at MAP (/home/basti/repos/streamlink-twitch-gui/node_modules/terser/dist/bundle.min.js:137:52)
```

Unfortunately I've not been able to identify the exact cause, so I can't provide a test case for this, but the solution mentioned in #1006 by @ManoharChennuru works.

As you can see from the call stack beginning at [`AST_VarDef.optimize`](https://github.com/terser/terser/blob/5d8dde3c70b218b60b748a5ac27377756a0f6560/lib/compress/index.js#L5105-L5114), the function [`is_undefined`](https://github.com/terser/terser/blob/5d8dde3c70b218b60b748a5ac27377756a0f6560/lib/compress/index.js#L2522-L2530) requires a `compressor` as second argument, otherwise it'll pass `undefined` to `node.expression.has_side_effects` (which is [`AST_Dot.has_side_effects`](https://github.com/terser/terser/blob/5d8dde3c70b218b60b748a5ac27377756a0f6560/lib/compress/index.js#L3474-L3477) in this case), which then throws a `TypeError` in [`AST_SymbolRef.may_throw_on_access`](https://github.com/terser/terser/blob/5d8dde3c70b218b60b748a5ac27377756a0f6560/lib/compress/index.js#L2535-L2538) as it can't access the `option` property of the undefined `compressor`.

The function `def_optimize` which defines `AST_VarDef.optimize` [always passes the `compressor` argument](https://github.com/terser/terser/blob/5d8dde3c70b218b60b748a5ac27377756a0f6560/lib/compress/index.js#L449).

----

As a side-note, before applying my changes to the current HEAD of the master branch, the "sourcemaps -> sourceMapInline -> Should work with unicode characters" mocha test failed with "InvalidCharacterError: Invalid character" for some reason, so I had to commit my changes afterwards with `--no-verify`. Not sure what this is about. I'm on Linux using NodeJS `16.3.0` if that matters. I hope the tests on the CI side will pass.