### PR TITLE
Add example in README for mangling private class fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,22 @@ $ terser example.js -c passes=2 -m --mangle-props regex=/_$/
 ```javascript
 var x={o:3,t:1,calc:function(){return this.t+this.o},i:2};console.log(x.calc());
 ```
+Mangle all private class fields (this should generally be safe, unless you are using quoted properties that start with `#`):
+```javascript
+export class MyClass {
+  #someField = 5
+};
+export const obj = {
+  ['#someField']: 42,
+};
+```
+
+```bash
+$ terser example2.js -c passes=2 -m --mangle-props regex=/^#/
+```
+```javascript
+export class MyClass{#s=5}export const obj={o:42};
+```
 
 Combining mangle properties options:
 ```bash

--- a/README.md
+++ b/README.md
@@ -315,6 +315,9 @@ Mangle all private class fields (this should generally be safe, unless you are u
 ```javascript
 export class MyClass {
   #someField = 5
+  someMethod() {
+    this.#someField = 42;
+  }
 };
 export const obj = {
   ['#someField']: 42,
@@ -325,7 +328,7 @@ export const obj = {
 $ terser example2.js -c passes=2 -m --mangle-props regex=/^#/
 ```
 ```javascript
-export class MyClass{#s=5}export const obj={o:42};
+export class MyClass{#s=5;someMethod(){this.#s=42}}export const obj={o:42};
 ```
 
 Combining mangle properties options:


### PR DESCRIPTION
I was looking into mangling private class fields with Terser.
Even though I think it would be generally safe for Terser
to do this by default, it is currently already possible
by using a regex as `--mangle-props`.

Therefore, let's add an explicit example in the README
for anybody else who is looking to mangling private
class fields.