### PR TITLE
fix: private class element access equality

### DIFF
--- a/lib/equivalent-to.js
+++ b/lib/equivalent-to.js
@@ -18,6 +18,7 @@ import {
     AST_Directive,
     AST_Do,
     AST_Dot,
+    AST_DotHash,
     AST_EmptyStatement,
     AST_Expansion,
     AST_Export,
@@ -230,6 +231,10 @@ AST_PropAccess.prototype.shallow_cmp = pass_through;
 AST_Chain.prototype.shallow_cmp = pass_through;
 
 AST_Dot.prototype.shallow_cmp = mkshallow({
+    property: "eq"
+});
+
+AST_DotHash.prototype.shallow_cmp = mkshallow({
     property: "eq"
 });
 

--- a/test/compress/issue_1014.js
+++ b/test/compress/issue_1014.js
@@ -1,0 +1,117 @@
+ternary_and_private_fields: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    options = {
+        conditionals: true,
+    }
+    input: {
+        class A {
+            #fail = false;
+            #pass = "PASS";
+            print() {
+                console.log(this.#fail ? this.#fail : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            #fail = false;
+            #pass = "PASS";
+            print() {
+                console.log(this.#fail ? this.#fail : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect_stdout: "PASS"
+}
+
+ternary_and_private_public_fields: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    options = {
+        conditionals: true,
+    }
+    input: {
+        class A {
+            fail = false;
+            #pass = "PASS";
+            print() {
+                console.log(this.fail ? this.fail : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            fail = false;
+            #pass = "PASS";
+            print() {
+                console.log(this.fail ? this.fail : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect_stdout: "PASS"
+}
+
+ternary_and_private_methods: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    options = {
+        conditionals: true,
+    }
+    input: {
+        class A {
+            #fail() { return false; }
+            get #pass() { return "PASS"; }
+            print() {
+                console.log(this.#fail() ? this.#fail() : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            #fail() { return false; }
+            get #pass() { return "PASS"; }
+            print() {
+                console.log(this.#fail() ? this.#fail() : this.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect_stdout: "PASS"
+}
+
+ternary_and_private_static_fields: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    options = {
+        conditionals: true,
+    }
+    input: {
+        class A {
+            static #fail = false;
+            static #pass = "PASS";
+            print() {
+                console.log(A.#fail ? A.#fail : A.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect: {
+        class A {
+            static #fail = false;
+            static #pass = "PASS";
+            print() {
+                console.log(A.#fail ? A.#fail : A.#pass);
+            }
+        }
+        new A().print();
+    }
+    expect_stdout: "PASS"
+}
+
+

--- a/test/compress/issue_999.js
+++ b/test/compress/issue_999.js
@@ -1,0 +1,41 @@
+switch_case_and_private_fields: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    options = {
+        switches: true,
+        dead_code: true,
+    }
+    input: {
+        class A {
+            #a = "FAIL";
+            #b = "PASS";
+
+            print(variant) {
+                switch (variant) {
+                    case 1:
+                        return this.#a;
+                    case 2:
+                        return this.#b;
+                }
+            }
+        }
+        console.log(new A().print(2));
+    }
+    expect: {
+        class A {
+            #a = "FAIL";
+            #b = "PASS";
+
+            print(variant) {
+                switch (variant) {
+                    case 1:
+                        return this.#a;
+                    case 2:
+                        return this.#b;
+                }
+            }
+        }
+        console.log(new A().print(2));
+    }
+    expect_stdout: "PASS"
+}


### PR DESCRIPTION
`AST_DotHash#shallow_cmp` was never implemented so equality checks for private element access were using the comparison function from the super (`AST_PropAccess`) class. With these changes we compare private element access expressions by private name.

Fixes #1014.
Fixes #999.