### PR TITLE
Documentation and type definition: MinifyOptions.enclose

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,11 @@ try {
 - `ecma` (default `undefined`) - pass `5`, `2015`, `2016`, etc to override
   `compress` and `format`'s `ecma` options.
 
+- `enclose` (default `false`) - pass `true`, or a string in the format
+  of `"args[:values]"`, where `args` and `values` are comma-separated
+  argument names and values, respectively, to embed the output in a big
+  function with the configurable arguments and values.
+
 - `parse` (default `{}`) — pass an object if you wish to specify some
   additional [parse options](#parse-options).
 
@@ -602,6 +607,7 @@ try {
         // source map options
     },
     ecma: 5, // specify one of: 5, 2015, 2016, etc.
+    enclose: false, // or specify true, or "args:values"
     keep_classnames: false,
     keep_fnames: false,
     ie8: false,

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -138,6 +138,7 @@ export enum OutputQuoteStyle {
 export interface MinifyOptions {
     compress?: boolean | CompressOptions;
     ecma?: ECMA;
+    enclose?: boolean | string;
     ie8?: boolean;
     keep_classnames?: boolean | RegExp;
     keep_fnames?: boolean | RegExp;


### PR DESCRIPTION
This patch updates the documentation to explain the existing `enclose` option, and also modifies the type definition of `MinifyOptions` to accept the `enclose` field.

Related lines of code: https://github.com/terser/terser/blob/d3d924fa9e4c57bbe286b811c6068bcc7026e902/lib/minify.js#L186-L188 https://github.com/terser/terser/blob/d3d924fa9e4c57bbe286b811c6068bcc7026e902/lib/ast.js#L448-L451