### PR TITLE
Optimize various switch statements

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1615,41 +1615,6 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
-    // If all cases fall through into the final branch, and a default is present anywhere,
-    // we can collapse all branches.
-    if (default_branch) {
-        let i = 0;
-        for (; i < body.length; i++) {
-            let branch = body[i];
-            if (branch.body.length > 0) break;
-            if (branch === default_branch) continue;
-            // It's actually ok for the last branch's expression to have a side-effect
-            if (branch.expression.has_side_effects(compressor)) break;
-        }
-        // 3 cases:
-        // 1. i < body.length - 1, there's a side-effect/non-empty branch, and nothing to optimize.
-        // 2. i === body.length - 1, the last branch has a side-effect/non-empty, but that can be collapsed.
-        // 3. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
-        if (i >= body.length - 1) {
-            if (i < body.length) {
-                let last = body[i];
-                if (last !== default_branch) {
-                    default_branch.body =  make_node(AST_BlockStatement, last, {
-                        body: [
-                            make_node(AST_SimpleStatement, last.expression, { body: last.expression })
-                        ].concat(last.body),
-                    }).optimize(compressor);
-                }
-            }
-            body = [default_branch];
-        }
-    }
-
-    if (body.length > 0) {
-        body[0].body = decl.concat(body[0].body);
-    }
-    self.body = body;
-
     // Try to prune any empty branches at the end of the switch statement.
     {
         let i = body.length - 1;
@@ -1684,6 +1649,33 @@ def_optimize(AST_Switch, function(self, compressor) {
             body.length = pointer;
         }
     }
+
+    // Collapse branches into the default.
+    if (default_branch) {
+        let i = find_significant_branch_index(body, 0, 1);
+        // 3 cases:
+        if (i >= body.length - 1) {
+            // 1. i === body.length - 1, the last branch has a side-effect/non-empty, but that can be collapsed.
+            // 2. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
+            if (i < body.length) {
+                let last = body[i];
+                if (last !== default_branch) {
+                    default_branch.body =  make_node(AST_BlockStatement, last, {
+                        body: [
+                            make_node(AST_SimpleStatement, last.expression, { body: last.expression })
+                        ].concat(last.body),
+                    }).optimize(compressor);
+                }
+            }
+            body = [default_branch];
+        }
+    }
+
+    if (body.length > 0) {
+        body[0].body = decl.concat(body[0].body);
+    }
+    self.body = body;
+
     if (body.length == 0) {
         return make_node(AST_BlockStatement, self, {
             body: decl.concat(make_node(AST_SimpleStatement, self.expression, {
@@ -1691,7 +1683,7 @@ def_optimize(AST_Switch, function(self, compressor) {
             }))
         }).optimize(compressor);
     }
-    if (body.length == 1 && (body[0] === exact_match || body[0] === default_branch)) {
+    if (body.length == 1) {
         var has_break = false;
         var tw = new TreeWalker(function(node) {
             if (has_break
@@ -1702,18 +1694,76 @@ def_optimize(AST_Switch, function(self, compressor) {
         });
         self.walk(tw);
         if (!has_break) {
-            var statements = body[0].body.slice();
-            var exp = body[0].expression;
-            if (exp) statements.unshift(make_node(AST_SimpleStatement, exp, {
-                body: exp
-            }));
-            statements.unshift(make_node(AST_SimpleStatement, self.expression, {
-                body:self.expression
-            }));
-            return make_node(AST_BlockStatement, self, {
-                body: statements
+            let branch = body[0];
+            if (branch === exact_match || branch === default_branch) {
+                let statements = [make_node(AST_SimpleStatement, self.expression, {
+                    body: self.expression
+                })];
+                if (branch.expression) {
+                    statements.push(make_node(AST_SimpleStatement, branch.expression, {
+                        body: branch.expression
+                    }));
+                }
+                return make_node(AST_BlockStatement, branch, {
+                    body: statements.concat(branch.body)
+                }).optimize(compressor);
+            } else {
+                return make_node(AST_If, self, {
+                    condition: make_node(AST_Binary, self, {
+                        operator: "===",
+                        left: self.expression,
+                        right: branch.expression,
+                    }),
+                    body: make_node(AST_BlockStatement, branch, {
+                        body: branch.body
+                    }),
+                    alternative: null
+                }).optimize(compressor);
+            }
+        }
+    }
+    if (body.length === 2 && default_branch) {
+        let branch = body[0] === default_branch ? body[1] : body[0];
+        if (aborts(body[0])) {
+            body[0].body.pop();
+            return make_node(AST_If, self, {
+                condition: make_node(AST_Binary, self, {
+                    operator: "===",
+                    left: self.expression,
+                    right: branch.expression,
+                }),
+                body: make_node(AST_BlockStatement, branch, {
+                    body: branch.body
+                }),
+                alternative: make_node(AST_BlockStatement, default_branch, {
+                    body: default_branch.body
+                })
             }).optimize(compressor);
         }
+        let operator = "===";
+        let consequent = branch;
+        let always = default_branch;
+        if (body[0] === default_branch) {
+            operator = "!==";
+            consequent = default_branch;
+            always = branch;
+        }
+        return make_node(AST_BlockStatement, self, {
+            body: [
+                make_node(AST_If, self, {
+                    condition: make_node(AST_Binary, self, {
+                        operator: operator,
+                        left: self.expression,
+                        right: branch.expression,
+                    }),
+                    body: make_node(AST_BlockStatement, consequent, {
+                        body: consequent.body,
+                    }),
+                    alternative: null
+                })
+            ].concat(always.body)
+        }).optimize(compressor);
+
     }
     return self;
 
@@ -1734,6 +1784,18 @@ def_optimize(AST_Switch, function(self, compressor) {
         let bblock = make_node(AST_BlockStatement, branch, { body: bbody });
         let pblock = make_node(AST_BlockStatement, prev, { body: pbody });
         return bblock.equivalent_to(pblock);
+    }
+    function find_significant_branch_index(body, start_index, direction) {
+        let i = start_index;
+        for (; i < body.length && i >= 0; i += direction) {
+            if (is_significant_branch(body[i])) return i;
+        }
+        return i;
+    }
+    function is_significant_branch(branch) {
+        if (branch.body.length > 0) return true;
+        if (branch instanceof AST_Default) return false;
+        return branch.expression.has_side_effects(compressor);
     }
 });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1594,6 +1594,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         body.push(branch);
     }
     while (i < len) eliminate_branch(self.body[i++], body[body.length - 1]);
+    self.body = body;
 
     for (let i = 0; i < body.length; i++) {
         let branch = body[i];
@@ -1615,7 +1616,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
-    // Try to prune any empty branches at the end of the switch statement.
+    // Prune any empty branches at the end of the switch statement.
     {
         let i = body.length - 1;
         for (; i >= 0; i--) {
@@ -1631,7 +1632,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         // i now points to the index of a branch that contains a body. By incrementing, it's
         // pointing to the first branch that's empty.
         i++;
-        if (i < body.length && (!default_branch || body.indexOf(default_branch, i) >= i)) {
+        if (!default_branch || body.indexOf(default_branch) >= i) {
             // The default behavior is to do nothing. We can take advantage of that to
             // remove all case expressions that are side-effect free that also do
             // nothing, since they'll default to doing nothing. But we can't remove any
@@ -1651,31 +1652,86 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
-    // Collapse branches into the default.
+    // Prune side-effect free branches that fall into default.
     if (default_branch) {
-        let i = find_significant_branch_index(body, 0, 1);
-        // 3 cases:
-        if (i >= body.length - 1) {
+        let default_index = body.indexOf(default_branch);
+        let default_body_index = default_index;
+        for (; default_body_index < body.length - 1; default_body_index++) {
+            if (body[default_body_index].body.length > 0) break;
+        }
+        let side_effect_index = body.length - 1;
+        for (; side_effect_index >= 0; side_effect_index--) {
+            let branch = body[side_effect_index];
+            if (branch === default_branch) continue;
+            if (branch.expression.has_side_effects(compressor)) break;
+        }
+        if (default_body_index > side_effect_index) {
+            let prev_body_index = default_index - 1;
+            for (; prev_body_index >= 0; prev_body_index--) {
+                if (body[prev_body_index].body.length > 0) break;
+            }
+            let before = Math.max(side_effect_index, prev_body_index) + 1;
+            let after = default_index;
+            if (side_effect_index > default_index) {
+                after = side_effect_index;
+                body[side_effect_index].body = body[default_body_index].body;
+            } else {
+                default_branch.body = body[default_body_index].body;
+            }
+
+            body.splice(after + 1, default_body_index - after);
+            body.splice(before, default_index - before);
+        }
+    }
+
+    // See if we can remove the switch entirely if all cases (the default) fall into the same case body.
+    DEFAULT: if (default_branch) {
+        let i = body.findIndex(branch => branch.body.length > 0);
+        let caseBody;
+        if (i === body.length - 1) {
+            // There is only one case body. We can extract the body and place it after the switch.
+            let branch = body[i];
+            caseBody = make_node(AST_BlockStatement, branch, {
+                body: branch.body
+            });
+            branch.body = [];
+        } else if (i !== -1) {
+            break DEFAULT;
+        }
+        let sideEffect = body.find(branch => {
+            return (
+                branch !== default_branch
+                && branch.expression.has_side_effects(compressor)
+            );
+        });
+        if (!sideEffect || sideEffect === body[body.length - 1]) {
             // 1. i === body.length - 1, the last branch has a side-effect/non-empty, but that can be collapsed.
             // 2. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
-            if (i < body.length) {
-                let last = body[i];
-                if (last !== default_branch) {
-                    default_branch.body =  make_node(AST_BlockStatement, last, {
-                        body: [
-                            make_node(AST_SimpleStatement, last.expression, { body: last.expression })
-                        ].concat(last.body),
-                    }).optimize(compressor);
-                }
-            }
-            body = [default_branch];
+            return make_node(AST_BlockStatement, self, {
+                body: decl.concat(
+                    make_node(AST_SimpleStatement, self.expression, { body: self.expression }),
+                    sideEffect ? make_node(AST_SimpleStatement, sideEffect.expression, { body: sideEffect.expression }) : [],
+                    caseBody || []
+                )
+            }).optimize(compressor);
         }
+        if (caseBody) {
+            let default_index = body.indexOf(default_branch);
+            body.splice(default_index, 1);
+            // Recurse into switch statement one more time so that we can append the case body
+            // outside of the switch. This recursion will only happen once since we've pruned
+            // the default case.
+            return make_node(AST_BlockStatement, self, {
+                body: decl.concat(self, caseBody)
+            }).optimize(compressor);
+        }
+        // If we fall here, there is a default branch somewhere, there are no case bodies,
+        // and there's a side-effect somewhere. Just let the below paths take care of it.
     }
 
     if (body.length > 0) {
         body[0].body = decl.concat(body[0].body);
     }
-    self.body = body;
 
     if (body.length == 0) {
         return make_node(AST_BlockStatement, self, {
@@ -1785,18 +1841,6 @@ def_optimize(AST_Switch, function(self, compressor) {
         let bblock = make_node(AST_BlockStatement, branch, { body: bbody });
         let pblock = make_node(AST_BlockStatement, prev, { body: pbody });
         return bblock.equivalent_to(pblock);
-    }
-    function find_significant_branch_index(body, start_index, direction) {
-        let i = start_index;
-        for (; i < body.length && i >= 0; i += direction) {
-            if (is_significant_branch(body[i])) return i;
-        }
-        return i;
-    }
-    function is_significant_branch(branch) {
-        if (branch.body.length > 0) return true;
-        if (branch instanceof AST_Default) return false;
-        return branch.expression.has_side_effects(compressor);
     }
 });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -108,6 +108,7 @@ import {
     AST_String,
     AST_Sub,
     AST_Switch,
+    AST_SwitchBranch,
     AST_Symbol,
     AST_SymbolBlockDeclaration,
     AST_SymbolCatch,
@@ -1616,6 +1617,10 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
+    let default_or_exact = default_branch || exact_match;
+    default_branch = null;
+    exact_match = null;
+
     // Prune any empty branches at the end of the switch statement.
     {
         let i = body.length - 1;
@@ -1632,7 +1637,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         // i now points to the index of a branch that contains a body. By incrementing, it's
         // pointing to the first branch that's empty.
         i++;
-        if (!default_branch || body.indexOf(default_branch) >= i) {
+        if (!default_or_exact || body.indexOf(default_or_exact) >= i) {
             // The default behavior is to do nothing. We can take advantage of that to
             // remove all case expressions that are side-effect free that also do
             // nothing, since they'll default to doing nothing. But we can't remove any
@@ -1640,8 +1645,8 @@ def_optimize(AST_Switch, function(self, compressor) {
             // the side-effect to be skipped.
             for (let j = body.length - 1; j >= i; j--) {
                 let branch = body[j];
-                if (branch === default_branch) {
-                    default_branch = null;
+                if (branch === default_or_exact) {
+                    default_or_exact = null;
                     body.pop();
                 } else if (!branch.expression.has_side_effects(compressor)) {
                     body.pop();
@@ -1652,9 +1657,10 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
+
     // Prune side-effect free branches that fall into default.
-    if (default_branch) {
-        let default_index = body.indexOf(default_branch);
+    if (default_or_exact) {
+        let default_index = body.indexOf(default_or_exact);
         let default_body_index = default_index;
         for (; default_body_index < body.length - 1; default_body_index++) {
             if (body[default_body_index].body.length > 0) break;
@@ -1662,7 +1668,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         let side_effect_index = body.length - 1;
         for (; side_effect_index >= 0; side_effect_index--) {
             let branch = body[side_effect_index];
-            if (branch === default_branch) continue;
+            if (branch === default_or_exact) continue;
             if (branch.expression.has_side_effects(compressor)) break;
         }
         if (default_body_index > side_effect_index) {
@@ -1676,7 +1682,7 @@ def_optimize(AST_Switch, function(self, compressor) {
                 after = side_effect_index;
                 body[side_effect_index].body = body[default_body_index].body;
             } else {
-                default_branch.body = body[default_body_index].body;
+                default_or_exact.body = body[default_body_index].body;
             }
 
             body.splice(after + 1, default_body_index - after);
@@ -1685,12 +1691,16 @@ def_optimize(AST_Switch, function(self, compressor) {
     }
 
     // See if we can remove the switch entirely if all cases (the default) fall into the same case body.
-    DEFAULT: if (default_branch) {
+    DEFAULT: if (default_or_exact) {
         let i = body.findIndex(branch => branch.body.length > 0);
         let caseBody;
         if (i === body.length - 1) {
             // There is only one case body. We can extract the body and place it after the switch.
             let branch = body[i];
+            if (has_nested_break(self)) break DEFAULT;
+
+            // This is the last case body, and we've already pruned any breaks, so it's
+            // safe to hoist.
             caseBody = make_node(AST_BlockStatement, branch, {
                 body: branch.body
             });
@@ -1700,7 +1710,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
         let sideEffect = body.find(branch => {
             return (
-                branch !== default_branch
+                branch !== default_or_exact
                 && branch.expression.has_side_effects(compressor)
             );
         });
@@ -1709,18 +1719,19 @@ def_optimize(AST_Switch, function(self, compressor) {
             // 2. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
             return make_node(AST_BlockStatement, self, {
                 body: decl.concat(
-                    make_node(AST_SimpleStatement, self.expression, { body: self.expression }),
-                    sideEffect ? make_node(AST_SimpleStatement, sideEffect.expression, { body: sideEffect.expression }) : [],
+                    statement(self.expression),
+                    default_or_exact.expression ? statement(default_or_exact.expression) : [],
+                    sideEffect ? statement(sideEffect.expression) : [],
                     caseBody || []
                 )
             }).optimize(compressor);
         }
         if (caseBody) {
-            let default_index = body.indexOf(default_branch);
-            body.splice(default_index, 1);
             // Recurse into switch statement one more time so that we can append the case body
             // outside of the switch. This recursion will only happen once since we've pruned
             // the default case.
+            const default_index = body.indexOf(default_or_exact);
+            body.splice(default_index, 1);
             return make_node(AST_BlockStatement, self, {
                 body: decl.concat(self, caseBody)
             }).optimize(compressor);
@@ -1735,52 +1746,39 @@ def_optimize(AST_Switch, function(self, compressor) {
 
     if (body.length == 0) {
         return make_node(AST_BlockStatement, self, {
-            body: decl.concat(make_node(AST_SimpleStatement, self.expression, {
-                body: self.expression
-            }))
+            body: decl.concat(statement(self.expression))
         }).optimize(compressor);
     }
-    if (body.length == 1) {
-        var has_break = false;
-        var tw = new TreeWalker(function(node) {
-            if (has_break
-                || node instanceof AST_Lambda
-                || node instanceof AST_SimpleStatement) return true;
-            if (node instanceof AST_Break && tw.loopcontrol_target(node) === self)
-                has_break = true;
-        });
-        self.walk(tw);
-        if (!has_break) {
-            let branch = body[0];
-            if (branch === exact_match || branch === default_branch) {
-                let statements = [make_node(AST_SimpleStatement, self.expression, {
-                    body: self.expression
-                })];
-                if (branch.expression) {
-                    statements.push(make_node(AST_SimpleStatement, branch.expression, {
-                        body: branch.expression
-                    }));
-                }
-                return make_node(AST_BlockStatement, branch, {
-                    body: statements.concat(branch.body)
-                }).optimize(compressor);
-            } else {
-                return make_node(AST_If, self, {
-                    condition: make_node(AST_Binary, self, {
-                        operator: "===",
-                        left: self.expression,
-                        right: branch.expression,
-                    }),
-                    body: make_node(AST_BlockStatement, branch, {
-                        body: branch.body
-                    }),
-                    alternative: null
-                }).optimize(compressor);
+    if (body.length == 1 && !has_nested_break(self)) {
+        // This is the last case body, and we've already pruned any breaks, so it's
+        // safe to hoist.
+        let branch = body[0];
+        if (branch === default_or_exact) {
+            let statements = [statement(self.expression)];
+            if (branch.expression) {
+                statements.push(statement(branch.expression));
             }
+            return make_node(AST_BlockStatement, branch, {
+                body: statements.concat(branch.body)
+            }).optimize(compressor);
+        } else {
+            return make_node(AST_If, self, {
+                condition: make_node(AST_Binary, self, {
+                    operator: "===",
+                    left: self.expression,
+                    right: branch.expression,
+                }),
+                body: make_node(AST_BlockStatement, branch, {
+                    body: branch.body
+                }),
+                alternative: null
+            }).optimize(compressor);
         }
     }
-    if (body.length === 2 && default_branch) {
-        let branch = body[0] === default_branch ? body[1] : body[0];
+    if (body.length === 2 && default_or_exact && !has_nested_break(self)) {
+        let branch = body[0] === default_or_exact ? body[1] : body[0];
+        let exact_exp = default_or_exact.expression && statement(default_or_exact.expression);
+        // Only the first branch body could have a break (at the last statement)
         if (aborts(body[0])) {
             body[0].body.pop();
             return make_node(AST_If, self, {
@@ -1792,18 +1790,29 @@ def_optimize(AST_Switch, function(self, compressor) {
                 body: make_node(AST_BlockStatement, branch, {
                     body: branch.body
                 }),
-                alternative: make_node(AST_BlockStatement, default_branch, {
-                    body: default_branch.body
+                alternative: make_node(AST_BlockStatement, default_or_exact, {
+                    body: [].concat(
+                        exact_exp || [],
+                        default_or_exact.body
+                    )
                 })
             }).optimize(compressor);
         }
         let operator = "===";
-        let consequent = branch;
-        let always = default_branch;
-        if (body[0] === default_branch) {
+        let consequent = make_node(AST_BlockStatement, branch, {
+            body: branch.body,
+        });
+        let always = make_node(AST_BlockStatement, default_or_exact, {
+            body: [].concat(
+                exact_exp || [],
+                default_or_exact.body
+            )
+        });
+        if (body[0] === default_or_exact) {
             operator = "!==";
-            consequent = default_branch;
-            always = branch;
+            let tmp = always;
+            always = consequent;
+            consequent = tmp;
         }
         return make_node(AST_BlockStatement, self, {
             body: [
@@ -1813,14 +1822,11 @@ def_optimize(AST_Switch, function(self, compressor) {
                         left: self.expression,
                         right: branch.expression,
                     }),
-                    body: make_node(AST_BlockStatement, consequent, {
-                        body: consequent.body,
-                    }),
+                    body: consequent,
                     alternative: null
                 })
-            ].concat(always.body)
+            ].concat(always)
         }).optimize(compressor);
-
     }
     return self;
 
@@ -1841,6 +1847,31 @@ def_optimize(AST_Switch, function(self, compressor) {
         let bblock = make_node(AST_BlockStatement, branch, { body: bbody });
         let pblock = make_node(AST_BlockStatement, prev, { body: pbody });
         return bblock.equivalent_to(pblock);
+    }
+    function statement(expression) {
+        return make_node(AST_SimpleStatement, expression, {
+            body: expression
+        });
+    }
+    function has_nested_break(root) {
+        let has_break = false;
+        let tw = new TreeWalker(node => {
+            if (has_break) return true;
+            if (node instanceof AST_Lambda) return true;
+            if (node instanceof AST_SimpleStatement) return true;
+            if (!(node instanceof AST_Break)) return;
+            if (tw.loopcontrol_target(node) !== self) return;
+            let parent = tw.parent();
+            if (
+                parent instanceof AST_SwitchBranch
+                && parent.body[parent.body.length - 1] === node
+            ) {
+                return;
+            }
+            has_break = true;
+        });
+        root.walk(tw);
+        return has_break;
     }
 });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1634,19 +1634,20 @@ def_optimize(AST_Switch, function(self, compressor) {
         if (i < body.length && (!default_branch || body.indexOf(default_branch, i) >= i)) {
             // The default behavior is to do nothing. We can take advantage of that to
             // remove all case expressions that are side-effect free that also do
-            // nothing, since they'll default to doing nothing.
-            let pointer = i;
-            for (let j = pointer; j < body.length; j++) {
+            // nothing, since they'll default to doing nothing. But we can't remove any
+            // case expressions before one that would side-effect, since they may cause
+            // the side-effect to be skipped.
+            for (let j = body.length - 1; j >= i; j--) {
                 let branch = body[j];
                 if (branch === default_branch) {
                     default_branch = null;
-                    continue;
+                    body.pop();
+                } else if (!branch.expression.has_side_effects(compressor)) {
+                    body.pop();
+                } else {
+                    break;
                 }
-                if (!branch.expression.has_side_effects(compressor)) continue;
-                // preserve branches that contain a side-effect
-                body[pointer++] = branch;
             }
-            body.length = pointer;
         }
     }
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1770,27 +1770,17 @@ def_optimize(AST_Switch, function(self, compressor) {
         // This is the last case body, and we've already pruned any breaks, so it's
         // safe to hoist.
         let branch = body[0];
-        if (branch === default_or_exact) {
-            let statements = [statement(self.expression)];
-            if (branch.expression) {
-                statements.push(statement(branch.expression));
-            }
-            return make_node(AST_BlockStatement, branch, {
-                body: statements.concat(branch.body)
-            }).optimize(compressor);
-        } else {
-            return make_node(AST_If, self, {
-                condition: make_node(AST_Binary, self, {
-                    operator: "===",
-                    left: self.expression,
-                    right: branch.expression,
-                }),
-                body: make_node(AST_BlockStatement, branch, {
-                    body: branch.body
-                }),
-                alternative: null
-            }).optimize(compressor);
-        }
+        return make_node(AST_If, self, {
+            condition: make_node(AST_Binary, self, {
+                operator: "===",
+                left: self.expression,
+                right: branch.expression,
+            }),
+            body: make_node(AST_BlockStatement, branch, {
+                body: branch.body
+            }),
+            alternative: null
+        }).optimize(compressor);
     }
     if (body.length === 2 && default_or_exact && !has_nested_break(self)) {
         let branch = body[0] === default_or_exact ? body[1] : body[0];
@@ -1892,7 +1882,6 @@ def_optimize(AST_Switch, function(self, compressor) {
         root.walk(tw);
         return has_break;
     }
-
     function is_break(node, stack) {
         return node instanceof AST_Break
             && stack.loopcontrol_target(node) === self;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -53,7 +53,6 @@ import {
     AST_Boolean,
     AST_Break,
     AST_Call,
-    AST_Case,
     AST_Catch,
     AST_Chain,
     AST_Class,
@@ -1616,7 +1615,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
-    // If all cases fall through into the final, and a default is present anywhere,
+    // If all cases fall through into the final branch, and a default is present anywhere,
     // we can collapse all branches.
     if (default_branch) {
         let i = 0;
@@ -1650,13 +1649,40 @@ def_optimize(AST_Switch, function(self, compressor) {
         body[0].body = decl.concat(body[0].body);
     }
     self.body = body;
-    while (branch = body[body.length - 1]) {
-        var stat = branch.body[branch.body.length - 1];
-        if (stat instanceof AST_Break && compressor.loopcontrol_target(stat) === self)
-            branch.body.pop();
-        if (branch.body.length || branch instanceof AST_Case
-            && (default_branch || branch.expression.has_side_effects(compressor))) break;
-        if (body.pop() === default_branch) default_branch = null;
+
+    // Try to prune any empty branches at the end of the switch statement.
+    {
+        let i = body.length - 1;
+        for (; i >= 0; i--) {
+            let bbody = body[i].body;
+            if (bbody.length > 0) {
+                let stat = bbody[bbody.length - 1];
+                if (stat instanceof AST_Break && compressor.loopcontrol_target(stat) === self) {
+                    bbody.pop();
+                }
+            }
+            if (bbody.length > 0) break;
+        }
+        // i now points to the index of a branch that contains a body. By incrementing, it's
+        // pointing to the first branch that's empty.
+        i++;
+        if (i < body.length && (!default_branch || body.indexOf(default_branch, i) >= i)) {
+            // The default behavior is to do nothing. We can take advantage of that to
+            // remove all case expressions that are side-effect free that also do
+            // nothing, since they'll default to doing nothing.
+            let pointer = i;
+            for (let j = pointer; j < body.length; j++) {
+                let branch = body[j];
+                if (branch === default_branch) {
+                    default_branch = null;
+                    continue;
+                }
+                if (!branch.expression.has_side_effects(compressor)) continue;
+                // preserve branches that contain a side-effect
+                body[pointer++] = branch;
+            }
+            body.length = pointer;
+        }
     }
     if (body.length == 0) {
         return make_node(AST_BlockStatement, self, {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1626,12 +1626,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         let i = body.length - 1;
         for (; i >= 0; i--) {
             let bbody = body[i].body;
-            if (bbody.length > 0) {
-                let stat = bbody[bbody.length - 1];
-                if (stat instanceof AST_Break && compressor.loopcontrol_target(stat) === self) {
-                    bbody.pop();
-                }
-            }
+            if (is_break(bbody[bbody.length - 1], compressor)) bbody.pop();
             if (bbody.length > 0) break;
         }
         // i now points to the index of a branch that contains a body. By incrementing, it's
@@ -1778,9 +1773,12 @@ def_optimize(AST_Switch, function(self, compressor) {
     if (body.length === 2 && default_or_exact && !has_nested_break(self)) {
         let branch = body[0] === default_or_exact ? body[1] : body[0];
         let exact_exp = default_or_exact.expression && statement(default_or_exact.expression);
-        // Only the first branch body could have a break (at the last statement)
         if (aborts(body[0])) {
-            body[0].body.pop();
+            // Only the first branch body could have a break (at the last statement)
+            let first = body[0];
+            if (is_break(first.body[first.body.length - 1], compressor)) {
+                first.body.pop();
+            }
             return make_node(AST_If, self, {
                 condition: make_node(AST_Binary, self, {
                     operator: "===",
@@ -1859,8 +1857,7 @@ def_optimize(AST_Switch, function(self, compressor) {
             if (has_break) return true;
             if (node instanceof AST_Lambda) return true;
             if (node instanceof AST_SimpleStatement) return true;
-            if (!(node instanceof AST_Break)) return;
-            if (tw.loopcontrol_target(node) !== self) return;
+            if (!is_break(node, tw)) return;
             let parent = tw.parent();
             if (
                 parent instanceof AST_SwitchBranch
@@ -1872,6 +1869,11 @@ def_optimize(AST_Switch, function(self, compressor) {
         });
         root.walk(tw);
         return has_break;
+    }
+
+    function is_break(node, stack) {
+        return node instanceof AST_Break
+            && stack.loopcontrol_target(node) === self;
     }
 });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1708,30 +1708,30 @@ def_optimize(AST_Switch, function(self, compressor) {
         } else if (i !== -1) {
             break DEFAULT;
         }
+
         let sideEffect = body.find(branch => {
             return (
                 branch !== default_or_exact
                 && branch.expression.has_side_effects(compressor)
             );
         });
-        if (!sideEffect || sideEffect === body[body.length - 1]) {
-            // 1. i === body.length - 1, the last branch has a side-effect/non-empty, but that can be collapsed.
-            // 2. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
+        if (!sideEffect) {
             return make_node(AST_BlockStatement, self, {
                 body: decl.concat(
                     statement(self.expression),
                     default_or_exact.expression ? statement(default_or_exact.expression) : [],
-                    sideEffect ? statement(sideEffect.expression) : [],
                     caseBody || []
                 )
             }).optimize(compressor);
         }
+
+        const default_index = body.indexOf(default_or_exact);
+        body.splice(default_index, 1);
+        default_or_exact = null;
         if (caseBody) {
             // Recurse into switch statement one more time so that we can append the case body
             // outside of the switch. This recursion will only happen once since we've pruned
             // the default case.
-            const default_index = body.indexOf(default_or_exact);
-            body.splice(default_index, 1);
             return make_node(AST_BlockStatement, self, {
                 body: decl.concat(self, caseBody)
             }).optimize(compressor);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1627,7 +1627,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         for (; i >= 0; i--) {
             let bbody = body[i].body;
             if (is_break(bbody[bbody.length - 1], compressor)) bbody.pop();
-            if (bbody.length > 0) break;
+            if (!is_inert_body(body[i])) break;
         }
         // i now points to the index of a branch that contains a body. By incrementing, it's
         // pointing to the first branch that's empty.
@@ -1658,7 +1658,7 @@ def_optimize(AST_Switch, function(self, compressor) {
         let default_index = body.indexOf(default_or_exact);
         let default_body_index = default_index;
         for (; default_body_index < body.length - 1; default_body_index++) {
-            if (body[default_body_index].body.length > 0) break;
+            if (!is_inert_body(body[default_body_index])) break;
         }
         let side_effect_index = body.length - 1;
         for (; side_effect_index >= 0; side_effect_index--) {
@@ -1666,31 +1666,46 @@ def_optimize(AST_Switch, function(self, compressor) {
             if (branch === default_or_exact) continue;
             if (branch.expression.has_side_effects(compressor)) break;
         }
+        // If the default behavior comes after any side-effect case expressions,
+        // then we can fold all side-effect free cases into the default branch.
+        // If the side-effect case is after the default, then any side-effect
+        // free cases could prevent the side-effect from occurring.
         if (default_body_index > side_effect_index) {
             let prev_body_index = default_index - 1;
             for (; prev_body_index >= 0; prev_body_index--) {
-                if (body[prev_body_index].body.length > 0) break;
+                if (!is_inert_body(body[prev_body_index])) break;
             }
             let before = Math.max(side_effect_index, prev_body_index) + 1;
             let after = default_index;
             if (side_effect_index > default_index) {
+                // If the default falls into the same body as a side-effect
+                // case, then we need preserve that case and only prune the
+                // cases after it.
                 after = side_effect_index;
                 body[side_effect_index].body = body[default_body_index].body;
             } else {
+                // The default will be the last branch.
                 default_or_exact.body = body[default_body_index].body;
             }
 
+            // Prune everything after the default (or last side-effect case)
+            // until the next case with a body.
             body.splice(after + 1, default_body_index - after);
+            // Prune everything before the default that falls into it.
             body.splice(before, default_index - before);
         }
     }
 
     // See if we can remove the switch entirely if all cases (the default) fall into the same case body.
     DEFAULT: if (default_or_exact) {
-        let i = body.findIndex(branch => branch.body.length > 0);
+        let i = body.findIndex(branch => !is_inert_body(branch));
         let caseBody;
+        // `i` is equal to one of the following:
+        // - `-1`, there is no body in the switch statement.
+        // - `body.length - 1`, all cases fall into the same body.
+        // - anything else, there are multiple bodies in the switch.
         if (i === body.length - 1) {
-            // There is only one case body. We can extract the body and place it after the switch.
+            // All cases fall into the case body.
             let branch = body[i];
             if (has_nested_break(self)) break DEFAULT;
 
@@ -1701,6 +1716,7 @@ def_optimize(AST_Switch, function(self, compressor) {
             });
             branch.body = [];
         } else if (i !== -1) {
+            // If there are multiple bodies, then we cannot optimize anything.
             break DEFAULT;
         }
 
@@ -1710,6 +1726,7 @@ def_optimize(AST_Switch, function(self, compressor) {
                 && branch.expression.has_side_effects(compressor)
             );
         });
+        // If no cases cause a side-effect, we can eliminate the switch entirely.
         if (!sideEffect) {
             return make_node(AST_BlockStatement, self, {
                 body: decl.concat(
@@ -1720,9 +1737,14 @@ def_optimize(AST_Switch, function(self, compressor) {
             }).optimize(compressor);
         }
 
+        // If we're this far, either there was no body or all cases fell into the same body.
+        // If there was no body, then we don't need a default branch (because the default is
+        // do nothing). If there was a body, we'll extract it to after the switch, so the
+        // switch's new default is to do nothing and we can still prune it.
         const default_index = body.indexOf(default_or_exact);
         body.splice(default_index, 1);
         default_or_exact = null;
+
         if (caseBody) {
             // Recurse into switch statement one more time so that we can append the case body
             // outside of the switch. This recursion will only happen once since we've pruned
@@ -1874,6 +1896,11 @@ def_optimize(AST_Switch, function(self, compressor) {
     function is_break(node, stack) {
         return node instanceof AST_Break
             && stack.loopcontrol_target(node) === self;
+    }
+    function is_inert_body(branch) {
+        return !aborts(branch) && !make_node(AST_BlockStatement, branch, {
+            body: branch.body
+        }).has_side_effects(compressor)
     }
 });
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1592,16 +1592,60 @@ def_optimize(AST_Switch, function(self, compressor) {
                 }
             }
         }
-        if (aborts(branch)) {
-            var prev = body[body.length - 1];
-            if (aborts(prev) && prev.body.length == branch.body.length
-                && make_node(AST_BlockStatement, prev, prev).equivalent_to(make_node(AST_BlockStatement, branch, branch))) {
-                prev.body = [];
-            }
-        }
         body.push(branch);
     }
     while (i < len) eliminate_branch(self.body[i++], body[body.length - 1]);
+
+    for (let i = 0; i < body.length; i++) {
+        let branch = body[i];
+        if (branch.body.length === 0) continue;
+        if (!aborts(branch)) continue;
+
+        for (let j = i + 1; j < body.length; i++, j++) {
+            let next = body[j];
+            if (next.body.length === 0) continue;
+            if (
+                branches_equivalent(next, branch, false)
+                || (j === body.length - 1 && branches_equivalent(next, branch, true))
+            ) {
+                branch.body = [];
+                branch = next;
+                continue;
+            }
+            break;
+        }
+    }
+
+    // If all cases fall through into the final, and a default is present anywhere,
+    // we can collapse all branches.
+    if (default_branch) {
+        let i = 0;
+        for (; i < body.length; i++) {
+            let branch = body[i];
+            if (branch.body.length > 0) break;
+            if (branch === default_branch) continue;
+            // It's actually ok for the last branch's expression to have a side-effect
+            if (branch.expression.has_side_effects(compressor)) break;
+        }
+        // 3 cases:
+        // 1. i < body.length - 1, there's a side-effect/non-empty branch, and nothing to optimize.
+        // 2. i === body.length - 1, the last branch has a side-effect/non-empty, but that can be collapsed.
+        // 3. i === body.length, all branches are empty, and we can pretend only an empty default branch exists.
+        if (i >= body.length - 1) {
+            if (i < body.length) {
+                let last = body[i];
+                if (last !== default_branch) {
+                    default_branch.body =  make_node(AST_BlockStatement, last, {
+                        body: [
+                            make_node(AST_SimpleStatement, last.expression, { body: last.expression })
+                        ].concat(last.body),
+                    }).optimize(compressor);
+                }
+            }
+            body = [default_branch];
+        }
+    }
+
     if (body.length > 0) {
         body[0].body = decl.concat(body[0].body);
     }
@@ -1653,6 +1697,17 @@ def_optimize(AST_Switch, function(self, compressor) {
         } else {
             trim_unreachable_code(compressor, branch, decl);
         }
+    }
+    function branches_equivalent(branch, prev, insertBreak) {
+        let bbody = branch.body;
+        let pbody = prev.body;
+        if (insertBreak) {
+            bbody = bbody.concat(make_node(AST_Break));
+        }
+        if (bbody.length !== pbody.length) return false;
+        let bblock = make_node(AST_BlockStatement, branch, { body: bbody });
+        let pblock = make_node(AST_BlockStatement, prev, { body: pbody });
+        return bblock.equivalent_to(pblock);
     }
 });
 

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -1328,9 +1328,7 @@ issue_2620_4: {
     expect: {
         var c = "FAIL";
         !function() {
-            switch (NaN) {
-              case void (c = "PASS"):
-            }
+            if (NaN === void (c = "PASS"));
         }();
         console.log(c);
     }

--- a/test/compress/issue-1750.js
+++ b/test/compress/issue-1750.js
@@ -16,10 +16,7 @@ case_1: {
     }
     expect: {
         var a = 0, b = 1;
-        switch (true) {
-          case a || true:
-            b = 2;
-        }
+        if (true === (a || true)) b = 2;
         console.log(a, b);
     }
     expect_stdout: "0 2"
@@ -44,10 +41,7 @@ case_2: {
     }
     expect: {
         var a = 0, b = 1;
-        switch (0) {
-          case a:
-            a = 3;
-        }
+        if (0 === a) a = 3;
         console.log(a, b);
     }
     expect_stdout: "3 1"

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1947,13 +1947,8 @@ issue_1670_6: {
     }
     expect: {
         (function(a) {
-            switch (1) {
-              case a = 1:
-                console.log(a);
-                break;
-              default:
-                console.log(2);
-            }
+            if (1 === (a = 1)) console.log(a);
+            else console.log(2);
         })(1);
     }
     expect_stdout: "1"

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -515,6 +515,39 @@ collapse_into_default_7: {
     }
 }
 
+collapse_into_default_8: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        function test(foo) {
+            switch (foo) {
+              case 1:
+                return 1;
+              case 2:
+              default:
+              case 3:
+            }
+        }
+
+        console.log(test(1));
+    }
+    expect: {
+        console.log(function (foo) {
+            switch (foo) {
+              case 1:
+                return 1;
+            }
+        }(1));
+    }
+}
+
 issue_1663: {
     options = {
         dead_code: true,
@@ -582,7 +615,7 @@ keep_case: {
     }
     expect: {
         switch (foo) {
-          case 'bar': baz(); break;
+          case 'bar': baz();
           case moo:
         }
     }
@@ -799,7 +832,6 @@ issue_1679: {
               case b--:
                 0;
                 a--;
-                break;
               case (a++):
             }
         }
@@ -878,8 +910,6 @@ issue_1680_2: {
             break;
           case b:
             var c;
-            break;
-          case a:
           case a--:
         }
         console.log(a, b);

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -266,9 +266,7 @@ drop_default_1: {
         }
     }
     expect: {
-        switch (foo) {
-          case 'bar': baz();
-        }
+        if ("bar" === foo) baz();
     }
 }
 
@@ -285,9 +283,7 @@ drop_default_2: {
         }
     }
     expect: {
-        switch (foo) {
-          case 'bar': baz();
-        }
+        if ("bar" === foo) baz();
     }
 }
 
@@ -305,11 +301,8 @@ keep_default: {
         }
     }
     expect: {
-        switch (foo) {
-          case 'bar': baz();
-          default:
-            something();
-        }
+        if ('bar' === foo) baz();
+        something();
     }
 }
 
@@ -540,10 +533,7 @@ collapse_into_default_8: {
     }
     expect: {
         console.log(function (foo) {
-            switch (foo) {
-              case 1:
-                return 1;
-            }
+            if (1 === foo) return 1;
         }(1));
     }
 }
@@ -595,8 +585,29 @@ drop_case: {
         }
     }
     expect: {
+        if ('bar' === foo) baz();
+    }
+}
+
+drop_case_2: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
         switch (foo) {
-          case 'bar': baz();
+          case 'bar': bar(); break;
+          case 'moo':
+          case moo:
+          case 'baz':
+            break;
+        }
+    }
+    expect: {
+        switch (foo) {
+          case 'bar': bar();
+          case 'moo':
+          case moo:
         }
     }
 }
@@ -621,6 +632,84 @@ keep_case: {
     }
 }
 
+if_else: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          case 'bar':
+            bar();
+            break;
+          default:
+            other();
+        }
+    }
+    expect: {
+        if ('bar' === foo) bar();
+        else other();
+    }
+}
+
+if_else2: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          case 'bar':
+            bar();
+          default:
+            other();
+        }
+    }
+    expect: {
+        if ('bar' === foo) bar();
+        other();
+    }
+}
+
+if_else3: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          default:
+            other();
+            break;
+          case 'bar':
+            bar();
+        }
+    }
+    expect: {
+        if ('bar' === foo) bar();
+        else other();
+    }
+}
+
+if_else4: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          default:
+            other();
+          case 'bar':
+            bar();
+        }
+    }
+    expect: {
+        if ('bar' !== foo) other();
+        bar();
+    }
+}
+
 issue_376: {
     options = {
         dead_code: true,
@@ -638,10 +727,7 @@ issue_376: {
         }
     }
     expect: {
-        switch (true) {
-          case boolCondition:
-            console.log(1);
-        }
+        if (true === boolCondition) console.log(1);
     }
 }
 
@@ -801,6 +887,8 @@ issue_1679: {
         dead_code: true,
         evaluate: true,
         switches: true,
+        conditionals: true,
+        side_effects: true,
     }
     input: {
         var a = 100, b = 10;
@@ -830,7 +918,6 @@ issue_1679: {
               case !function x() {}:
                 break;
               case b--:
-                0;
                 a--;
               case (a++):
             }
@@ -838,7 +925,7 @@ issue_1679: {
         f();
         console.log(a, b);
     }
-    expect_stdout: true
+    expect_stdout: ["99 8"]
 }
 
 issue_1680_1: {
@@ -910,6 +997,7 @@ issue_1680_2: {
             break;
           case b:
             var c;
+          case a:
           case a--:
         }
         console.log(a, b);
@@ -998,11 +1086,7 @@ issue_1705_1: {
     }
     expect: {
         var a = 0;
-        switch (a) {
-          default:
-            console.log("FAIL");
-          case 0:
-        }
+        if (0 !== a) console.log("FAIL");
     }
     expect_stdout: true
 }

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -306,7 +306,7 @@ keep_default: {
     }
 }
 
-collapse_into_default: {
+remove_switch_1: {
     options = {
         dead_code: true,
         switches: true,
@@ -336,7 +336,7 @@ collapse_into_default: {
     }
 }
 
-collapse_into_default_2: {
+remove_switch_2: {
     options = {
         dead_code: true,
         switches: true,
@@ -362,7 +362,7 @@ collapse_into_default_2: {
     }
 }
 
-collapse_into_default_3: {
+remove_switch_3: {
     options = {
         dead_code: true,
         switches: true,
@@ -388,7 +388,7 @@ collapse_into_default_3: {
     }
 }
 
-collapse_into_default_4: {
+remove_switch_4: {
     options = {
         dead_code: true,
         switches: true,
@@ -417,7 +417,7 @@ collapse_into_default_4: {
     }
 }
 
-collapse_into_default_5: {
+remove_switch_5: {
     options = {
         dead_code: true,
         switches: true,
@@ -447,7 +447,7 @@ collapse_into_default_5: {
     }
 }
 
-collapse_into_default_6: {
+remove_switch_6: {
     options = {
         dead_code: true,
         switches: true,
@@ -475,7 +475,7 @@ collapse_into_default_6: {
     }
 }
 
-collapse_into_default_7: {
+remove_switch_7: {
     options = {
         dead_code: true,
         switches: true,
@@ -501,14 +501,13 @@ collapse_into_default_7: {
     expect: {
         switch (foo) {
           case bar:
-          default:
           case qux:
-            doSomething();
         }
+        doSomething();
     }
 }
 
-collapse_into_default_8: {
+remove_switch_8: {
     options = {
         dead_code: true,
         switches: true,
@@ -535,6 +534,927 @@ collapse_into_default_8: {
         console.log(function (foo) {
             if (1 === foo) return 1;
         }(1));
+    }
+}
+
+remove_switch_9: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            doSomethting();
+            break;
+          case 2:
+          default:
+            break;
+          case 3:
+        }
+    }
+    expect: {
+        if (1 === foo) doSomethting();
+    }
+}
+
+remove_switch_10: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case 0:
+            var x = 1;
+          case bar():
+          default:
+          case bar():
+          case 1:
+            console.log(x);
+        }
+        function bar() {}
+    }
+    expect: {
+        var x;
+        switch (1) {
+          case bar():
+          case bar():
+        }
+        console.log(x);
+        function bar() {}
+    }
+    expect_stdout: ["undefined"]
+}
+
+remove_switch_11: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case 0:
+            var x = 1;
+          case 1:
+            console.log(x);
+        }
+    }
+    expect: {
+        var x;
+        console.log(x);
+    }
+    expect_stdout: ["undefined"]
+}
+
+remove_switch_12: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case 0:
+            var x = 1;
+          case foo():
+            console.log('foo');
+          case 1:
+            console.log(x);
+        }
+        function foo() {}
+    }
+    expect: {
+        if (1 === foo()) {
+            var x;
+            console.log('foo');
+        }
+        console.log(x);
+        function foo() {}
+    }
+    expect_stdout: ["undefined"]
+}
+
+remove_switch_13: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case 0:
+            var x = 1;
+          case foo():
+            console.log('foo');
+            break;
+          case 1:
+            console.log(x);
+        }
+        function foo() {}
+    }
+    expect: {
+        if (1 === foo()) {
+            var x;
+            console.log('foo');
+        } else console.log(x);
+        function foo() {}
+    }
+    expect_stdout: ["undefined"]
+}
+
+collapse_into_default_1: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 'bar':
+            bar();
+          case 'baz':
+            baz();
+          case 'qux':
+          default:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case 'bar':
+            bar();
+          case 'baz':
+            baz();
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_2: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 'bar':
+            bar();
+          case 'baz':
+            baz();
+          default:
+          case 'qux':
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case 'bar':
+            bar();
+          case 'baz':
+            baz();
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_3: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          default:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_4: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case qux:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case qux:
+            other();
+        }
+    }
+}
+
+collapse_into_default_5: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case 'qux':
+          case qux:
+          default:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case 'qux':
+          case qux:
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_6: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          case 'qux':
+          default:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_7: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case 'qux':
+          case qux:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case 'qux':
+          case qux:
+            other();
+        }
+    }
+}
+
+collapse_into_default_8: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case qux:
+          case 'qux':
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          default:
+          case qux:
+            other();
+        }
+    }
+}
+
+collapse_into_default_9: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case 'qux':
+          default:
+          case qux:
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case 'qux':
+          default:
+          case qux:
+            other();
+        }
+    }
+}
+
+collapse_into_default_10: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          default:
+          case 'qux':
+            other();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case baz:
+            baz();
+          case qux:
+          default:
+            other();
+        }
+    }
+}
+
+collapse_into_default_11: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          case qux:
+          default:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          case qux:
+          default:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_12: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          case 'qux':
+          default:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          default:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_13: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case 'qux':
+          case qux:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case 'qux':
+          case qux:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_14: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case qux:
+          case 'qux':
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case qux:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_15: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          default:
+          case qux:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          default:
+          case qux:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_16: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          default:
+          case 'qux':
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          default:
+            other();
+          case 'baz':
+            baz();
+        }
+    }
+}
+
+collapse_into_default_17: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          case qux:
+          default:
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          case qux:
+          default:
+            other();
+          case baz:
+            baz();
+        }
+    }
+}
+
+collapse_into_default_18: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          case 'qux':
+          default:
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          case 'qux':
+          default:
+            other();
+          case baz:
+            baz();
+        }
+    }
+}
+
+collapse_into_default_19: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case 'qux':
+          case qux:
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case 'qux':
+          case qux:
+            other();
+          case baz:
+            baz();
+        }
+    }
+}
+
+collapse_into_default_20: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case qux:
+          case 'qux':
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          default:
+          case qux:
+          case 'qux':
+            other();
+          case baz:
+            baz();
+        }
+    }
+}
+
+collapse_into_default_21: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          default:
+          case qux:
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case 'qux':
+          default:
+          case qux:
+            other();
+          case baz:
+            baz();
+        }
+    }
+}
+
+collapse_into_default_22: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          default:
+          case 'qux':
+            other();
+          case baz:
+            baz();
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+            bar();
+          case qux:
+          default:
+          case 'qux':
+            other();
+          case baz:
+            baz();
+        }
     }
 }
 
@@ -710,6 +1630,71 @@ if_else4: {
     }
 }
 
+if_else5: {
+    options = {
+        dead_code: true,
+        switches: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case bar:
+            bar();
+            break;
+          case 1:
+            other();
+        }
+    }
+    expect: {
+      if (1 === bar) bar();
+      else {
+          1;
+          other();
+      }
+    }
+}
+
+if_else6: {
+    options = {
+        dead_code: true,
+        switches: true,
+        evaluate: true,
+    }
+    input: {
+        switch (1) {
+          case bar:
+            bar();
+          case 1:
+            other();
+        }
+    }
+    expect: {
+        if (1 === bar) bar();
+        1;
+        other();
+    }
+}
+
+if_else7: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          case 'bar':
+            break;
+            bar();
+          default:
+            other();
+        }
+    }
+    expect: {
+        if ('bar' === foo);
+        else other();
+    }
+}
+
 issue_376: {
     options = {
         dead_code: true,
@@ -753,9 +1738,8 @@ issue_441_1: {
         switch (foo) {
           case bar:
           case baz:
-          default:
-            qux();
         }
+        qux();
     }
 }
 
@@ -783,9 +1767,8 @@ issue_441_2: {
           case bar:
           case fall:
           case baz:
-          default:
-            qux();
         }
+        qux();
     }
 }
 

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2121,7 +2121,6 @@ issue_1680_2: {
         var a = 100, b = 10;
         switch (b) {
           case a--:
-            break;
           case b:
             var c;
           case a:
@@ -2129,7 +2128,7 @@ issue_1680_2: {
         }
         console.log(a, b);
     }
-    expect_stdout: true
+    expect_stdout: ["99 10"]
 }
 
 issue_1690_1: {
@@ -2404,17 +2403,17 @@ collapse_same_branches: {
             case 1:
                 console.log("PASS");
                 break
-            
-            case 2: 
+
+            case 2:
                 console.log("PASS");
                 break
-            
+
         }
     }
     expect: {
         switch (id(1)) {
             case 1:
-            case 2: 
+            case 2:
                 console.log("PASS");
         }
     }
@@ -2431,8 +2430,8 @@ collapse_same_branches_2: {
         switch (id(1)) {
             case 1:
                 console.log("PASS");
-            
-            case 2: 
+
+            case 2:
                 console.log("PASS");
         }
     }
@@ -2440,8 +2439,8 @@ collapse_same_branches_2: {
         switch (id(1)) {
             case 1:
                 console.log("PASS");
-            
-            case 2: 
+
+            case 2:
                 console.log("PASS");
         }
     }
@@ -2462,7 +2461,7 @@ trim_empty_last_branches: {
                 // break should be removed too
                 break
             case 3: {}
-            case 4: 
+            case 4:
         }
     }
     expect: {
@@ -2485,7 +2484,7 @@ trim_empty_last_branches_2: {
                 case 2:
                     break somewhere_else
                 case 3: {}
-                case 4: 
+                case 4:
             }
         }
     }
@@ -2497,6 +2496,25 @@ trim_empty_last_branches_2: {
                 case 2:
                     break somewhere_else
             }
+    }
+    expect_stdout: "PASS"
+}
+
+trim_empty_last_branches_3: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS")
+            case 2:
+                "no side effect"
+        }
+    }
+    expect: {
+        if (1 === id(1)) console.log("PASS")
     }
     expect_stdout: "PASS"
 }
@@ -2525,6 +2543,29 @@ trim_side_effect_free_branches_falling_into_default: {
     }
 }
 
+trim_side_effect_free_branches_falling_into_default_2: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            default:
+            case 0:
+                "no side effect"
+            case 1:
+                console.log("PASS default")
+            case 2:
+                console.log("PASS 2")
+        }
+    }
+    expect: {
+        if (2 !== id(1))
+            console.log("PASS default");
+        console.log("PASS 2")
+    }
+}
+
 gut_entire_switch: {
     options = {
         switches: true,
@@ -2535,6 +2576,27 @@ gut_entire_switch: {
             case 1:
             case 2:
             case 3:
+            default:
+                console.log("PASS");
+        }
+    }
+    expect: {
+        id(123); console.log("PASS");
+    }
+    expect_stdout: "PASS"
+}
+
+gut_entire_switch_2: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(123)) {
+            case 1:
+                "no side effect"
+            case 1:
+                // Not here either
             default:
                 console.log("PASS");
         }

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -1814,6 +1814,31 @@ if_else7: {
     }
 }
 
+if_else8: {
+    options = {
+        defaults: true,
+    }
+    input: {
+        function test(foo) {
+            switch (foo) {
+            case 'bar':
+                return 'PASS';
+            default:
+                return 'FAIL';
+            }
+        }
+        console.log(test('bar'));
+    }
+    expect: {
+        function test(foo) {
+            return 'bar' === foo ? 'PASS' : 'FAIL';
+
+        }
+        console.log(test('bar'));
+    }
+    expect_stdout: ["PASS"]
+}
+
 issue_376: {
     options = {
         dead_code: true,

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -682,6 +682,125 @@ remove_switch_13: {
     expect_stdout: ["undefined"]
 }
 
+remove_switch_14: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              case 1:
+              default:
+              case x--:
+                console.log(x);
+            }
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              case 1:
+              case x--:
+            }
+            console.log(x);
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect_stdout: ["1", "1", "0"]
+}
+
+remove_switch_15: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              default:
+              case x--:
+                console.log(x);
+            }
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              case x--:
+            }
+            console.log(x);
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect_stdout: ["1", "0", "0"]
+}
+
+remove_switch_16: {
+    options = {
+        dead_code: true,
+        switches: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              default:
+              case x--:
+            }
+            console.log(x);
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect: {
+        function test(foo) {
+            var x = 1;
+            switch (foo) {
+              case 0:
+              case x--:
+            }
+            console.log(x);
+        }
+        test(0);
+        test(1);
+        test(2);
+    }
+    expect_stdout: ["1", "0", "0"]
+}
+
 collapse_into_default_1: {
     options = {
         dead_code: true,

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -313,6 +313,208 @@ keep_default: {
     }
 }
 
+collapse_into_default: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            1;
+          case 2:
+            invariant();
+          case 3:
+          default:
+            doSomething();
+        }
+        function invariant() {
+            /* production build */
+        }
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_2: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            doSomething();
+            break;
+          default:
+            doSomething();
+            break;
+        }
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_3: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          default:
+            doSomething();
+            break;
+          case 1:
+            doSomething();
+            break;
+        }
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_4: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            doSomething();
+            break;
+          default:
+            doSomething();
+            break;
+          case 2:
+            doSomething();
+            break;
+        }
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_5: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case "bar":
+            doSomething();
+            break;
+          default:
+            doSomething();
+            break;
+          case "qux":
+            doSomething();
+            break;
+        }
+
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_6: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            doSomething();
+            break;
+          default:
+            doSomething();
+            break;
+          case 2:
+            doSomething();
+        }
+    }
+    expect: {
+        foo;
+        doSomething();
+    }
+}
+
+collapse_into_default_7: {
+    options = {
+        dead_code: true,
+        switches: true,
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+        module: true,
+        evaluate: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            doSomething();
+            break;
+          default:
+            doSomething();
+            break;
+          case qux:
+            doSomething();
+            break;
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+          default:
+          case qux:
+            doSomething();
+        }
+    }
+}
+
 issue_1663: {
     options = {
         dead_code: true,
@@ -446,7 +648,6 @@ issue_441_2: {
     input: {
         switch (foo) {
           case bar:
-            // TODO: Fold into the case below
             qux();
             break;
           case fall:
@@ -461,12 +662,80 @@ issue_441_2: {
     expect: {
         switch (foo) {
           case bar:
-            qux();
-            break;
           case fall:
           case baz:
           default:
             qux();
+        }
+    }
+}
+
+issue_441_3: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          case bar:
+            qux();
+            break;
+          case fall:
+          case baz:
+            qux();
+            break;
+        }
+    }
+    expect: {
+        switch (foo) {
+          case bar:
+          case fall:
+          case baz:
+            qux();
+        }
+    }
+}
+
+issue_441_4: {
+    options = {
+        dead_code: true,
+        switches: true,
+    }
+    input: {
+        switch (foo) {
+          case 1:
+            qux();
+            break;
+          case fall1:
+          case 2:
+            qux();
+            break;
+          case 3:
+            other();
+            break;
+          case 4:
+            qux();
+            break;
+          case fall2:
+          case 5:
+            qux();
+            break;
+        }
+    }
+    expect: {
+        switch (foo) {
+          case 1:
+          case fall1:
+          case 2:
+            qux();
+            break;
+          case 3:
+            other();
+            break;
+          case 4:
+          case fall2:
+          case 5:
+            qux()
         }
     }
 }
@@ -528,10 +797,8 @@ issue_1679: {
               case !function x() {}:
                 break;
               case b--:
-                switch (0) {
-                  default:
-                  case a--:
-                }
+                0;
+                a--;
                 break;
               case (a++):
             }


### PR DESCRIPTION
This implements:

1. Full case folding for equivalent branches
2. Full removal of empty tail branches (even when `default` isn't last branch, as long as `default` falls through to the empty tail)
3. Converts 1-case switches into an If statement
4. Converts 2-case switches into an If-Else statement
5. Folds side-effect free case expressions into default (when there are no side-effect case expressions after them)
6. Full Switch removal when all cases are "default"

The Switch removal is hard to describe, but easy to demonstrate:

```js
switch (expression) {
  case 1:
  case 2:
  case 3:
  default:
    doSomething();
}
```

Because all of the case `expression`s are side-effect free, we can consider just the case bodies. Because all cases fall through to the last branch, we can check to see if this branch is always guaranteed to run due to a `default` branch. If everything is good, we can eliminate the switch statement entirely.

```js
// output
doSomething();
```

I've hit this a few times when programming TypeScript. I tend to write exhaustive type checking, and a times that leads to code like:

```js
switch (type) {
  case "Foo":
  case "Bar":
    if (process.env.NODE_ENV !== 'production') {
      throw new Error('invariant failed!');
    }
  default:
    doSomething(type);
}
```

In production builds, I I strip the invariant checks out for file size (my tests should have caught if it were ever possible to hit those cases). And this used to leave me with large useless switch statements:

```js
switch (type) {
  case "Foo":
  case "Bar":
  default:
    doSomething(type);
}
```

This creates the "all cases are default" behavior, which I'd really like to have minimized.