### PR TITLE
Fix nullish coalescing negation inference

### DIFF
--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -818,9 +818,6 @@ export function is_lhs(node, parent) {
             self.left = self.left.negate(compressor, first_in_statement);
             self.right = self.right.negate(compressor);
             return best(this, self, first_in_statement);
-          case "??":
-            self.right = self.right.negate(compressor);
-            return best(this, self, first_in_statement);
         }
         return basic_negation(this);
     });

--- a/test/compress/issue-1003.js
+++ b/test/compress/issue-1003.js
@@ -1,0 +1,16 @@
+nullish_coalescing_boolean_expr: {
+    options = {
+        booleans: true,
+        ecma: true,
+    }
+    input: {
+        (function(a, b) {
+            if(!(a ?? b)) throw new Error("Some error");
+        })()
+    }
+    expect: {
+        (function(a, b) {
+            if(!(a ?? b)) throw new Error("Some error");
+        })()
+    }
+}

--- a/test/compress/issue-1007.js
+++ b/test/compress/issue-1007.js
@@ -1,0 +1,18 @@
+optional_chaining_boolean_expr: {
+    options = {
+        booleans: true,
+        ecma: true,
+    }
+    input: {
+        (function(option) {
+            if (!(option.container?.tagName === "DIV"))
+                throw new Error("Invalid `container` and/or `viewer` option.");
+        })()
+    }
+    expect: {
+        (function(option) {
+            if ("DIV" !== option.container?.tagName)
+                throw new Error("Invalid `container` and/or `viewer` option.");
+        })()
+    }
+}


### PR DESCRIPTION
This PR does 2 things:

- It removes special casing for nullish coalescing (??) in negation
  - This fixes #1003
- We also made sure optional chaining (?.) is ok
  - This cements #1007 as fixed