### PR TITLE
fix: functions may be compressed mistakenly if passes=2

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2166,6 +2166,9 @@ def_optimize(AST_Call, function(self, compressor) {
     if (can_inline && has_annotation(self, _INLINE)) {
         set_flag(fn, SQUEEZED);
         fn = make_node(fn.CTOR === AST_Defun ? AST_Function : fn.CTOR, fn, fn);
+        if (!exp.definition().single_use) {
+            fn = fn.clone(true);
+        }
         fn.figure_out_scope({}, {
             parent_scope: find_scope(compressor),
             toplevel: compressor.get_toplevel()

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2166,9 +2166,7 @@ def_optimize(AST_Call, function(self, compressor) {
     if (can_inline && has_annotation(self, _INLINE)) {
         set_flag(fn, SQUEEZED);
         fn = make_node(fn.CTOR === AST_Defun ? AST_Function : fn.CTOR, fn, fn);
-        if (!exp.definition().single_use) {
-            fn = fn.clone(true);
-        }
+        fn = fn.clone(true);
         fn.figure_out_scope({}, {
             parent_scope: find_scope(compressor),
             toplevel: compressor.get_toplevel()

--- a/test/compress/inline.js
+++ b/test/compress/inline.js
@@ -459,3 +459,30 @@ do_not_repeat_when_variable_larger_than_inlined_node: {
         pass(s);
     }
 }
+
+inline_using_correct_arguments: {
+    options = {
+        reduce_vars: true,
+        inline: true,
+        passes: 2,
+        toplevel: true,
+        unused: true
+    }
+
+    input: {
+        function run (s, t) {
+            return s.run(t);
+        }
+
+        /*#__INLINE__*/ run(a, "foo");
+        /*#__INLINE__*/ run(a, "bar");
+        /*#__INLINE__*/ run(a, "123");
+    }
+
+    expect: {
+        s = a, t = "foo", s.run(t);
+        var s, t;
+        (function(s, t) { return s.run("bar") })(a);
+        (function(s, t) { return s.run("123") })(a);
+    }
+}


### PR DESCRIPTION
This fixes #1046 . I also added a simple test case to `tests/compress/inline.js` to verify it.