### PR TITLE
Don't mangle computed properties with keep_quoted

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4485,12 +4485,15 @@ function lift_key(self, compressor) {
         if (self.key.value == "constructor"
             && compressor.parent() instanceof AST_Class) return self;
         if (self instanceof AST_ObjectKeyVal) {
+            self.quote = self.key.quote;
             self.key = self.key.value;
         } else if (self instanceof AST_ClassProperty) {
+            self.quote = self.key.quote;
             self.key = make_node(AST_SymbolClassProperty, self.key, {
                 name: self.key.value
             });
         } else {
+            self.quote = self.key.quote;
             self.key = make_node(AST_SymbolMethod, self.key, {
                 name: self.key.value
             });

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -189,7 +189,7 @@ function mangle_properties(ast, options) {
     var unmangleable = new Set();
     var private_properties = new Set();
 
-    var keep_quoted_strict = options.keep_quoted === "strict";
+    var keep_quoted = !!options.keep_quoted;
 
     // step 1: find candidates to mangle
     ast.walk(new TreeWalker(function(node) {
@@ -201,13 +201,12 @@ function mangle_properties(ast, options) {
         } else if (node instanceof AST_DotHash) {
             private_properties.add(node.property);
         } else if (node instanceof AST_ObjectKeyVal) {
-            if (typeof node.key == "string" &&
-                (!keep_quoted_strict || !node.quote)) {
+            if (typeof node.key == "string" && (!keep_quoted || !node.quote)) {
                 add(node.key);
             }
         } else if (node instanceof AST_ObjectProperty) {
             // setter or getter, since KeyVal is handled above
-            if (!keep_quoted_strict || !node.key.end.quote) {
+            if (!keep_quoted || !node.quote) {
                 add(node.key.name);
             }
         } else if (node instanceof AST_Dot) {
@@ -220,11 +219,11 @@ function mangle_properties(ast, options) {
                 declared = !(root.thedef && root.thedef.undeclared);
             }
             if (declared &&
-                (!keep_quoted_strict || !node.quote)) {
+                (!keep_quoted || !node.quote)) {
                 add(node.property);
             }
         } else if (node instanceof AST_Sub) {
-            if (!keep_quoted_strict) {
+            if (!keep_quoted) {
                 addStrings(node.property, add);
             }
         } else if (node instanceof AST_Call
@@ -245,20 +244,19 @@ function mangle_properties(ast, options) {
         } else if (node instanceof AST_DotHash) {
             node.property = mangle_private(node.property);
         } else if (node instanceof AST_ObjectKeyVal) {
-            if (typeof node.key == "string" &&
-                (!keep_quoted_strict || !node.quote)) {
+            if (typeof node.key == "string" && (!keep_quoted || !node.quote)) {
                 node.key = mangle(node.key);
             }
         } else if (node instanceof AST_ObjectProperty) {
             // setter, getter, method or class field
-            if (!keep_quoted_strict || !node.key.end.quote) {
+            if (!keep_quoted || !node.quote) {
                 node.key.name = mangle(node.key.name);
             }
         } else if (node instanceof AST_Dot) {
-            if (!keep_quoted_strict || !node.quote) {
+            if (!keep_quoted || !node.quote) {
                 node.property = mangle(node.property);
             }
-        } else if (!options.keep_quoted && node instanceof AST_Sub) {
+        } else if (!keep_quoted && node instanceof AST_Sub) {
             node.property = mangleStrings(node.property);
         } else if (node instanceof AST_Call
             && node.expression.print_to_string() == "Object.defineProperty") {

--- a/test/compress/mangleprops-computed.js
+++ b/test/compress/mangleprops-computed.js
@@ -1,0 +1,551 @@
+computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}

--- a/test/compress/mangleprops-strict-computed.js
+++ b/test/compress/mangleprops-strict-computed.js
@@ -1,0 +1,551 @@
+computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}

--- a/test/compress/mangleprops-strict.js
+++ b/test/compress/mangleprops-strict.js
@@ -1,0 +1,771 @@
+computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = {
+            '_foo': 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = {
+            '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = {
+            get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = class {
+            static '_foo' = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = class {
+            static '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = class {
+            static get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = new class {
+            '_foo' = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = new class {
+            '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let o = new class {
+            get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let {
+            '_foo': val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_strict_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_strict_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_strict_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_strict_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}

--- a/test/compress/mangleprops-strict.js
+++ b/test/compress/mangleprops-strict.js
@@ -1,9 +1,193 @@
-computed_props_keep_quoted_inlined_sub_1: {
+inline_string_keep_quoted_strict: {
     options = {
         defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let quoted_obj = {
+            '_obj_prop': 'bar',
+            '_obj_method'() {},
+            get '_obj_getter'() {},
+        };
+        let quoted_static_class = class {
+            static '_static_prop' = 'bar';
+            static '_static_method'() {}
+            static get '_static_getter'() {}
+        };
+        let quoted_instance_class = class {
+            '_instance_prop' = 'bar';
+            '_instance_method'() {}
+            get '_instance_getter'() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { '_destructure': quoted_destructure } = global;
+
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
+        };
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
+        };
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
+    }
+    expect: {
+        let quoted_obj = {
+            '_obj_prop': 'bar',
+            '_obj_method'() {},
+            get '_obj_getter'() {},
+        };
+        let quoted_static_class = class {
+            static '_static_prop' = 'bar';
+            static '_static_method'() {}
+            static get '_static_getter'() {}
+        };
+        let quoted_instance_class = class {
+            '_instance_prop' = 'bar';
+            '_instance_method'() {}
+            get '_instance_getter'() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { '_destructure': quoted_destructure } = global;
+
+        let obj = {
+            t: "bar",
+            _() {},
+            get l() {}
+        };
+        let static_class = class {
+            static o = "bar";
+            static i() {}
+            static get g() {}
+        };
+        let instance_class = class {
+            p = "bar";
+            u() {}
+            get j() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { h: destructure } = global;
+    }
+}
+
+computed_inline_string_keep_quoted_strict_no_computed_props: {
+    options = {
+        defaults: false,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: 'strict',
+        },
+    }
+    input: {
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
+        };
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
+        };
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
+
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
+        };
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
+        };
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
+    }
+    expect: {
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
+        };
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
+        };
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
+
+        let obj = {
+            _: "bar",
+            l() {},
+            get o() {}
+        };
+        let static_class = class {
+            static i = 'bar';
+            static g() {}
+            static get p() {}
+        };
+        let instance_class = class {
+            u = 'bar';
+            j() {}
+            get h() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { m: destructure } = global;
+    }
+}
+
+computed_inline_string_keep_quoted_strict_computed_props: {
+    options = {
+        defaults: false,
         computed_props: true,
     }
     mangle = {
@@ -12,760 +196,85 @@ computed_props_keep_quoted_inlined_sub_1: {
         },
     }
     input: {
-        let prop = '_foo';
-        let o = {
-            [prop]: 'bar'
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]() { return 'bar' }
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            get [prop]() { return 'bar' }
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
 
-computed_props_keep_quoted_inlined_sub_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop] = 'bar'
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop]() { return 'bar' }
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static get [prop]() { return 'bar' }
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
         };
-        console.log(o[id('_foo')]);
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
     }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop] = 'bar'
+    expect: {
+        let quoted_obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop]() { return 'bar' }
+        let quoted_static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            get [prop]() { return 'bar' }
+        let quoted_instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { _destructure: quoted_destructure } = global;
 
-computed_props_keep_quoted_inlined_sub_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let {
-            [prop]: val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_1: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]: 'bar'
+        let obj = {
+            t: "bar",
+            _() {},
+            get l() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]() { return 'bar' }
+        let static_class = class {
+            static o = "bar";
+            static i() {}
+            static get g() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            get [prop]() { return 'bar' }
+        let instance_class = class {
+            p = "bar";
+            u() {}
+            get j() {}
         };
-        console.log(o[id('_foo')]);
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { h: destructure } = global;
     }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop] = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static get [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop] = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            get [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let {
-            [prop]: val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_1: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = {
-            '_foo': 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = {
-            '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = {
-            get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = class {
-            static '_foo' = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = class {
-            static '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = class {
-            static get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = new class {
-            '_foo' = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = new class {
-            '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let o = new class {
-            get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let {
-            '_foo': val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_strict_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_strict_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_strict_optional_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o?.[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_strict_optional_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: 'strict',
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o?.[prop]);
-    }
-    expect_stdout: 'bar'
 }

--- a/test/compress/mangleprops.js
+++ b/test/compress/mangleprops.js
@@ -1,0 +1,771 @@
+computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]: 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = class {
+            static get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop] = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let o = new class {
+            get [prop]() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_inlined_sub_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = '_foo';
+        let {
+            [prop]: val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_1: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = {
+            '_foo': 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_2: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = {
+            '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_3: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = {
+            get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_4: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = class {
+            static '_foo' = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_5: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = class {
+            static '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_6: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = class {
+            static get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_7: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = new class {
+            '_foo' = 'bar'
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_8: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = new class {
+            '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]());
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_9: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let o = new class {
+            get '_foo'() { return 'bar' }
+        };
+        console.log(o[id('_foo')]);
+    }
+    expect_stdout: 'bar'
+}
+
+inline_string_keep_quoted_strict_10: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let {
+            '_foo': val
+        } = { [id('_foo')]: 'bar' };
+        console.log(val);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_strict_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_strict_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+no_computed_props_keep_quoted_strict_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}
+
+computed_props_keep_quoted_strict_optional_property_access_sub: {
+    options = {
+        defaults: false,
+        reduce_vars: true,
+        unused: true,
+        toplevel: true,
+        computed_props: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let prop = 'foo_';
+        let o = {
+            [id('foo_')]: 'bar'
+        };
+        console.log(o?.[prop]);
+    }
+    expect_stdout: 'bar'
+}

--- a/test/compress/mangleprops.js
+++ b/test/compress/mangleprops.js
@@ -1,9 +1,193 @@
-computed_props_keep_quoted_inlined_sub_1: {
+inline_string_keep_quoted: {
     options = {
         defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let quoted_obj = {
+            '_obj_prop': 'bar',
+            '_obj_method'() {},
+            get '_obj_getter'() {},
+        };
+        let quoted_static_class = class {
+            static '_static_prop' = 'bar';
+            static '_static_method'() {}
+            static get '_static_getter'() {}
+        };
+        let quoted_instance_class = class {
+            '_instance_prop' = 'bar';
+            '_instance_method'() {}
+            get '_instance_getter'() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { '_destructure': quoted_destructure } = global;
+
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
+        };
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
+        };
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
+    }
+    expect: {
+        let quoted_obj = {
+            '_obj_prop': 'bar',
+            '_obj_method'() {},
+            get '_obj_getter'() {},
+        };
+        let quoted_static_class = class {
+            static '_static_prop' = 'bar';
+            static '_static_method'() {}
+            static get '_static_getter'() {}
+        };
+        let quoted_instance_class = class {
+            '_instance_prop' = 'bar';
+            '_instance_method'() {}
+            get '_instance_getter'() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { '_destructure': quoted_destructure } = global;
+
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
+        };
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
+        };
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
+    }
+}
+
+computed_inline_string_keep_quoted_no_computed_props: {
+    options = {
+        defaults: false,
+        computed_props: false,
+    }
+    mangle = {
+        properties: {
+            keep_quoted: true,
+        },
+    }
+    input: {
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
+        };
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
+        };
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
+
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
+        };
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
+        };
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
+    }
+    expect: {
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
+        };
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
+        };
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
+        };
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
+
+        let obj = {
+            _: "bar",
+            l() {},
+            get o() {}
+        };
+        let static_class = class {
+            static i = 'bar';
+            static g() {}
+            static get p() {}
+        };
+        let instance_class = class {
+            u = 'bar';
+            j() {}
+            get h() {}
+        };
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { m: destructure } = global;
+    }
+}
+
+computed_inline_string_keep_quoted_computed_props: {
+    options = {
+        defaults: false,
         computed_props: true,
     }
     mangle = {
@@ -12,760 +196,85 @@ computed_props_keep_quoted_inlined_sub_1: {
         },
     }
     input: {
-        let prop = '_foo';
-        let o = {
-            [prop]: 'bar'
+        let quoted_obj = {
+            ['_obj_prop']: 'bar',
+            ['_obj_method']() {},
+            get ['_obj_getter']() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]() { return 'bar' }
+        let quoted_static_class = class {
+            static ['_static_prop'] = 'bar';
+            static ['_static_method']() {}
+            static get ['_static_getter']() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            get [prop]() { return 'bar' }
+        let quoted_instance_class = class {
+            ['_instance_prop'] = 'bar';
+            ['_instance_method']() {}
+            get ['_instance_getter']() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { ['_destructure']: quoted_destructure } = global;
 
-computed_props_keep_quoted_inlined_sub_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop] = 'bar'
+        let obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop]() { return 'bar' }
+        let static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static get [prop]() { return 'bar' }
+        let instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
         };
-        console.log(o[id('_foo')]);
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { _destructure: destructure } = global;
     }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop] = 'bar'
+    expect: {
+        let quoted_obj = {
+            _obj_prop: 'bar',
+            _obj_method() {},
+            get _obj_getter() {},
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop]() { return 'bar' }
+        let quoted_static_class = class {
+            static _static_prop = 'bar';
+            static _static_method() {}
+            static get _static_getter() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_inlined_sub_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            get [prop]() { return 'bar' }
+        let quoted_instance_class = class {
+            _instance_prop = 'bar';
+            _instance_method() {}
+            get _instance_getter() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
+        global['_sub'];
+        global?.['_optional_sub'];
+        global?.deep['_deep_optional_sub'];
+        let { _destructure: quoted_destructure } = global;
 
-computed_props_keep_quoted_inlined_sub_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let {
-            [prop]: val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_1: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]: 'bar'
+        let obj = {
+            t: "bar",
+            _() {},
+            get l() {}
         };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            [prop]() { return 'bar' }
+        let static_class = class {
+            static o = "bar";
+            static i() {}
+            static get g() {}
         };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = {
-            get [prop]() { return 'bar' }
+        let instance_class = class {
+            p = "bar";
+            u() {}
+            get j() {}
         };
-        console.log(o[id('_foo')]);
+        global._sub;
+        global?._optional_sub;
+        global?.deep._deep_optional_sub;
+        let { h: destructure } = global;
     }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop] = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = class {
-            static get [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop] = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let o = new class {
-            get [prop]() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_inlined_sub_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = '_foo';
-        let {
-            [prop]: val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_1: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = {
-            '_foo': 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_2: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = {
-            '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_3: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = {
-            get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_4: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = class {
-            static '_foo' = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_5: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = class {
-            static '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_6: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = class {
-            static get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_7: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = new class {
-            '_foo' = 'bar'
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_8: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = new class {
-            '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]());
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_9: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let o = new class {
-            get '_foo'() { return 'bar' }
-        };
-        console.log(o[id('_foo')]);
-    }
-    expect_stdout: 'bar'
-}
-
-inline_string_keep_quoted_strict_10: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let {
-            '_foo': val
-        } = { [id('_foo')]: 'bar' };
-        console.log(val);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_strict_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_strict_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-no_computed_props_keep_quoted_strict_optional_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: false,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o?.[prop]);
-    }
-    expect_stdout: 'bar'
-}
-
-computed_props_keep_quoted_strict_optional_property_access_sub: {
-    options = {
-        defaults: false,
-        reduce_vars: true,
-        unused: true,
-        toplevel: true,
-        computed_props: true,
-    }
-    mangle = {
-        properties: {
-            keep_quoted: true,
-        },
-    }
-    input: {
-        let prop = 'foo_';
-        let o = {
-            [id('foo_')]: 'bar'
-        };
-        console.log(o?.[prop]);
-    }
-    expect_stdout: 'bar'
 }

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -191,14 +191,15 @@ describe("minify", function() {
     });
 
     describe("mangleProperties", function() {
-        it.skip("Shouldn't mangle quoted properties", async function() {
-            var js = 'a["foo"] = "bar"; a.color = "red"; x = {"bar": 10};';
+        it("Shouldn't mangle quoted properties", async function() {
+            var js = 'var a = {}; a["foo"] = "bar"; a.color = "red"; x = {"bar": 10};';
             var result = await minify(js, {
                 compress: {
                     properties: false
                 },
                 mangle: {
                     properties: {
+                        builtins: true,
                         keep_quoted: true
                     }
                 },
@@ -208,9 +209,10 @@ describe("minify", function() {
                 }
             });
             assert.strictEqual(result.code,
-                    'a["foo"]="bar",a.a="red",x={"bar":10};');
+                    'var a={foo:"bar",r:"red"};x={"bar":10};');
         });
-        it.skip("Should not mangle quoted property within dead code", async function() {
+
+        it("Should not mangle quoted property within dead code", async function() {
             var result = await minify('var g = {}; ({ "keep": 1 }); g.keep = g.change;', {
                 mangle: {
                     properties: {


### PR DESCRIPTION
There were various failures when using computed properties with property mangling enabled with `keep_quoted`:

```js
// keep_quoted: true

let prop = '_foo';
let o = {
  [prop]: 'bar'
};
console.log(o[id('_foo')]);

// - - -

let prop = '_foo';
let o = {
  [prop]() { return 'bar' }
};
console.log(o[id('_foo')]());

// - - -

let prop = '_foo';
let o = {
  get [prop]() { return 'bar' }
};
console.log(o[id('_foo')]);
```

```js
// keep_quoted: 'strict'

let prop = '_foo';
let o = {
  [prop]: 'bar'
};
console.log(o[id('_foo')]);
```