### PR TITLE
Fix compress/eval of optional chains

### DIFF
--- a/lib/compress/drop-side-effect-free.js
+++ b/lib/compress/drop-side-effect-free.js
@@ -122,7 +122,7 @@ def_drop_side_effect_free(AST_This, return_null);
 
 def_drop_side_effect_free(AST_Call, function (compressor, first_in_statement) {
     if (is_nullish(this, compressor)) {
-        return make_node(AST_Undefined, this);
+        return this.expression.drop_side_effect_free(compressor, first_in_statement);
     }
 
     if (!this.is_callee_pure(compressor)) {
@@ -298,14 +298,18 @@ def_drop_side_effect_free(AST_Array, function (compressor, first_in_statement) {
 });
 
 def_drop_side_effect_free(AST_Dot, function (compressor, first_in_statement) {
-    if (is_nullish(this, compressor)) return make_node(AST_Undefined, this);
+    if (is_nullish(this, compressor)) {
+        return this.expression.drop_side_effect_free(compressor, first_in_statement);
+    }
     if (this.expression.may_throw_on_access(compressor)) return this;
 
     return this.expression.drop_side_effect_free(compressor, first_in_statement);
 });
 
 def_drop_side_effect_free(AST_Sub, function (compressor, first_in_statement) {
-    if (is_nullish(this, compressor)) return make_node(AST_Undefined, this);
+    if (is_nullish(this, compressor)) {
+        return this.expression.drop_side_effect_free(compressor, first_in_statement);
+    }
     if (this.expression.may_throw_on_access(compressor)) return this;
 
     var expression = this.expression.drop_side_effect_free(compressor, first_in_statement);

--- a/lib/compress/drop-side-effect-free.js
+++ b/lib/compress/drop-side-effect-free.js
@@ -73,13 +73,12 @@ import {
     AST_TemplateString,
     AST_This,
     AST_Unary,
-    AST_Undefined,
 } from "../ast.js";
 import { make_node, return_null, return_this } from "../utils/index.js";
 import { first_in_statement } from "../utils/first_in_statement.js";
 
 import { pure_prop_access_globals } from "./native-objects.js";
-import { lazy_op, unary_side_effects, is_nullish } from "./inference.js";
+import { lazy_op, unary_side_effects, is_nullish_shortcircuited } from "./inference.js";
 import { WRITE_ONLY, set_flag, clear_flag } from "./compressor-flags.js";
 import { make_sequence, is_func_expr, is_iife_call } from "./common.js";
 
@@ -121,7 +120,7 @@ def_drop_side_effect_free(AST_Constant, return_null);
 def_drop_side_effect_free(AST_This, return_null);
 
 def_drop_side_effect_free(AST_Call, function (compressor, first_in_statement) {
-    if (is_nullish(this, compressor)) {
+    if (is_nullish_shortcircuited(this, compressor)) {
         return this.expression.drop_side_effect_free(compressor, first_in_statement);
     }
 
@@ -298,7 +297,7 @@ def_drop_side_effect_free(AST_Array, function (compressor, first_in_statement) {
 });
 
 def_drop_side_effect_free(AST_Dot, function (compressor, first_in_statement) {
-    if (is_nullish(this, compressor)) {
+    if (is_nullish_shortcircuited(this, compressor)) {
         return this.expression.drop_side_effect_free(compressor, first_in_statement);
     }
     if (this.expression.may_throw_on_access(compressor)) return this;
@@ -307,7 +306,7 @@ def_drop_side_effect_free(AST_Dot, function (compressor, first_in_statement) {
 });
 
 def_drop_side_effect_free(AST_Sub, function (compressor, first_in_statement) {
-    if (is_nullish(this, compressor)) {
+    if (is_nullish_shortcircuited(this, compressor)) {
         return this.expression.drop_side_effect_free(compressor, first_in_statement);
     }
     if (this.expression.may_throw_on_access(compressor)) return this;

--- a/lib/compress/drop-side-effect-free.js
+++ b/lib/compress/drop-side-effect-free.js
@@ -121,7 +121,7 @@ def_drop_side_effect_free(AST_Constant, return_null);
 def_drop_side_effect_free(AST_This, return_null);
 
 def_drop_side_effect_free(AST_Call, function (compressor, first_in_statement) {
-    if (this.optional && is_nullish(this.expression, compressor)) {
+    if (is_nullish(this, compressor)) {
         return make_node(AST_Undefined, this);
     }
 
@@ -298,21 +298,15 @@ def_drop_side_effect_free(AST_Array, function (compressor, first_in_statement) {
 });
 
 def_drop_side_effect_free(AST_Dot, function (compressor, first_in_statement) {
-    if (this.optional) {
-        return is_nullish(this.expression, compressor) ? make_node(AST_Undefined, this) : this;
-    }
-    if (this.expression.may_throw_on_access(compressor))
-        return this;
+    if (is_nullish(this, compressor)) return make_node(AST_Undefined, this);
+    if (this.expression.may_throw_on_access(compressor)) return this;
 
     return this.expression.drop_side_effect_free(compressor, first_in_statement);
 });
 
 def_drop_side_effect_free(AST_Sub, function (compressor, first_in_statement) {
-    if (this.optional) {
-        return is_nullish(this.expression, compressor) ? make_node(AST_Undefined, this) : this;
-    }
-    if (this.expression.may_throw_on_access(compressor))
-        return this;
+    if (is_nullish(this, compressor)) return make_node(AST_Undefined, this);
+    if (this.expression.may_throw_on_access(compressor)) return this;
 
     var expression = this.expression.drop_side_effect_free(compressor, first_in_statement);
     if (!expression)

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -83,7 +83,7 @@ function def_eval(node, func) {
 }
 
 // Used to propagate a nullish short-circuit signal upwards through the chain.
-const nullish = {};
+const nullish = Symbol("This AST_Chain is nullish");
 
 // If the node has been successfully reduced to a constant,
 // then its value is returned; otherwise the element itself

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -82,6 +82,9 @@ function def_eval(node, func) {
     node.DEFMETHOD("_eval", func);
 }
 
+// Used to propagate a nullish short-circuit signal upwards through the chain.
+const nullish = {};
+
 // If the node has been successfully reduced to a constant,
 // then its value is returned; otherwise the element itself
 // is returned.
@@ -338,11 +341,8 @@ const regexp_flags = new Set([
 ]);
 
 def_eval(AST_PropAccess, function (compressor, depth) {
-    if (this.optional) {
-        const obj = this.expression._eval(compressor, depth);
-        if (obj == null)
-            return undefined;
-    }
+    const obj = this.expression._eval(compressor, depth);
+    if (obj === nullish || (this.optional && obj == null)) return nullish;
     if (compressor.option("unsafe")) {
         var key = this.property;
         if (key instanceof AST_Node) {
@@ -397,16 +397,15 @@ def_eval(AST_PropAccess, function (compressor, depth) {
 
 def_eval(AST_Chain, function (compressor, depth) {
     const evaluated = this.expression._eval(compressor, depth);
-    return evaluated === this.expression ? this : evaluated;
+    return evaluated === nullish ? undefined : this;
 });
 
 def_eval(AST_Call, function (compressor, depth) {
     var exp = this.expression;
-    if (this.optional) {
-        const callee = this.expression._eval(compressor, depth);
-        if (callee == null)
-            return undefined;
-    }
+
+    const callee = exp._eval(compressor, depth);
+    if (callee === nullish || (this.optional && callee == null)) return nullish;
+
     if (compressor.option("unsafe") && exp instanceof AST_PropAccess) {
         var key = exp.property;
         if (key instanceof AST_Node) {

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -96,7 +96,7 @@ AST_Node.DEFMETHOD("evaluate", function (compressor) {
     var val = this._eval(compressor, 1);
     if (!val || val instanceof RegExp)
         return val;
-    if (typeof val == "function" || typeof val == "object")
+    if (typeof val == "function" || typeof val == "object" || val == nullish)
         return this;
     return val;
 });

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -397,7 +397,11 @@ def_eval(AST_PropAccess, function (compressor, depth) {
 
 def_eval(AST_Chain, function (compressor, depth) {
     const evaluated = this.expression._eval(compressor, depth);
-    return evaluated === nullish ? undefined : this;
+    return evaluated === nullish
+        ? undefined
+        : evaluated === this.expression
+          ? this
+          : evaluated;
 });
 
 def_eval(AST_Call, function (compressor, depth) {

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -83,7 +83,7 @@ function def_eval(node, func) {
 }
 
 // Used to propagate a nullish short-circuit signal upwards through the chain.
-const nullish = Symbol("This AST_Chain is nullish");
+export const nullish = Symbol("This AST_Chain is nullish");
 
 // If the node has been successfully reduced to a constant,
 // then its value is returned; otherwise the element itself

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -177,7 +177,7 @@ import {
 } from "../scope.js";
 import "../size.js";
 
-import "./evaluate.js";
+import { nullish } from "./evaluate.js";
 import "./drop-side-effect-free.js";
 import "./reduce-vars.js";
 import {
@@ -2432,7 +2432,7 @@ def_optimize(AST_Call, function(self, compressor) {
     }
 
     var ev = self.evaluate(compressor);
-    if (ev !== self) {
+    if (ev !== self && ev !== nullish) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }
@@ -4191,7 +4191,7 @@ def_optimize(AST_Sub, function(self, compressor) {
         }
     }
     var ev = self.evaluate(compressor);
-    if (ev !== self) {
+    if (ev !== self && ev !== nullish) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }
@@ -4262,7 +4262,7 @@ def_optimize(AST_Dot, function(self, compressor) {
         if (sub) return sub.optimize(compressor);
     }
     let ev = self.evaluate(compressor);
-    if (ev !== self) {
+    if (ev !== self && ev !== nullish) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -177,7 +177,7 @@ import {
 } from "../scope.js";
 import "../size.js";
 
-import { nullish } from "./evaluate.js";
+import "./evaluate.js";
 import "./drop-side-effect-free.js";
 import "./reduce-vars.js";
 import {
@@ -2432,7 +2432,7 @@ def_optimize(AST_Call, function(self, compressor) {
     }
 
     var ev = self.evaluate(compressor);
-    if (ev !== self && ev !== nullish) {
+    if (ev !== self) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }
@@ -4191,7 +4191,7 @@ def_optimize(AST_Sub, function(self, compressor) {
         }
     }
     var ev = self.evaluate(compressor);
-    if (ev !== self && ev !== nullish) {
+    if (ev !== self) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }
@@ -4262,7 +4262,7 @@ def_optimize(AST_Dot, function(self, compressor) {
         if (sub) return sub.optimize(compressor);
     }
     let ev = self.evaluate(compressor);
-    if (ev !== self && ev !== nullish) {
+    if (ev !== self) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -2012,10 +2012,6 @@ def_optimize(AST_Call, function(self, compressor) {
         }
     }
 
-    if (self.optional && is_nullish(fn, compressor)) {
-        return make_node(AST_Undefined, self);
-    }
-
     var is_func = fn instanceof AST_Lambda;
 
     if (is_func && fn.pinned()) return self;
@@ -4199,14 +4195,11 @@ def_optimize(AST_Sub, function(self, compressor) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
     }
-    if (self.optional && is_nullish(self.expression, compressor)) {
-        return make_node(AST_Undefined, self);
-    }
     return self;
 });
 
 def_optimize(AST_Chain, function (self, compressor) {
-    self.expression = self.expression.optimize(compressor);
+    if (is_nullish(self.expression, compressor)) return make_node(AST_Undefined, self);
     return self;
 });
 
@@ -4272,9 +4265,6 @@ def_optimize(AST_Dot, function(self, compressor) {
     if (ev !== self) {
         ev = make_node_from_constant(ev, self).optimize(compressor);
         return best_of(compressor, ev, self);
-    }
-    if (self.optional && is_nullish(self.expression, compressor)) {
-        return make_node(AST_Undefined, self);
     }
     return self;
 });

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -240,16 +240,16 @@ function is_null_or_undefined(node, compressor) {
     );
 }
 
-// Find out if this expression is chained from a base-point that we can
-// statically analyze as null or undefined.
-function is_nullish_shortcircuit(node, compressor) {
+// Find out if this expression is optionally chained from a base-point that we
+// can statically analyze as null or undefined.
+export function is_nullish_shortcircuited(node, compressor) {
     if (node instanceof AST_PropAccess || node instanceof AST_Call) {
         return (
             (node.optional && is_null_or_undefined(node.expression, compressor))
-            || is_nullish_shortcircuit(node.expression, compressor)
+            || is_nullish_shortcircuited(node.expression, compressor)
         );
     }
-    if (node instanceof AST_Chain) return is_nullish_shortcircuit(node.expression, compressor);
+    if (node instanceof AST_Chain) return is_nullish_shortcircuited(node.expression, compressor);
     return false;
 }
 
@@ -257,7 +257,7 @@ function is_nullish_shortcircuit(node, compressor) {
 // Used to optimize ?. and ??
 export function is_nullish(node, compressor) {
     if (is_null_or_undefined(node, compressor)) return true;
-    return is_nullish_shortcircuit(node, compressor);
+    return is_nullish_shortcircuited(node, compressor);
 }
 
 // Determine if expression might cause side effects

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -226,9 +226,8 @@ export function is_undefined(node, compressor) {
     );
 }
 
-// Find out if something is == null
-// Used to optimize ?. and ??
-export function is_nullish(node, compressor) {
+// Is the node explicitly null or undefined.
+function is_null_or_undefined(node, compressor) {
     let fixed;
     return (
         node instanceof AST_Null
@@ -238,11 +237,27 @@ export function is_nullish(node, compressor) {
             && (fixed = node.definition().fixed) instanceof AST_Node
             && is_nullish(fixed, compressor)
         )
-        // Recurse into those optional chains!
-        || node instanceof AST_PropAccess && node.optional && is_nullish(node.expression, compressor)
-        || node instanceof AST_Call && node.optional && is_nullish(node.expression, compressor)
-        || node instanceof AST_Chain && is_nullish(node.expression, compressor)
     );
+}
+
+// Find out if this expression is chained from a base-point that we can
+// statically analyze as null or undefined.
+function is_nullish_shortcircuit(node, compressor) {
+    if (node instanceof AST_PropAccess || node instanceof AST_Call) {
+        return (
+            (node.optional && is_null_or_undefined(node.expression, compressor))
+            || is_nullish_shortcircuit(node.expression, compressor)
+        );
+    }
+    if (node instanceof AST_Chain) return is_nullish_shortcircuit(node.expression);
+    return false;
+}
+
+// Find out if something is == null, or can short circuit into nullish.
+// Used to optimize ?. and ??
+export function is_nullish(node, compressor) {
+    if (is_null_or_undefined(node, compressor)) return true;
+    return is_nullish_shortcircuit(node, compressor);
 }
 
 // Determine if expression might cause side effects
@@ -352,13 +367,12 @@ export function is_nullish(node, compressor) {
         return any(this.elements, compressor);
     });
     def_has_side_effects(AST_Dot, function(compressor) {
+        if (is_nullish(this, compressor)) return false;
         return !this.optional && this.expression.may_throw_on_access(compressor)
             || this.expression.has_side_effects(compressor);
     });
     def_has_side_effects(AST_Sub, function(compressor) {
-        if (this.optional && is_nullish(this.expression, compressor)) {
-            return false;
-        }
+        if (is_nullish(this, compressor)) return false;
 
         return !this.optional && this.expression.may_throw_on_access(compressor)
             || this.expression.has_side_effects(compressor)
@@ -426,7 +440,7 @@ export function is_nullish(node, compressor) {
         return any(this.body, compressor);
     });
     def_may_throw(AST_Call, function(compressor) {
-        if (this.optional && is_nullish(this.expression, compressor)) return false;
+        if (is_nullish(this.expression, compressor)) return false;
         if (any(this.args, compressor)) return true;
         if (this.is_callee_pure(compressor)) return false;
         if (this.expression.may_throw(compressor)) return true;
@@ -485,12 +499,12 @@ export function is_nullish(node, compressor) {
         return this.body.may_throw(compressor);
     });
     def_may_throw(AST_Dot, function(compressor) {
+        if (is_nullish(this, compressor)) return false;
         return !this.optional && this.expression.may_throw_on_access(compressor)
             || this.expression.may_throw(compressor);
     });
     def_may_throw(AST_Sub, function(compressor) {
-        if (this.optional && is_nullish(this.expression, compressor)) return false;
-
+        if (is_nullish(this, compressor)) return false;
         return !this.optional && this.expression.may_throw_on_access(compressor)
             || this.expression.may_throw(compressor)
             || this.property.may_throw(compressor);

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -249,7 +249,7 @@ function is_nullish_shortcircuit(node, compressor) {
             || is_nullish_shortcircuit(node.expression, compressor)
         );
     }
-    if (node instanceof AST_Chain) return is_nullish_shortcircuit(node.expression);
+    if (node instanceof AST_Chain) return is_nullish_shortcircuit(node.expression, compressor);
     return false;
 }
 
@@ -440,7 +440,7 @@ export function is_nullish(node, compressor) {
         return any(this.body, compressor);
     });
     def_may_throw(AST_Call, function(compressor) {
-        if (is_nullish(this.expression, compressor)) return false;
+        if (is_nullish(this, compressor)) return false;
         if (any(this.args, compressor)) return true;
         if (this.is_callee_pure(compressor)) return false;
         if (this.expression.may_throw(compressor)) return true;

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -2927,8 +2927,6 @@ unused_null_conditional_chain: {
         null?.maybe_call?.(3);
     }
     expect: {
-        undefined.i_will_throw;
-        undefined(1);
     }
 }
 

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -2930,3 +2930,112 @@ unused_null_conditional_chain: {
     }
 }
 
+unused_null_conditional_chain_2: {
+    options = {
+        toplevel: true,
+        defaults: true,
+        passes: 5,
+    }
+    input: {
+        let i = 0;
+        (i++, null)?.unused;
+        (i++, null)?.[side_effect()];
+        (i++, null)?.unused.i_will_throw;
+        (i++, null)?.call(1);
+        (i++, null)?.(2);
+        (i++, null)?.maybe_call?.(3);
+    }
+    expect: {
+    }
+}
+
+unused_null_conditional_chain_3: {
+    options = {
+        toplevel: true,
+        defaults: true,
+        passes: 5,
+    }
+    input: {
+        (side_effect(), null)?.unused;
+        (side_effect(), null)?.[side_effect()];
+        (side_effect(), null)?.unused.i_will_throw;
+        (side_effect(), null)?.call(1);
+        (side_effect(), null)?.(2);
+        (side_effect(), null)?.maybe_call?.(3);
+    }
+    expect: {
+        // TODO: Elminate everything after ?.
+        (side_effect(), null)?.unused,
+            (side_effect(), null)?.[side_effect()],
+            (side_effect(), null)?.unused.i_will_throw,
+            (side_effect(), null)?.call(1),
+            (side_effect(), null)?.(2),
+            (side_effect(), null)?.maybe_call?.(3);
+    }
+}
+
+unused_null_conditional_chain_4: {
+    options = {
+        toplevel: true,
+        defaults: true,
+        passes: 5,
+    }
+    input: {
+        function nullish() {
+            side_effect();
+            return null;
+        }
+        nullish()?.unused;
+        nullish()?.[side_effect()];
+        nullish()?.unused.i_will_throw;
+        nullish()?.call(1);
+        nullish()?.(2);
+        nullish()?.maybe_call?.(3);
+    }
+    expect: {
+        // TODO: Elminate everything after ?.
+        function nullish() {
+            return side_effect(), null;
+        }
+        nullish()?.unused,
+            nullish()?.[side_effect()],
+            nullish()?.unused.i_will_throw,
+            nullish()?.call(1),
+            nullish()?.(2),
+            nullish()?.maybe_call?.(3);
+    }
+}
+
+unused_null_conditional_chain_5: {
+    options = {
+        toplevel: true,
+        defaults: true,
+        passes: 5,
+    }
+    input: {
+        export const obj = {
+            side_effect() {
+                side_effect();
+                return { null: null };
+            }
+        }
+        obj.side_effect().null?.unused;
+        obj.side_effect().null?.[side_effect()];
+        obj.side_effect().null?.unused.i_will_throw;
+        obj.side_effect().null?.call(1);
+        obj.side_effect().null?.(2);
+        obj.side_effect().null?.maybe_call?.(3);
+    }
+    expect: {
+        export const obj = {
+            side_effect: () => (side_effect(), {null: null})
+        }
+        // TODO: Elminate everything after ?.
+        obj.side_effect().null?.unused,
+            obj.side_effect().null?.[side_effect()],
+            obj.side_effect().null?.unused.i_will_throw,
+            obj.side_effect().null?.call(1),
+            obj.side_effect().null?.(2),
+            obj.side_effect().null?.maybe_call?.(3);
+    }
+}

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1783,8 +1783,29 @@ null_conditional_chain_eval: {
         null?.maybe_call?.(3)
     }
     expect: {
-        (void 0).but_might_throw;
-        (void 0)(1);
+    }
+}
+
+null_conditional_chain_eval_2: {
+    options = {
+        evaluate: true,
+        side_effects: true
+    }
+    input: {
+        null.deep?.unused
+        null.deep?.[side_effect()]
+        null.deep?.unused.but_might_throw
+        null.deep?.call(1)
+        null.deep?.(2)
+        null.deep?.maybe_call?.(3)
+    }
+    expect: {
+        null.deep?.unused
+        null.deep?.[side_effect()]
+        null.deep?.unused.but_might_throw
+        null.deep?.call(1)
+        null.deep?.(2)
+        null.deep?.maybe_call?.(3)
     }
 }
 


### PR DESCRIPTION
This implements the recursion necessary to determine if a property access/call is part of an optional chain that has short-circuited.

Fixes https://github.com/terser/terser/issues/1040