### PR TITLE
Fix collisions between original property and mangled property

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -197,9 +197,6 @@ function mangle_properties(ast, options) {
     var cache;
     if (options.cache) {
         cache = options.cache.props;
-        cache.forEach(function(mangled_name) {
-            reserved.add(mangled_name);
-        });
     } else {
         cache = new Map();
     }

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -214,6 +214,9 @@ function mangle_properties(ast, options) {
 
     var names_to_mangle = new Set();
     var unmangleable = new Set();
+    // Track each already-mangled name to prevent nth_identifier from generating
+    // the same name.
+    cache.forEach((mangled_name) => unmangleable.add(mangled_name));
 
     var keep_quoted = !!options.keep_quoted;
 


### PR DESCRIPTION
This fixes a bug when an original property (`obj.i`) shares the same name as a mangled property (`obj.prop` -> `n.i`), and you're using a name-cache. Because our mangled name collides, we have to ensure all original `.i` properties are renamed to something else (`n.o`).

But, because we had a name-cache, we would reserve the mangled property name in the mangler. That prevents us from attempting to rename the original `.i` property to `.o`.

Fixes https://github.com/terser/terser/issues/233.