### PR TITLE
Fix mangling nested dothash expressions

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -57,7 +57,6 @@ import {
     AST_Definitions,
     AST_Destructuring,
     AST_Do,
-    AST_Dot,
     AST_Exit,
     AST_Expansion,
     AST_Export,
@@ -74,6 +73,7 @@ import {
     AST_Object,
     AST_ObjectProperty,
     AST_PrefixedTemplateString,
+    AST_PropAccess,
     AST_Sequence,
     AST_SimpleStatement,
     AST_Sub,
@@ -228,7 +228,7 @@ def_transform(AST_Sequence, function(self, tw) {
         : [new AST_Number({ value: 0 })];
 });
 
-def_transform(AST_Dot, function(self, tw) {
+def_transform(AST_PropAccess, function(self, tw) {
     self.expression = self.expression.transform(tw);
 });
 

--- a/test/compress/class-properties.js
+++ b/test/compress/class-properties.js
@@ -390,3 +390,66 @@ private_properties_can_be_mangled: {
         new X().log()
     }
 }
+
+nested_private_properties_can_be_mangled: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    mangle = {
+        properties: true
+    }
+    input: {
+        class X {
+            #test = "PASS"
+            #aaaaaa = this;
+            #bbbbbb() {
+                return this;
+            }
+            get #cccccc() { return this; }
+            log() {
+                console.log(this.#test);
+                console.log(this.#aaaaaa.#test);
+                console.log(this.#bbbbbb().#test);
+                console.log(this.#cccccc.#test);
+                console.log(this?.#test);
+                console.log(this?.#aaaaaa.#test);
+                console.log(this?.#bbbbbb().#test);
+                console.log(this?.#cccccc.#test);
+                console.log(this.#test);
+                console.log(this.#aaaaaa?.#test);
+                console.log(this.#bbbbbb?.().#test);
+                console.log(this.#bbbbbb()?.#test);
+                console.log(this.#cccccc?.#test);
+            }
+        }
+
+        new X().log()
+    }
+    expect: {
+        class X {
+            #s = "PASS";
+            #o = this;
+            #t() {
+                return this;
+            }
+            get #c() {
+                return this;
+            }
+            log() {
+                console.log(this.#s);
+                console.log(this.#o.#s);
+                console.log(this.#t().#s);
+                console.log(this.#c.#s);
+                console.log(this?.#s);
+                console.log(this?.#o.#s);
+                console.log(this?.#t().#s);
+                console.log(this?.#c.#s);
+                console.log(this.#s);
+                console.log(this.#o?.#s);
+                console.log(this.#t?.().#s);
+                console.log(this.#t()?.#s);
+                console.log(this.#c?.#s);
+            }
+        }
+        new X().log();
+    }
+}


### PR DESCRIPTION
We forgot to define the transform function for `AST_DotHash`. Since it's the same as `AST_Dot`, I opted to share on the base `AST_PropAccess` class and just list `AST_Sub` define it's own special transform.

Fixes #1067.