### PR TITLE
Fix missing nth_identifier default in minify()

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -11,6 +11,7 @@ import { AST_Toplevel, AST_Node } from "./ast.js";
 import { parse } from "./parse.js";
 import { OutputStream } from "./output.js";
 import { Compressor } from "./compress/index.js";
+import { base54 } from "./scope.js";
 import { SourceMap } from "./sourcemap.js";
 import {
     mangle_properties,
@@ -113,6 +114,7 @@ async function minify(files, options) {
             keep_classnames: false,
             keep_fnames: false,
             module: false,
+            nth_identifier: base54,
             properties: false,
             reserved: [],
             safari10: false,


### PR DESCRIPTION
While the test cases work, actually attempting to use the `nth_identifier` feature in a downstream project encountered a `DefaultsError: nth_identifier is not a supported option`.

Testing with a monkey patch showed that adding the missing default value fixes the issue.