### PR TITLE
collapsing switch cases with same bodies, when not lined in a row

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -145,8 +145,7 @@ import {
 
     _INLINE,
     _NOINLINE,
-    _PURE,
-    AST_Case
+    _PURE
 } from "../ast.js";
 import {
     defaults,
@@ -1599,20 +1598,15 @@ def_optimize(AST_Switch, function(self, compressor) {
     while (i < len) eliminate_branch(self.body[i++], body[body.length - 1]);
     self.body = body;
 
+    let default_or_exact = default_branch || exact_match;
+
     // group equivalent branches so they will be located next to each other,
     // that way the next micro-optimization will merge them.
     // ** bail micro-optimization if not a simple switch case with breaks
     if (body.every(branch =>
-        (
-            branch instanceof AST_Default || // default
-            !branch.expression.has_side_effects(compressor) // or no_side_effects
-        )
-            && (
-                branch.body.length === 0 // empty
-                || is_break(branch.body[branch.body.length - 1], compressor) // or has a break
-                || is_return(branch.body[branch.body.length - 1]) // or has a return
-            )
-    )) {
+        (branch === default_or_exact || !branch.expression.has_side_effects(compressor))
+        && (branch.body.length === 0 || branch.body.some(aborts)))
+    ) {
         for (let i = 0; i < body.length; i++) {
             let branch = body[i];
             if (branch.body.length === 0) continue;
@@ -1625,11 +1619,11 @@ def_optimize(AST_Switch, function(self, compressor) {
                     || (j === body.length - 1 && branches_equivalent(next, branch, true))
                 ) {
                     // let's find previous siblings with empty fallthrough...
-                    let x = j-1;
+                    let x = j - 1;
                     let fallthroughDepth = 0;
-                    while(x > i) {
+                    while (x > i) {
                         let previousSiblingBranch = body[x--];
-                        if(previousSiblingBranch.body.length === 0 && previousSiblingBranch instanceof AST_Case) {
+                        if (previousSiblingBranch.body.length === 0) {
                             fallthroughDepth++;
                         } else {
                             break;
@@ -1637,7 +1631,7 @@ def_optimize(AST_Switch, function(self, compressor) {
                     }
 
                     const plucked = body.splice(j - fallthroughDepth, 1 + fallthroughDepth);
-                    body.splice(i+1, 0, ...plucked);
+                    body.splice(i + 1, 0, ...plucked);
                     i += plucked.length;
                 }
             }
@@ -1665,7 +1659,6 @@ def_optimize(AST_Switch, function(self, compressor) {
         }
     }
 
-    let default_or_exact = default_branch || exact_match;
     default_branch = null;
     exact_match = null;
 
@@ -1933,9 +1926,6 @@ def_optimize(AST_Switch, function(self, compressor) {
     function is_break(node, stack) {
         return node instanceof AST_Break
             && stack.loopcontrol_target(node) === self;
-    }
-    function is_return(node) {
-        return node instanceof AST_Return;
     }
     function is_inert_body(branch) {
         return !aborts(branch) && !make_node(AST_BlockStatement, branch, {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1603,21 +1603,27 @@ def_optimize(AST_Switch, function(self, compressor) {
     // group equivalent branches so they will be located next to each other,
     // that way the next micro-optimization will merge them.
     // ** bail micro-optimization if not a simple switch case with breaks
-    if (body.every(branch =>
+    if (body.every((branch, i) =>
         (branch === default_or_exact || !branch.expression.has_side_effects(compressor))
-        && (branch.body.length === 0 || branch.body.some(aborts)))
+        && (branch.body.length === 0 || branch.body.some(aborts) || body.length - 1 === i))
     ) {
         for (let i = 0; i < body.length; i++) {
-            let branch = body[i];
+            const branch = body[i];
             if (branch.body.length === 0) continue;
             if (!aborts(branch)) continue;
             for (let j = i + 1; j < body.length; j++) {
-                let next = body[j];
+                const next = body[j];
                 if (next.body.length === 0) continue;
-                if (
-                    branches_equivalent(next, branch, false)
-                    || (j === body.length - 1 && branches_equivalent(next, branch, true))
+                const last_branch = j === (body.length - 1);
+                const equivalentBranch = branches_equivalent(next, branch, false);
+                if (equivalentBranch || (last_branch && branches_equivalent(next, branch, true))
                 ) {
+                    if (!equivalentBranch && last_branch) {
+                        if (!is_break(next.body[next.body.length - 1])) {
+                            next.body.push(make_node(AST_Break));
+                        }
+                    }
+
                     // let's find previous siblings with empty fallthrough...
                     let x = j - 1;
                     let fallthroughDepth = 0;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1621,12 +1621,11 @@ def_optimize(AST_Switch, function(self, compressor) {
                         next.body.push(make_node(AST_Break));
                     }
 
-                    // let's find previous siblings with empty fallthrough...
+                    // let's find previous siblings with inert fallthrough...
                     let x = j - 1;
                     let fallthroughDepth = 0;
                     while (x > i) {
-                        let previousSiblingBranch = body[x--];
-                        if (previousSiblingBranch.body.length === 0) {
+                        if (is_inert_body(body[x--])) {
                             fallthroughDepth++;
                         } else {
                             break;

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1599,6 +1599,8 @@ def_optimize(AST_Switch, function(self, compressor) {
     self.body = body;
 
     let default_or_exact = default_branch || exact_match;
+    default_branch = null;
+    exact_match = null;
 
     // group equivalent branches so they will be located next to each other,
     // that way the next micro-optimization will merge them.
@@ -1659,9 +1661,6 @@ def_optimize(AST_Switch, function(self, compressor) {
             break;
         }
     }
-
-    default_branch = null;
-    exact_match = null;
 
     // Prune any empty branches at the end of the switch statement.
     {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -145,7 +145,8 @@ import {
 
     _INLINE,
     _NOINLINE,
-    _PURE
+    _PURE,
+    AST_Case
 } from "../ast.js";
 import {
     defaults,
@@ -1607,7 +1608,7 @@ def_optimize(AST_Switch, function(self, compressor) {
             !branch.expression.has_side_effects(compressor) // or no_side_effects
         )
             && (
-                branch.body.length === 0 // or empty
+                branch.body.length === 0 // empty
                 || is_break(branch.body[branch.body.length - 1], compressor) // or has a break
                 || is_return(branch.body[branch.body.length - 1]) // or has a return
             )
@@ -1623,8 +1624,21 @@ def_optimize(AST_Switch, function(self, compressor) {
                     branches_equivalent(next, branch, false)
                     || (j === body.length - 1 && branches_equivalent(next, branch, true))
                 ) {
-                    body.splice(j, 1);
-                    body.splice(++i, 0, next);
+                    // let's find previous siblings with empty fallthrough...
+                    let x = j-1;
+                    let fallthroughDepth = 0;
+                    while(x > i) {
+                        let previousSiblingBranch = body[x--];
+                        if(previousSiblingBranch.body.length === 0 && previousSiblingBranch instanceof AST_Case) {
+                            fallthroughDepth++;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    const plucked = body.splice(j - fallthroughDepth, 1 + fallthroughDepth);
+                    body.splice(i+1, 0, ...plucked);
+                    i += plucked.length;
                 }
             }
         }

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1598,6 +1598,38 @@ def_optimize(AST_Switch, function(self, compressor) {
     while (i < len) eliminate_branch(self.body[i++], body[body.length - 1]);
     self.body = body;
 
+    // group equivalent branches so they will be located next to each other,
+    // that way the next micro-optimization will merge them.
+    // ** bail micro-optimization if not a simple switch case with breaks
+    if (body.every((branch, i) =>
+            (body.length - 1) === i // last branch
+            || branch instanceof AST_Default // or default:
+            || !branch.expression.has_side_effects(compressor) // or no_side_effects
+            && (
+                branch.body.length === 0 // or empty
+                || is_break(branch.body[branch.body.length - 1], compressor) // or has a break
+                || is_return(branch.body[branch.body.length - 1]) // or has a return
+            )
+    )) {
+        for (let i = 0; i < body.length; i++) {
+            let branch = body[i];
+            if (branch.body.length === 0) continue;
+            if (!aborts(branch)) continue;
+            for (let j = i + 1; j < body.length; j++) {
+                let next = body[j];
+                if (next.body.length === 0) continue;
+                if (
+                    branches_equivalent(next, branch, false)
+                    || (j === body.length - 1 && branches_equivalent(next, branch, true))
+                ) {
+                    body.splice(j, 1);
+                    body.splice(++i, 0, next);
+                }
+            }
+        }
+    }
+
+    // merge equivalent branches in a row
     for (let i = 0; i < body.length; i++) {
         let branch = body[i];
         if (branch.body.length === 0) continue;
@@ -1886,6 +1918,9 @@ def_optimize(AST_Switch, function(self, compressor) {
     function is_break(node, stack) {
         return node instanceof AST_Break
             && stack.loopcontrol_target(node) === self;
+    }
+    function is_return(node) {
+        return node instanceof AST_Return;
     }
     function is_inert_body(branch) {
         return !aborts(branch) && !make_node(AST_BlockStatement, branch, {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1605,23 +1605,18 @@ def_optimize(AST_Switch, function(self, compressor) {
     // ** bail micro-optimization if not a simple switch case with breaks
     if (body.every((branch, i) =>
         (branch === default_or_exact || !branch.expression.has_side_effects(compressor))
-        && (branch.body.length === 0 || branch.body.some(aborts) || body.length - 1 === i))
+        && (branch.body.length === 0 || aborts(branch) || body.length - 1 === i))
     ) {
         for (let i = 0; i < body.length; i++) {
             const branch = body[i];
-            if (branch.body.length === 0) continue;
-            if (!aborts(branch)) continue;
             for (let j = i + 1; j < body.length; j++) {
                 const next = body[j];
                 if (next.body.length === 0) continue;
                 const last_branch = j === (body.length - 1);
                 const equivalentBranch = branches_equivalent(next, branch, false);
-                if (equivalentBranch || (last_branch && branches_equivalent(next, branch, true))
-                ) {
+                if (equivalentBranch || (last_branch && branches_equivalent(next, branch, true))) {
                     if (!equivalentBranch && last_branch) {
-                        if (!is_break(next.body[next.body.length - 1])) {
-                            next.body.push(make_node(AST_Break));
-                        }
+                        next.body.push(make_node(AST_Break));
                     }
 
                     // let's find previous siblings with empty fallthrough...

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1601,10 +1601,11 @@ def_optimize(AST_Switch, function(self, compressor) {
     // group equivalent branches so they will be located next to each other,
     // that way the next micro-optimization will merge them.
     // ** bail micro-optimization if not a simple switch case with breaks
-    if (body.every((branch, i) =>
-            (body.length - 1) === i // last branch
-            || branch instanceof AST_Default // or default:
-            || !branch.expression.has_side_effects(compressor) // or no_side_effects
+    if (body.every(branch =>
+        (
+            branch instanceof AST_Default || // default
+            !branch.expression.has_side_effects(compressor) // or no_side_effects
+        )
             && (
                 branch.body.length === 0 // or empty
                 || is_break(branch.body[branch.body.length - 1], compressor) // or has a break

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2593,6 +2593,35 @@ collapse_same_branches_not_in_a_row_ensure_no_side_effects: {
     }
     expect_stdout: ["2"]
 }
+collapse_same_branches_not_in_a_row_even_if_last_case_without_abort: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(3)) {
+            case 1:
+                console.log(1);
+                break;
+            case 2:
+                console.log(2);
+                break;
+            case 3:
+                console.log(1);
+        }
+    }
+    expect: {
+        switch (id(3)) {
+            case 1:
+            case 3:
+                console.log(1);
+                break;
+            case 2:
+                console.log(2);
+        }
+    }
+    expect_stdout: ["1"]
+}
 
 
 collapse_same_branches_as_default_not_in_a_row: {

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2576,6 +2576,7 @@ collapse_same_branches_not_in_a_row_ensure_no_side_effects: {
                 break;
             case ++i:
                 console.log(1);
+                break;
         }
     }
     expect: {

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2447,6 +2447,183 @@ collapse_same_branches_2: {
     expect_stdout: ["PASS", "PASS"]
 }
 
+collapse_same_branches_not_in_a_row: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS")
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+                console.log("PASS");
+                break;
+        }
+    }
+    expect: {
+        switch (id(1)) {
+            case 1:
+            case 3:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+        }
+    }
+    expect_stdout: ["PASS"]
+}
+
+collapse_same_branches_not_in_a_row2: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+                console.log("PASS");
+                break;
+            case 4:
+                console.log("PASS");
+                break;
+        }
+    }
+    expect: {
+        switch (id(1)) {
+            case 1:
+            case 3:
+            case 4:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+        }
+    }
+    expect_stdout: ["PASS"]
+}
+
+
+collapse_same_branches_as_default_not_in_a_row: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+                console.log("PREVENT_IFS");
+                break;
+            case 4:
+                console.log("PASS");
+                break;
+            default:
+                console.log("PASS");
+                break;
+        }
+    }
+    expect: {
+        switch (id(1)) {
+            default:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+                console.log("PREVENT_IFS");
+        }
+    }
+    expect_stdout: ["PASS"]
+}
+
+collapse_same_branches_in_a_row2: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+                console.log("PASS");
+                break;
+            case 4:
+                console.log("FAIL");
+                break;
+        }
+    }
+    expect: {
+        switch (id(1)) {
+            case 1:
+            case 3:
+                console.log("PASS");
+                break;
+            case 2:
+            case 4:
+                console.log("FAIL");
+        }
+    }
+    expect_stdout: ["PASS"]
+}
+
+collapse_same_branches_in_a_row_with_return: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        function fn() {
+            switch (id(1)) {
+                case 1:
+                    return "PASS";
+                case 2:
+                    return "FAIL";
+                case 3:
+                    return "PASS";
+                case 4:
+                    return "FAIL";
+            }
+        }
+        console.log(fn())
+    }
+    expect: {
+        function fn() {
+            switch (id(1)) {
+                case 1:
+                case 3:
+                    return "PASS";
+                case 2:
+                case 4:
+                    return "FAIL";
+            }
+        }
+        console.log(fn())
+    }
+    expect_stdout: ["PASS"]
+}
+
 // Empty branches at the end of the switch get trimmed
 trim_empty_last_branches: {
     options = {

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2513,6 +2513,53 @@ collapse_same_branches_not_in_a_row2: {
     expect_stdout: ["PASS"]
 }
 
+collapse_same_branches_not_in_a_row_including_fallthrough_with_same_body: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        switch (id(1)) {
+            case 1:
+                console.log("PASS");
+                break;
+            case 2:
+                console.log("FAIL");
+                break;
+            case 3:
+            case 4:
+                console.log("PASS");
+                break;
+            case 9:
+                console.log("FAIL");
+                break;
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                console.log("PASS");
+                break;
+        }
+    }
+    expect: {
+        switch (id(1)) {
+            case 1:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                console.log("PASS");
+                break;
+            case 2:
+            case 9:
+                console.log("FAIL");
+        }
+    }
+    expect_stdout: ["PASS"]
+}
+
 collapse_same_branches_not_in_a_row_ensure_no_side_effects: {
     options = {
         switches: true,

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -2513,6 +2513,40 @@ collapse_same_branches_not_in_a_row2: {
     expect_stdout: ["PASS"]
 }
 
+collapse_same_branches_not_in_a_row_ensure_no_side_effects: {
+    options = {
+        switches: true,
+        dead_code: true
+    }
+    input: {
+        let i = 1;
+        switch (id(2)) {
+            case 1:
+                console.log(1);
+                break;
+            case 2:
+                console.log(2);
+                break;
+            case ++i:
+                console.log(1);
+        }
+    }
+    expect: {
+        let i = 1;
+        switch (id(2)) {
+            case 1:
+                console.log(1);
+                break;
+            case 2:
+                console.log(2);
+                break;
+            case ++i:
+                console.log(1);
+        }
+    }
+    expect_stdout: ["2"]
+}
+
 
 collapse_same_branches_as_default_not_in_a_row: {
     options = {


### PR DESCRIPTION
This is an additional optimization that leverages changes from #1044 @jridgewell 

Current code does not **fully optimize** the following code:
```js
 switch (_var) {
    case 1: return true;
    case 2: return true;
    case 3: return false;
    case 4: return true;
    case 5: return false;
    case 6: return false;
    case 7: return true;
    case 8: return true;
}
```

The current output returns something like this:
```js
 switch (_var) {
    case 1: case 2: 
      return true;
    case 3: 
      return false;
    case 4:
      return true;
    case 5: case 6: 
      return false;
    case 7: case 8: 
      return true;
}
```

The expected output in this case should be:
```js 
switch (_var) {
    case 1: case 2: case 4: case 7: case 8: 
      return true;
    case 3: case 5: case 6: 
      return false;
}
```
------------------------
Adding a default case can benefit the optimization even more:
```js
 switch (_var) {
    case 1: return true;
    case 2: return true;
    case 3: return false;
    case 4: return true;
    case 5: return false;
    case 6: return false;
    case 7: return true;
    case 8: return true;
    default: return true;
}
```

The expected output here should be:
```js 
switch (_var) {
    default: 
      return true;
    case 3: case 5: case 6: 
      return false;
}
```
