### PR TITLE
Fix inlining object spread properties

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -4335,9 +4335,11 @@ function inline_object_prop_spread(props, compressor) {
                 // non-iterable value silently does nothing; it is thus safe
                 // to remove. AST_String is the only iterable AST_Constant.
                 props.splice(i, 1);
+                i--;
             } else if (is_nullish(expr, compressor)) {
                 // Likewise, null and undefined can be silently removed.
                 props.splice(i, 1);
+                i--;
             }
         }
     }

--- a/test/compress/expansions.js
+++ b/test/compress/expansions.js
@@ -103,6 +103,31 @@ object_spread: {
     ]
 }
 
+object_spread_nullish_undefined: {
+    input: {
+        let o = { ...undefined, ...{a: true} }
+        id(o);
+    }
+
+    expect: {
+        let o = {a: true};
+        id(o)
+    }
+}
+
+object_spread_nullish_null: {
+    input: {
+        let o = { ...null, ...{a: true} }
+        id(o);
+    }
+
+    expect: {
+        let o = {a: true};
+        id(o)
+    }
+}
+
+
 avoid_spread_hole: {
     input: {
         let x = [...[,]]


### PR DESCRIPTION
The two cases forgot to backtrack, so the following property was not being inlined.