### PR TITLE
Fix a collision with exported variables with short names

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -781,8 +781,11 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
     }
 
     const mangled_names = this.mangled_names = new Set();
+    unmangleable_names = new Set();
+
     if (options.cache) {
         this.globals.forEach(collect);
+        // TODO
         if (options.cache.props) {
             options.cache.props.forEach(function(mangled_name) {
                 mangled_names.add(mangled_name);
@@ -833,7 +836,6 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
     this.walk(tw);
 
     if (options.keep_fnames || options.keep_classnames) {
-        unmangleable_names = new Set();
         // Collect a set of short names which are unmangleable,
         // for use in avoiding collisions in next_mangled.
         to_mangle.forEach(def => {
@@ -849,9 +851,9 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
     unmangleable_names = null;
 
     function collect(symbol) {
-        const should_mangle = !options.reserved.has(symbol.name)
-            && !(symbol.export & MASK_EXPORT_DONT_MANGLE);
-        if (should_mangle) {
+        if (symbol.export & MASK_EXPORT_DONT_MANGLE) {
+            unmangleable_names.add(symbol.name);
+        } else if (!options.reserved.has(symbol.name)) {
             to_mangle.push(symbol);
         }
     }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -785,7 +785,6 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
 
     if (options.cache) {
         this.globals.forEach(collect);
-        // TODO
         if (options.cache.props) {
             options.cache.props.forEach(function(mangled_name) {
                 mangled_names.add(mangled_name);

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -921,3 +921,34 @@ issue_333_toplevel: {
         export { _setToString };
     }
 }
+
+export_object_property_mangle: {
+    module = true
+    options = {
+        reduce_vars: false,
+    }
+    mangle = true
+    input: {
+        const n = null;
+        export const o = { o: n };
+    }
+    expect: {
+        const n = null;
+        export const o = {o: n};
+    }
+}
+
+export_object_property_mangle_2: {
+    module = true
+    mangle = true
+    input: {
+        const n = null;
+        const o = { o: n };
+        export { o };
+    }
+    expect: {
+        const o = null;
+        const n = {o: o};
+        export {n as o};
+    }
+}


### PR DESCRIPTION
In some cases, it's possible to generate a collision between an exported variable declaration (which cannot be mangled) and a local reference. Eg,

```js
// input
const n = null;
export const o = {o: n};

// options:
{ module: true, reduce_vars: false }

// output
const o=null;
export const o={o:o};
```