### PR TITLE
Support for custom `indent_space` characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,9 @@ as "output options".
 
 - `indent_start` (default `0`) -- prefix all lines by that many spaces
 
+- `indent_space` (default ` `) -- use custom indent character. For example `\t`
+   to use tabs instead of spaces.  Be sure to adapt `indent_level` accordingly.
+
 - `inline_script` (default `true`) -- escape HTML comments and the slash in
   occurrences of `</script>` in strings
 

--- a/lib/output.js
+++ b/lib/output.js
@@ -230,6 +230,7 @@ function OutputStream(options) {
         ie8                  : false,
         indent_level         : 4,
         indent_start         : 0,
+        indent_space         : " ",
         inline_script        : true,
         keep_numbers         : false,
         keep_quoted_props    : false,
@@ -373,7 +374,7 @@ function OutputStream(options) {
     }
 
     function make_indent(back) {
-        return " ".repeat(options.indent_start + indentation - back * options.indent_level);
+        return options.indent_space.repeat(options.indent_start + indentation - back * options.indent_level);
     }
 
     /* -----[ beautification/minification ]----- */

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -146,6 +146,7 @@ export interface FormatOptions {
     ie8?: boolean;
     indent_level?: number;
     indent_start?: number;
+    indent_space?: string;
     inline_script?: boolean;
     keep_quoted_props?: boolean;
     max_line_len?: number | false;


### PR DESCRIPTION
Allows support for using tabs instead of spaces in beautified code
output.

Example:

        # defaults...
        :; ./bin/terser -f beautify,indent_space='" "',indent_level=4 -- ../sauce-chartjs/dist/Chart.js | wc -c
        310359

        # single tab indents...
        :; ./bin/terser -f beautify,indent_space='"\t"',indent_level=1 -- ../sauce-chartjs/dist/Chart.js | wc -c
        234954

Fixes #1113