### PR TITLE
make `is_constant()` recognize constants with several unary prefixes

### DIFF
--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -117,8 +117,13 @@ AST_Node.DEFMETHOD("is_constant", function () {
         return !(this instanceof AST_RegExp);
     } else {
         return this instanceof AST_UnaryPrefix
-            && this.expression instanceof AST_Constant
-            && unaryPrefix.has(this.operator);
+            && unaryPrefix.has(this.operator)
+            && (
+                // `this.expression` may be an `AST_RegExp`,
+                // so not only `.is_constant()`.
+                this.expression instanceof AST_Constant
+                || this.expression.is_constant()
+            );
     }
 });
 

--- a/test/compress/expansions.js
+++ b/test/compress/expansions.js
@@ -104,6 +104,10 @@ object_spread: {
 }
 
 object_spread_constant: {
+    options = {
+        evaluate: false,
+    }
+
     input: {
         id({
             ...null,
@@ -114,6 +118,15 @@ object_spread_constant: {
             ...~"foo",
             .../baz/,
             ...-/baz2/,
+
+            // Several unary prefixes
+            ...!!0,
+            ...~!-+0,
+            ...void !1,
+            ...!~"foo",
+            ...+!/foo/,
+            ...!!!!!!!null,
+            ...!~void +-42,
 
             ..."bar",
         });


### PR DESCRIPTION
E.g. previously it would return `false` for expressions like `void !0`