### PR TITLE
Update source-map -> 0.8.0-beta.0 for compatibility with global `fetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -912,6 +912,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -1246,8 +1251,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "random-int": {
       "version": "2.0.1",
@@ -1487,9 +1491,12 @@
       }
     },
     "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "requires": {
+        "whatwg-url": "^7.0.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.20",
@@ -1624,6 +1631,14 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1693,6 +1708,21 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "acorn": "^8.5.0",
     "commander": "^2.20.0",
-    "source-map": "~0.7.2",
+    "source-map": "~0.8.0-beta.0",
     "source-map-support": "~0.5.20"
   },
   "devDependencies": {


### PR DESCRIPTION
`source-map@0.7.3` has an issue with buggy identification of node vs browser environment (it uses `typeof fetch === 'function'` to spot browsers) - See https://github.com/mozilla/source-map/issues/349, https://github.com/mozilla/source-map/issues/432 and fixes https://github.com/mozilla/source-map/pull/350, https://github.com/mozilla/source-map/pull/363.

This is an issue for React (Native) environments where `fetch` is often polyfilled, eg for testing or SSR. It's one of the last issues holding us back from making `terser` the default minifier for https://github.com/facebook/metro.

Importantly, this is also **probably going to be an issue for all NodeJS users soon**, as NodeJS moves forward with a native global `fetch`: https://github.com/nodejs/node/pull/41749

Unfortunately, the only `source-map` release since that bug was fixed is [0.8.0-beta.0](https://github.com/mozilla/source-map/releases/tag/0.8.0-beta.0), dated Nov 2018. 
 - Comparison: https://github.com/mozilla/source-map/compare/0.7.3...0.8.0-beta.0 . 
 - Changelog: https://github.com/mozilla/source-map/blob/master/CHANGELOG.md#080-beta0
 I've suggested they publish a release but I'm not optimistic (https://github.com/mozilla/source-map/issues/452).

Would you consider a dependency on a "prerelease", or is this a non-starter?