### PR TITLE
Run Eval removing codeshift

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -48,23 +48,13 @@ import {
 } from "./utils/index.js";
 import { parse } from "./parse.js";
 
-function DEFNODE(type, props, methods, base = AST_Node) {
+function DEFNODE(type, props, ctor, methods, base = AST_Node) {
     if (!props) props = [];
     else props = props.split(/\s+/);
     var self_props = props;
     if (base && base.PROPS)
         props = props.concat(base.PROPS);
-    var code = "return function AST_" + type + "(props){ if (props) { ";
-    for (var i = props.length; --i >= 0;) {
-        code += "this." + props[i] + " = props." + props[i] + ";";
-    }
     const proto = base && Object.create(base.prototype);
-    if (proto && proto.initialize || (methods && methods.initialize))
-        code += "this.initialize();";
-    code += "}";
-    code += "this.flags = 0;";
-    code += "}";
-    var ctor = new Function(code)();
     if (proto) {
         ctor.prototype = proto;
         ctor.BASE = base;
@@ -78,7 +68,7 @@ function DEFNODE(type, props, methods, base = AST_Node) {
     if (type) {
         ctor.prototype.TYPE = ctor.TYPE = type;
     }
-    if (methods) for (i in methods) if (HOP(methods, i)) {
+    if (methods) for (let i in methods) if (HOP(methods, i)) {
         if (i[0] === "$") {
             ctor[i.substr(1)] = methods[i];
         } else {
@@ -140,7 +130,14 @@ class AST_Token {
     }
 }
 
-var AST_Node = DEFNODE("Node", "start end", {
+var AST_Node = DEFNODE("Node", "start end", function AST_Node(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     _clone: function(deep) {
         if (deep) {
             var self = this.clone();
@@ -171,15 +168,38 @@ var AST_Node = DEFNODE("Node", "start end", {
 
 /* -----[ statements ]----- */
 
-var AST_Statement = DEFNODE("Statement", null, {
+var AST_Statement = DEFNODE("Statement", null, function AST_Statement(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class of all statements",
 });
 
-var AST_Debugger = DEFNODE("Debugger", null, {
+var AST_Debugger = DEFNODE("Debugger", null, function AST_Debugger(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Represents a debugger statement",
 }, AST_Statement);
 
-var AST_Directive = DEFNODE("Directive", "value quote", {
+var AST_Directive = DEFNODE("Directive", "value quote", function AST_Directive(props) {
+    if (props) {
+        this.value = props.value;
+        this.quote = props.quote;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Represents a directive, like \"use strict\";",
     $propdoc: {
         value: "[string] The value of this directive as a plain string (it's not an AST_String!)",
@@ -187,7 +207,15 @@ var AST_Directive = DEFNODE("Directive", "value quote", {
     },
 }, AST_Statement);
 
-var AST_SimpleStatement = DEFNODE("SimpleStatement", "body", {
+var AST_SimpleStatement = DEFNODE("SimpleStatement", "body", function AST_SimpleStatement(props) {
+    if (props) {
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A statement consisting of an expression, i.e. a = 1 + 2",
     $propdoc: {
         body: "[AST_Node] an expression node (should not be instanceof AST_Statement)"
@@ -217,7 +245,16 @@ function clone_block_scope(deep) {
     return clone;
 }
 
-var AST_Block = DEFNODE("Block", "body block_scope", {
+var AST_Block = DEFNODE("Block", "body block_scope", function AST_Block(props) {
+    if (props) {
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A body of statements (usually braced)",
     $propdoc: {
         body: "[AST_Statement*] an array of statements",
@@ -235,22 +272,55 @@ var AST_Block = DEFNODE("Block", "body block_scope", {
     clone: clone_block_scope
 }, AST_Statement);
 
-var AST_BlockStatement = DEFNODE("BlockStatement", null, {
+var AST_BlockStatement = DEFNODE("BlockStatement", null, function AST_BlockStatement(props) {
+    if (props) {
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A block statement",
 }, AST_Block);
 
-var AST_EmptyStatement = DEFNODE("EmptyStatement", null, {
+var AST_EmptyStatement = DEFNODE("EmptyStatement", null, function AST_EmptyStatement(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The empty statement (empty block or simply a semicolon)"
 }, AST_Statement);
 
-var AST_StatementWithBody = DEFNODE("StatementWithBody", "body", {
+var AST_StatementWithBody = DEFNODE("StatementWithBody", "body", function AST_StatementWithBody(props) {
+    if (props) {
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for all statements that contain one nested body: `For`, `ForIn`, `Do`, `While`, `With`",
     $propdoc: {
         body: "[AST_Statement] the body; this should always be present, even if it's an AST_EmptyStatement"
     }
 }, AST_Statement);
 
-var AST_LabeledStatement = DEFNODE("LabeledStatement", "label", {
+var AST_LabeledStatement = DEFNODE("LabeledStatement", "label", function AST_LabeledStatement(props) {
+    if (props) {
+        this.label = props.label;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Statement with a label",
     $propdoc: {
         label: "[AST_Label] a label definition"
@@ -282,22 +352,57 @@ var AST_LabeledStatement = DEFNODE("LabeledStatement", "label", {
     }
 }, AST_StatementWithBody);
 
-var AST_IterationStatement = DEFNODE("IterationStatement", "block_scope", {
-    $documentation: "Internal class.  All loops inherit from it.",
-    $propdoc: {
-        block_scope: "[AST_Scope] the block scope for this iteration statement."
-    },
-    clone: clone_block_scope
-}, AST_StatementWithBody);
+var AST_IterationStatement = DEFNODE(
+    "IterationStatement",
+    "block_scope",
+    function AST_IterationStatement(props) {
+        if (props) {
+            this.block_scope = props.block_scope;
+            this.body = props.body;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-var AST_DWLoop = DEFNODE("DWLoop", "condition", {
+        this.flags = 0;
+    },
+    {
+        $documentation: "Internal class.  All loops inherit from it.",
+        $propdoc: {
+            block_scope: "[AST_Scope] the block scope for this iteration statement."
+        },
+        clone: clone_block_scope
+    },
+    AST_StatementWithBody
+);
+
+var AST_DWLoop = DEFNODE("DWLoop", "condition", function AST_DWLoop(props) {
+    if (props) {
+        this.condition = props.condition;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for do/while statements",
     $propdoc: {
         condition: "[AST_Node] the loop condition.  Should not be instanceof AST_Statement"
     }
 }, AST_IterationStatement);
 
-var AST_Do = DEFNODE("Do", null, {
+var AST_Do = DEFNODE("Do", null, function AST_Do(props) {
+    if (props) {
+        this.condition = props.condition;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `do` statement",
     _walk: function(visitor) {
         return visitor._visit(this, function() {
@@ -311,7 +416,17 @@ var AST_Do = DEFNODE("Do", null, {
     }
 }, AST_DWLoop);
 
-var AST_While = DEFNODE("While", null, {
+var AST_While = DEFNODE("While", null, function AST_While(props) {
+    if (props) {
+        this.condition = props.condition;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `while` statement",
     _walk: function(visitor) {
         return visitor._visit(this, function() {
@@ -325,7 +440,19 @@ var AST_While = DEFNODE("While", null, {
     },
 }, AST_DWLoop);
 
-var AST_For = DEFNODE("For", "init condition step", {
+var AST_For = DEFNODE("For", "init condition step", function AST_For(props) {
+    if (props) {
+        this.init = props.init;
+        this.condition = props.condition;
+        this.step = props.step;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `for` statement",
     $propdoc: {
         init: "[AST_Node?] the `for` initialization code, or null if empty",
@@ -348,7 +475,18 @@ var AST_For = DEFNODE("For", "init condition step", {
     },
 }, AST_IterationStatement);
 
-var AST_ForIn = DEFNODE("ForIn", "init object", {
+var AST_ForIn = DEFNODE("ForIn", "init object", function AST_ForIn(props) {
+    if (props) {
+        this.init = props.init;
+        this.object = props.object;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `for ... in` statement",
     $propdoc: {
         init: "[AST_Node] the `for/in` initialization code",
@@ -368,11 +506,32 @@ var AST_ForIn = DEFNODE("ForIn", "init object", {
     },
 }, AST_IterationStatement);
 
-var AST_ForOf = DEFNODE("ForOf", "await", {
+var AST_ForOf = DEFNODE("ForOf", "await", function AST_ForOf(props) {
+    if (props) {
+        this.await = props.await;
+        this.init = props.init;
+        this.object = props.object;
+        this.block_scope = props.block_scope;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `for ... of` statement",
 }, AST_ForIn);
 
-var AST_With = DEFNODE("With", "expression", {
+var AST_With = DEFNODE("With", "expression", function AST_With(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `with` statement",
     $propdoc: {
         expression: "[AST_Node] the `with` expression"
@@ -391,43 +550,82 @@ var AST_With = DEFNODE("With", "expression", {
 
 /* -----[ scope and functions ]----- */
 
-var AST_Scope = DEFNODE("Scope", "variables functions uses_with uses_eval parent_scope enclosed cname", {
-    $documentation: "Base class for all statements introducing a lexical scope",
-    $propdoc: {
-        variables: "[Map/S] a map of name -> SymbolDef for all variables/functions defined in this scope",
-        uses_with: "[boolean/S] tells whether this scope uses the `with` statement",
-        uses_eval: "[boolean/S] tells whether this scope contains a direct call to the global `eval`",
-        parent_scope: "[AST_Scope?/S] link to the parent scope",
-        enclosed: "[SymbolDef*/S] a list of all symbol definitions that are accessed from this scope or any subscopes",
-        cname: "[integer/S] current index for mangling variables (used internally by the mangler)",
-    },
-    get_defun_scope: function() {
-        var self = this;
-        while (self.is_block_scope()) {
-            self = self.parent_scope;
+var AST_Scope = DEFNODE(
+    "Scope",
+    "variables functions uses_with uses_eval parent_scope enclosed cname",
+    function AST_Scope(props) {
+        if (props) {
+            this.variables = props.variables;
+            this.functions = props.functions;
+            this.uses_with = props.uses_with;
+            this.uses_eval = props.uses_eval;
+            this.parent_scope = props.parent_scope;
+            this.enclosed = props.enclosed;
+            this.cname = props.cname;
+            this.body = props.body;
+            this.block_scope = props.block_scope;
+            this.start = props.start;
+            this.end = props.end;
         }
-        return self;
-    },
-    clone: function(deep, toplevel) {
-        var node = this._clone(deep);
-        if (deep && this.variables && toplevel && !this._block_scope) {
-            node.figure_out_scope({}, {
-                toplevel: toplevel,
-                parent_scope: this.parent_scope
-            });
-        } else {
-            if (this.variables) node.variables = new Map(this.variables);
-            if (this.enclosed) node.enclosed = this.enclosed.slice();
-            if (this._block_scope) node._block_scope = this._block_scope;
-        }
-        return node;
-    },
-    pinned: function() {
-        return this.uses_eval || this.uses_with;
-    }
-}, AST_Block);
 
-var AST_Toplevel = DEFNODE("Toplevel", "globals", {
+        this.flags = 0;
+    },
+    {
+        $documentation: "Base class for all statements introducing a lexical scope",
+        $propdoc: {
+            variables: "[Map/S] a map of name -> SymbolDef for all variables/functions defined in this scope",
+            uses_with: "[boolean/S] tells whether this scope uses the `with` statement",
+            uses_eval: "[boolean/S] tells whether this scope contains a direct call to the global `eval`",
+            parent_scope: "[AST_Scope?/S] link to the parent scope",
+            enclosed: "[SymbolDef*/S] a list of all symbol definitions that are accessed from this scope or any subscopes",
+            cname: "[integer/S] current index for mangling variables (used internally by the mangler)",
+        },
+        get_defun_scope: function() {
+            var self = this;
+            while (self.is_block_scope()) {
+                self = self.parent_scope;
+            }
+            return self;
+        },
+        clone: function(deep, toplevel) {
+            var node = this._clone(deep);
+            if (deep && this.variables && toplevel && !this._block_scope) {
+                node.figure_out_scope({}, {
+                    toplevel: toplevel,
+                    parent_scope: this.parent_scope
+                });
+            } else {
+                if (this.variables) node.variables = new Map(this.variables);
+                if (this.enclosed) node.enclosed = this.enclosed.slice();
+                if (this._block_scope) node._block_scope = this._block_scope;
+            }
+            return node;
+        },
+        pinned: function() {
+            return this.uses_eval || this.uses_with;
+        }
+    },
+    AST_Block
+);
+
+var AST_Toplevel = DEFNODE("Toplevel", "globals", function AST_Toplevel(props) {
+    if (props) {
+        this.globals = props.globals;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The toplevel scope",
     $propdoc: {
         globals: "[Map/S] a map of name -> SymbolDef for all undeclared names",
@@ -462,7 +660,15 @@ var AST_Toplevel = DEFNODE("Toplevel", "globals", {
     }
 }, AST_Scope);
 
-var AST_Expansion = DEFNODE("Expansion", "expression", {
+var AST_Expansion = DEFNODE("Expansion", "expression", function AST_Expansion(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An expandible argument, such as ...rest, a splat, such as [1,2,...all], or an expansion in a variable declaration, such as var [first, ...rest] = list",
     $propdoc: {
         expression: "[AST_Node] the thing to be expanded"
@@ -477,80 +683,200 @@ var AST_Expansion = DEFNODE("Expansion", "expression", {
     },
 });
 
-var AST_Lambda = DEFNODE("Lambda", "name argnames uses_arguments is_generator async", {
-    $documentation: "Base class for functions",
-    $propdoc: {
-        name: "[AST_SymbolDeclaration?] the name of this function",
-        argnames: "[AST_SymbolFunarg|AST_Destructuring|AST_Expansion|AST_DefaultAssign*] array of function arguments, destructurings, or expanding arguments",
-        uses_arguments: "[boolean/S] tells whether this function accesses the arguments array",
-        is_generator: "[boolean] is this a generator method",
-        async: "[boolean] is this method async",
-    },
-    args_as_names: function () {
-        var out = [];
-        for (var i = 0; i < this.argnames.length; i++) {
-            if (this.argnames[i] instanceof AST_Destructuring) {
-                out.push(...this.argnames[i].all_symbols());
-            } else {
-                out.push(this.argnames[i]);
-            }
-        }
-        return out;
-    },
-    _walk: function(visitor) {
-        return visitor._visit(this, function() {
-            if (this.name) this.name._walk(visitor);
-            var argnames = this.argnames;
-            for (var i = 0, len = argnames.length; i < len; i++) {
-                argnames[i]._walk(visitor);
-            }
-            walk_body(this, visitor);
-        });
-    },
-    _children_backwards(push) {
-        let i = this.body.length;
-        while (i--) push(this.body[i]);
-
-        i = this.argnames.length;
-        while (i--) push(this.argnames[i]);
-
-        if (this.name) push(this.name);
-    },
-    is_braceless() {
-        return this.body[0] instanceof AST_Return && this.body[0].value;
-    },
-    // Default args and expansion don't count, so .argnames.length doesn't cut it
-    length_property() {
-        let length = 0;
-
-        for (const arg of this.argnames) {
-            if (arg instanceof AST_SymbolFunarg || arg instanceof AST_Destructuring) {
-                length++;
-            }
+var AST_Lambda = DEFNODE(
+    "Lambda",
+    "name argnames uses_arguments is_generator async",
+    function AST_Lambda(props) {
+        if (props) {
+            this.name = props.name;
+            this.argnames = props.argnames;
+            this.uses_arguments = props.uses_arguments;
+            this.is_generator = props.is_generator;
+            this.async = props.async;
+            this.variables = props.variables;
+            this.functions = props.functions;
+            this.uses_with = props.uses_with;
+            this.uses_eval = props.uses_eval;
+            this.parent_scope = props.parent_scope;
+            this.enclosed = props.enclosed;
+            this.cname = props.cname;
+            this.body = props.body;
+            this.block_scope = props.block_scope;
+            this.start = props.start;
+            this.end = props.end;
         }
 
-        return length;
+        this.flags = 0;
+    },
+    {
+        $documentation: "Base class for functions",
+        $propdoc: {
+            name: "[AST_SymbolDeclaration?] the name of this function",
+            argnames: "[AST_SymbolFunarg|AST_Destructuring|AST_Expansion|AST_DefaultAssign*] array of function arguments, destructurings, or expanding arguments",
+            uses_arguments: "[boolean/S] tells whether this function accesses the arguments array",
+            is_generator: "[boolean] is this a generator method",
+            async: "[boolean] is this method async",
+        },
+        args_as_names: function () {
+            var out = [];
+            for (var i = 0; i < this.argnames.length; i++) {
+                if (this.argnames[i] instanceof AST_Destructuring) {
+                    out.push(...this.argnames[i].all_symbols());
+                } else {
+                    out.push(this.argnames[i]);
+                }
+            }
+            return out;
+        },
+        _walk: function(visitor) {
+            return visitor._visit(this, function() {
+                if (this.name) this.name._walk(visitor);
+                var argnames = this.argnames;
+                for (var i = 0, len = argnames.length; i < len; i++) {
+                    argnames[i]._walk(visitor);
+                }
+                walk_body(this, visitor);
+            });
+        },
+        _children_backwards(push) {
+            let i = this.body.length;
+            while (i--) push(this.body[i]);
+
+            i = this.argnames.length;
+            while (i--) push(this.argnames[i]);
+
+            if (this.name) push(this.name);
+        },
+        is_braceless() {
+            return this.body[0] instanceof AST_Return && this.body[0].value;
+        },
+        // Default args and expansion don't count, so .argnames.length doesn't cut it
+        length_property() {
+            let length = 0;
+
+            for (const arg of this.argnames) {
+                if (arg instanceof AST_SymbolFunarg || arg instanceof AST_Destructuring) {
+                    length++;
+                }
+            }
+
+            return length;
+        }
+    },
+    AST_Scope
+);
+
+var AST_Accessor = DEFNODE("Accessor", null, function AST_Accessor(props) {
+    if (props) {
+        this.name = props.name;
+        this.argnames = props.argnames;
+        this.uses_arguments = props.uses_arguments;
+        this.is_generator = props.is_generator;
+        this.async = props.async;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
     }
-}, AST_Scope);
 
-var AST_Accessor = DEFNODE("Accessor", null, {
+    this.flags = 0;
+}, {
     $documentation: "A setter/getter function.  The `name` property is always null."
 }, AST_Lambda);
 
-var AST_Function = DEFNODE("Function", null, {
+var AST_Function = DEFNODE("Function", null, function AST_Function(props) {
+    if (props) {
+        this.name = props.name;
+        this.argnames = props.argnames;
+        this.uses_arguments = props.uses_arguments;
+        this.is_generator = props.is_generator;
+        this.async = props.async;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A function expression"
 }, AST_Lambda);
 
-var AST_Arrow = DEFNODE("Arrow", null, {
+var AST_Arrow = DEFNODE("Arrow", null, function AST_Arrow(props) {
+    if (props) {
+        this.name = props.name;
+        this.argnames = props.argnames;
+        this.uses_arguments = props.uses_arguments;
+        this.is_generator = props.is_generator;
+        this.async = props.async;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An ES6 Arrow function ((a) => b)"
 }, AST_Lambda);
 
-var AST_Defun = DEFNODE("Defun", null, {
+var AST_Defun = DEFNODE("Defun", null, function AST_Defun(props) {
+    if (props) {
+        this.name = props.name;
+        this.argnames = props.argnames;
+        this.uses_arguments = props.uses_arguments;
+        this.is_generator = props.is_generator;
+        this.async = props.async;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A function definition"
 }, AST_Lambda);
 
 /* -----[ DESTRUCTURING ]----- */
-var AST_Destructuring = DEFNODE("Destructuring", "names is_array", {
+var AST_Destructuring = DEFNODE("Destructuring", "names is_array", function AST_Destructuring(props) {
+    if (props) {
+        this.names = props.names;
+        this.is_array = props.is_array;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A destructuring of several names. Used in destructuring assignment and with destructuring function argument names",
     $propdoc: {
         "names": "[AST_Node*] Array of properties or elements",
@@ -578,25 +904,47 @@ var AST_Destructuring = DEFNODE("Destructuring", "names is_array", {
     }
 });
 
-var AST_PrefixedTemplateString = DEFNODE("PrefixedTemplateString", "template_string prefix", {
-    $documentation: "A templatestring with a prefix, such as String.raw`foobarbaz`",
-    $propdoc: {
-        template_string: "[AST_TemplateString] The template string",
-        prefix: "[AST_Node] The prefix, which will get called."
-    },
-    _walk: function(visitor) {
-        return visitor._visit(this, function () {
-            this.prefix._walk(visitor);
-            this.template_string._walk(visitor);
-        });
-    },
-    _children_backwards(push) {
-        push(this.template_string);
-        push(this.prefix);
-    },
-});
+var AST_PrefixedTemplateString = DEFNODE(
+    "PrefixedTemplateString",
+    "template_string prefix",
+    function AST_PrefixedTemplateString(props) {
+        if (props) {
+            this.template_string = props.template_string;
+            this.prefix = props.prefix;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-var AST_TemplateString = DEFNODE("TemplateString", "segments", {
+        this.flags = 0;
+    },
+    {
+        $documentation: "A templatestring with a prefix, such as String.raw`foobarbaz`",
+        $propdoc: {
+            template_string: "[AST_TemplateString] The template string",
+            prefix: "[AST_Node] The prefix, which will get called."
+        },
+        _walk: function(visitor) {
+            return visitor._visit(this, function () {
+                this.prefix._walk(visitor);
+                this.template_string._walk(visitor);
+            });
+        },
+        _children_backwards(push) {
+            push(this.template_string);
+            push(this.prefix);
+        },
+    }
+);
+
+var AST_TemplateString = DEFNODE("TemplateString", "segments", function AST_TemplateString(props) {
+    if (props) {
+        this.segments = props.segments;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A template string literal",
     $propdoc: {
         segments: "[AST_Node*] One or more segments, starting with AST_TemplateSegment. AST_Node may follow AST_TemplateSegment, but each AST_Node must be followed by AST_TemplateSegment."
@@ -614,7 +962,16 @@ var AST_TemplateString = DEFNODE("TemplateString", "segments", {
     }
 });
 
-var AST_TemplateSegment = DEFNODE("TemplateSegment", "value raw", {
+var AST_TemplateSegment = DEFNODE("TemplateSegment", "value raw", function AST_TemplateSegment(props) {
+    if (props) {
+        this.value = props.value;
+        this.raw = props.raw;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A segment of a template string literal",
     $propdoc: {
         value: "Content of the segment",
@@ -624,11 +981,26 @@ var AST_TemplateSegment = DEFNODE("TemplateSegment", "value raw", {
 
 /* -----[ JUMPS ]----- */
 
-var AST_Jump = DEFNODE("Jump", null, {
+var AST_Jump = DEFNODE("Jump", null, function AST_Jump(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for “jumps” (for now that's `return`, `throw`, `break` and `continue`)"
 }, AST_Statement);
 
-var AST_Exit = DEFNODE("Exit", "value", {
+var AST_Exit = DEFNODE("Exit", "value", function AST_Exit(props) {
+    if (props) {
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for “exits” (`return` and `throw`)",
     $propdoc: {
         value: "[AST_Node?] the value returned or thrown by this statement; could be null for AST_Return"
@@ -643,15 +1015,39 @@ var AST_Exit = DEFNODE("Exit", "value", {
     },
 }, AST_Jump);
 
-var AST_Return = DEFNODE("Return", null, {
+var AST_Return = DEFNODE("Return", null, function AST_Return(props) {
+    if (props) {
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `return` statement"
 }, AST_Exit);
 
-var AST_Throw = DEFNODE("Throw", null, {
+var AST_Throw = DEFNODE("Throw", null, function AST_Throw(props) {
+    if (props) {
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `throw` statement"
 }, AST_Exit);
 
-var AST_LoopControl = DEFNODE("LoopControl", "label", {
+var AST_LoopControl = DEFNODE("LoopControl", "label", function AST_LoopControl(props) {
+    if (props) {
+        this.label = props.label;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for loop control statements (`break` and `continue`)",
     $propdoc: {
         label: "[AST_LabelRef?] the label, or null if none",
@@ -666,15 +1062,39 @@ var AST_LoopControl = DEFNODE("LoopControl", "label", {
     },
 }, AST_Jump);
 
-var AST_Break = DEFNODE("Break", null, {
+var AST_Break = DEFNODE("Break", null, function AST_Break(props) {
+    if (props) {
+        this.label = props.label;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `break` statement"
 }, AST_LoopControl);
 
-var AST_Continue = DEFNODE("Continue", null, {
+var AST_Continue = DEFNODE("Continue", null, function AST_Continue(props) {
+    if (props) {
+        this.label = props.label;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `continue` statement"
 }, AST_LoopControl);
 
-var AST_Await = DEFNODE("Await", "expression", {
+var AST_Await = DEFNODE("Await", "expression", function AST_Await(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An `await` statement",
     $propdoc: {
         expression: "[AST_Node] the mandatory expression being awaited",
@@ -689,7 +1109,16 @@ var AST_Await = DEFNODE("Await", "expression", {
     },
 });
 
-var AST_Yield = DEFNODE("Yield", "expression is_star", {
+var AST_Yield = DEFNODE("Yield", "expression is_star", function AST_Yield(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.is_star = props.is_star;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `yield` statement",
     $propdoc: {
         expression: "[AST_Node?] the value returned or thrown by this statement; could be null (representing undefined) but only when is_star is set to false",
@@ -707,7 +1136,17 @@ var AST_Yield = DEFNODE("Yield", "expression is_star", {
 
 /* -----[ IF ]----- */
 
-var AST_If = DEFNODE("If", "condition alternative", {
+var AST_If = DEFNODE("If", "condition alternative", function AST_If(props) {
+    if (props) {
+        this.condition = props.condition;
+        this.alternative = props.alternative;
+        this.body = props.body;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `if` statement",
     $propdoc: {
         condition: "[AST_Node] the `if` condition",
@@ -731,7 +1170,17 @@ var AST_If = DEFNODE("If", "condition alternative", {
 
 /* -----[ SWITCH ]----- */
 
-var AST_Switch = DEFNODE("Switch", "expression", {
+var AST_Switch = DEFNODE("Switch", "expression", function AST_Switch(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `switch` statement",
     $propdoc: {
         expression: "[AST_Node] the `switch` “discriminant”"
@@ -749,15 +1198,43 @@ var AST_Switch = DEFNODE("Switch", "expression", {
     }
 }, AST_Block);
 
-var AST_SwitchBranch = DEFNODE("SwitchBranch", null, {
+var AST_SwitchBranch = DEFNODE("SwitchBranch", null, function AST_SwitchBranch(props) {
+    if (props) {
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for `switch` branches",
 }, AST_Block);
 
-var AST_Default = DEFNODE("Default", null, {
+var AST_Default = DEFNODE("Default", null, function AST_Default(props) {
+    if (props) {
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `default` switch branch",
 }, AST_SwitchBranch);
 
-var AST_Case = DEFNODE("Case", "expression", {
+var AST_Case = DEFNODE("Case", "expression", function AST_Case(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `case` switch branch",
     $propdoc: {
         expression: "[AST_Node] the `case` expression"
@@ -777,7 +1254,18 @@ var AST_Case = DEFNODE("Case", "expression", {
 
 /* -----[ EXCEPTIONS ]----- */
 
-var AST_Try = DEFNODE("Try", "bcatch bfinally", {
+var AST_Try = DEFNODE("Try", "bcatch bfinally", function AST_Try(props) {
+    if (props) {
+        this.bcatch = props.bcatch;
+        this.bfinally = props.bfinally;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `try` statement",
     $propdoc: {
         bcatch: "[AST_Catch?] the catch block, or null if not present",
@@ -798,7 +1286,17 @@ var AST_Try = DEFNODE("Try", "bcatch bfinally", {
     },
 }, AST_Block);
 
-var AST_Catch = DEFNODE("Catch", "argname", {
+var AST_Catch = DEFNODE("Catch", "argname", function AST_Catch(props) {
+    if (props) {
+        this.argname = props.argname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `catch` node; only makes sense as part of a `try` statement",
     $propdoc: {
         argname: "[AST_SymbolCatch|AST_Destructuring|AST_Expansion|AST_DefaultAssign] symbol for the exception"
@@ -816,13 +1314,30 @@ var AST_Catch = DEFNODE("Catch", "argname", {
     },
 }, AST_Block);
 
-var AST_Finally = DEFNODE("Finally", null, {
+var AST_Finally = DEFNODE("Finally", null, function AST_Finally(props) {
+    if (props) {
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `finally` node; only makes sense as part of a `try` statement"
 }, AST_Block);
 
 /* -----[ VAR/CONST ]----- */
 
-var AST_Definitions = DEFNODE("Definitions", "definitions", {
+var AST_Definitions = DEFNODE("Definitions", "definitions", function AST_Definitions(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for `var` or `const` nodes (variable declarations/initializations)",
     $propdoc: {
         definitions: "[AST_VarDef*] array of variable definitions"
@@ -841,19 +1356,52 @@ var AST_Definitions = DEFNODE("Definitions", "definitions", {
     },
 }, AST_Statement);
 
-var AST_Var = DEFNODE("Var", null, {
+var AST_Var = DEFNODE("Var", null, function AST_Var(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `var` statement"
 }, AST_Definitions);
 
-var AST_Let = DEFNODE("Let", null, {
+var AST_Let = DEFNODE("Let", null, function AST_Let(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `let` statement"
 }, AST_Definitions);
 
-var AST_Const = DEFNODE("Const", null, {
+var AST_Const = DEFNODE("Const", null, function AST_Const(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
-var AST_VarDef = DEFNODE("VarDef", "name value", {
+var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
+    if (props) {
+        this.name = props.name;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A variable declaration; only appears in a AST_Definitions node",
     $propdoc: {
         name: "[AST_Destructuring|AST_SymbolConst|AST_SymbolLet|AST_SymbolVar] name of the variable",
@@ -871,7 +1419,16 @@ var AST_VarDef = DEFNODE("VarDef", "name value", {
     },
 });
 
-var AST_NameMapping = DEFNODE("NameMapping", "foreign_name name", {
+var AST_NameMapping = DEFNODE("NameMapping", "foreign_name name", function AST_NameMapping(props) {
+    if (props) {
+        this.foreign_name = props.foreign_name;
+        this.name = props.name;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The part of the export/import statement that declare names from a module.",
     $propdoc: {
         foreign_name: "[AST_SymbolExportForeign|AST_SymbolImportForeign] The name being exported/imported (as specified in the module)",
@@ -889,114 +1446,193 @@ var AST_NameMapping = DEFNODE("NameMapping", "foreign_name name", {
     },
 });
 
-var AST_Import = DEFNODE("Import", "imported_name imported_names module_name assert_clause", {
-    $documentation: "An `import` statement",
-    $propdoc: {
-        imported_name: "[AST_SymbolImport] The name of the variable holding the module's default export.",
-        imported_names: "[AST_NameMapping*] The names of non-default imported variables",
-        module_name: "[AST_String] String literal describing where this module came from",
-        assert_clause: "[AST_Object?] The import assertion"
-    },
-    _walk: function(visitor) {
-        return visitor._visit(this, function() {
-            if (this.imported_name) {
-                this.imported_name._walk(visitor);
-            }
-            if (this.imported_names) {
-                this.imported_names.forEach(function(name_import) {
-                    name_import._walk(visitor);
-                });
-            }
-            this.module_name._walk(visitor);
-        });
-    },
-    _children_backwards(push) {
-        push(this.module_name);
-        if (this.imported_names) {
-            let i = this.imported_names.length;
-            while (i--) push(this.imported_names[i]);
+var AST_Import = DEFNODE(
+    "Import",
+    "imported_name imported_names module_name assert_clause",
+    function AST_Import(props) {
+        if (props) {
+            this.imported_name = props.imported_name;
+            this.imported_names = props.imported_names;
+            this.module_name = props.module_name;
+            this.assert_clause = props.assert_clause;
+            this.start = props.start;
+            this.end = props.end;
         }
-        if (this.imported_name) push(this.imported_name);
-    },
-});
 
-var AST_ImportMeta = DEFNODE("ImportMeta", null, {
+        this.flags = 0;
+    },
+    {
+        $documentation: "An `import` statement",
+        $propdoc: {
+            imported_name: "[AST_SymbolImport] The name of the variable holding the module's default export.",
+            imported_names: "[AST_NameMapping*] The names of non-default imported variables",
+            module_name: "[AST_String] String literal describing where this module came from",
+            assert_clause: "[AST_Object?] The import assertion"
+        },
+        _walk: function(visitor) {
+            return visitor._visit(this, function() {
+                if (this.imported_name) {
+                    this.imported_name._walk(visitor);
+                }
+                if (this.imported_names) {
+                    this.imported_names.forEach(function(name_import) {
+                        name_import._walk(visitor);
+                    });
+                }
+                this.module_name._walk(visitor);
+            });
+        },
+        _children_backwards(push) {
+            push(this.module_name);
+            if (this.imported_names) {
+                let i = this.imported_names.length;
+                while (i--) push(this.imported_names[i]);
+            }
+            if (this.imported_name) push(this.imported_name);
+        },
+    }
+);
+
+var AST_ImportMeta = DEFNODE("ImportMeta", null, function AST_ImportMeta(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A reference to import.meta",
 });
 
-var AST_Export = DEFNODE("Export", "exported_definition exported_value is_default exported_names module_name assert_clause", {
-    $documentation: "An `export` statement",
-    $propdoc: {
-        exported_definition: "[AST_Defun|AST_Definitions|AST_DefClass?] An exported definition",
-        exported_value: "[AST_Node?] An exported value",
-        exported_names: "[AST_NameMapping*?] List of exported names",
-        module_name: "[AST_String?] Name of the file to load exports from",
-        is_default: "[Boolean] Whether this is the default exported value of this module",
-        assert_clause: "[AST_Object?] The import assertion"
-    },
-    _walk: function (visitor) {
-        return visitor._visit(this, function () {
-            if (this.exported_definition) {
-                this.exported_definition._walk(visitor);
-            }
-            if (this.exported_value) {
-                this.exported_value._walk(visitor);
-            }
-            if (this.exported_names) {
-                this.exported_names.forEach(function(name_export) {
-                    name_export._walk(visitor);
-                });
-            }
-            if (this.module_name) {
-                this.module_name._walk(visitor);
-            }
-        });
-    },
-    _children_backwards(push) {
-        if (this.module_name) push(this.module_name);
-        if (this.exported_names) {
-            let i = this.exported_names.length;
-            while (i--) push(this.exported_names[i]);
+var AST_Export = DEFNODE(
+    "Export",
+    "exported_definition exported_value is_default exported_names module_name assert_clause",
+    function AST_Export(props) {
+        if (props) {
+            this.exported_definition = props.exported_definition;
+            this.exported_value = props.exported_value;
+            this.is_default = props.is_default;
+            this.exported_names = props.exported_names;
+            this.module_name = props.module_name;
+            this.assert_clause = props.assert_clause;
+            this.start = props.start;
+            this.end = props.end;
         }
-        if (this.exported_value) push(this.exported_value);
-        if (this.exported_definition) push(this.exported_definition);
-    }
-}, AST_Statement);
+
+        this.flags = 0;
+    },
+    {
+        $documentation: "An `export` statement",
+        $propdoc: {
+            exported_definition: "[AST_Defun|AST_Definitions|AST_DefClass?] An exported definition",
+            exported_value: "[AST_Node?] An exported value",
+            exported_names: "[AST_NameMapping*?] List of exported names",
+            module_name: "[AST_String?] Name of the file to load exports from",
+            is_default: "[Boolean] Whether this is the default exported value of this module",
+            assert_clause: "[AST_Object?] The import assertion"
+        },
+        _walk: function (visitor) {
+            return visitor._visit(this, function () {
+                if (this.exported_definition) {
+                    this.exported_definition._walk(visitor);
+                }
+                if (this.exported_value) {
+                    this.exported_value._walk(visitor);
+                }
+                if (this.exported_names) {
+                    this.exported_names.forEach(function(name_export) {
+                        name_export._walk(visitor);
+                    });
+                }
+                if (this.module_name) {
+                    this.module_name._walk(visitor);
+                }
+            });
+        },
+        _children_backwards(push) {
+            if (this.module_name) push(this.module_name);
+            if (this.exported_names) {
+                let i = this.exported_names.length;
+                while (i--) push(this.exported_names[i]);
+            }
+            if (this.exported_value) push(this.exported_value);
+            if (this.exported_definition) push(this.exported_definition);
+        }
+    },
+    AST_Statement
+);
 
 /* -----[ OTHER ]----- */
 
-var AST_Call = DEFNODE("Call", "expression args optional _annotations", {
-    $documentation: "A function call expression",
-    $propdoc: {
-        expression: "[AST_Node] expression to invoke as function",
-        args: "[AST_Node*] array of arguments",
-        optional: "[boolean] whether this is an optional call (IE ?.() )",
-        _annotations: "[number] bitfield containing information about the call"
-    },
-    initialize() {
-        if (this._annotations == null) this._annotations = 0;
-    },
-    _walk(visitor) {
-        return visitor._visit(this, function() {
-            var args = this.args;
-            for (var i = 0, len = args.length; i < len; i++) {
-                args[i]._walk(visitor);
-            }
-            this.expression._walk(visitor);  // TODO why do we need to crawl this last?
-        });
-    },
-    _children_backwards(push) {
-        let i = this.args.length;
-        while (i--) push(this.args[i]);
-        push(this.expression);
-    },
-});
+var AST_Call = DEFNODE(
+    "Call",
+    "expression args optional _annotations",
+    function AST_Call(props) {
+        if (props) {
+            this.expression = props.expression;
+            this.args = props.args;
+            this.optional = props.optional;
+            this._annotations = props._annotations;
+            this.start = props.start;
+            this.end = props.end;
+            this.initialize();
+        }
 
-var AST_New = DEFNODE("New", null, {
+        this.flags = 0;
+    },
+    {
+        $documentation: "A function call expression",
+        $propdoc: {
+            expression: "[AST_Node] expression to invoke as function",
+            args: "[AST_Node*] array of arguments",
+            optional: "[boolean] whether this is an optional call (IE ?.() )",
+            _annotations: "[number] bitfield containing information about the call"
+        },
+        initialize() {
+            if (this._annotations == null) this._annotations = 0;
+        },
+        _walk(visitor) {
+            return visitor._visit(this, function() {
+                var args = this.args;
+                for (var i = 0, len = args.length; i < len; i++) {
+                    args[i]._walk(visitor);
+                }
+                this.expression._walk(visitor);  // TODO why do we need to crawl this last?
+            });
+        },
+        _children_backwards(push) {
+            let i = this.args.length;
+            while (i--) push(this.args[i]);
+            push(this.expression);
+        },
+    }
+);
+
+var AST_New = DEFNODE("New", null, function AST_New(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.args = props.args;
+        this.optional = props.optional;
+        this._annotations = props._annotations;
+        this.start = props.start;
+        this.end = props.end;
+        this.initialize();
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An object instantiation.  Derives from a function call since it has exactly the same properties"
 }, AST_Call);
 
-var AST_Sequence = DEFNODE("Sequence", "expressions", {
+var AST_Sequence = DEFNODE("Sequence", "expressions", function AST_Sequence(props) {
+    if (props) {
+        this.expressions = props.expressions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A sequence expression (comma-separated expressions)",
     $propdoc: {
         expressions: "[AST_Node*] array of expressions (at least two)"
@@ -1014,17 +1650,43 @@ var AST_Sequence = DEFNODE("Sequence", "expressions", {
     },
 });
 
-var AST_PropAccess = DEFNODE("PropAccess", "expression property optional", {
-    $documentation: "Base class for property access expressions, i.e. `a.foo` or `a[\"foo\"]`",
-    $propdoc: {
-        expression: "[AST_Node] the “container” expression",
-        property: "[AST_Node|string] the property to access.  For AST_Dot & AST_DotHash this is always a plain string, while for AST_Sub it's an arbitrary AST_Node",
+var AST_PropAccess = DEFNODE(
+    "PropAccess",
+    "expression property optional",
+    function AST_PropAccess(props) {
+        if (props) {
+            this.expression = props.expression;
+            this.property = props.property;
+            this.optional = props.optional;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-        optional: "[boolean] whether this is an optional property access (IE ?.)"
+        this.flags = 0;
+    },
+    {
+        $documentation: "Base class for property access expressions, i.e. `a.foo` or `a[\"foo\"]`",
+        $propdoc: {
+            expression: "[AST_Node] the “container” expression",
+            property: "[AST_Node|string] the property to access.  For AST_Dot & AST_DotHash this is always a plain string, while for AST_Sub it's an arbitrary AST_Node",
+
+            optional: "[boolean] whether this is an optional property access (IE ?.)"
+        }
     }
-});
+);
 
-var AST_Dot = DEFNODE("Dot", "quote", {
+var AST_Dot = DEFNODE("Dot", "quote", function AST_Dot(props) {
+    if (props) {
+        this.quote = props.quote;
+        this.expression = props.expression;
+        this.property = props.property;
+        this.optional = props.optional;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A dotted property access expression",
     $propdoc: {
         quote: "[string] the original quote character when transformed from AST_Sub",
@@ -1039,7 +1701,17 @@ var AST_Dot = DEFNODE("Dot", "quote", {
     },
 }, AST_PropAccess);
 
-var AST_DotHash = DEFNODE("DotHash", "", {
+var AST_DotHash = DEFNODE("DotHash", "", function AST_DotHash(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.property = props.property;
+        this.optional = props.optional;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A dotted property access to a private property",
     _walk: function(visitor) {
         return visitor._visit(this, function() {
@@ -1051,7 +1723,17 @@ var AST_DotHash = DEFNODE("DotHash", "", {
     },
 }, AST_PropAccess);
 
-var AST_Sub = DEFNODE("Sub", null, {
+var AST_Sub = DEFNODE("Sub", null, function AST_Sub(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.property = props.property;
+        this.optional = props.optional;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Index-style property access, i.e. `a[\"foo\"]`",
     _walk: function(visitor) {
         return visitor._visit(this, function() {
@@ -1065,7 +1747,15 @@ var AST_Sub = DEFNODE("Sub", null, {
     },
 }, AST_PropAccess);
 
-var AST_Chain = DEFNODE("Chain", "expression", {
+var AST_Chain = DEFNODE("Chain", "expression", function AST_Chain(props) {
+    if (props) {
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A chain expression like a?.b?.(c)?.[d]",
     $propdoc: {
         expression: "[AST_Call|AST_Dot|AST_DotHash|AST_Sub] chain element."
@@ -1080,7 +1770,16 @@ var AST_Chain = DEFNODE("Chain", "expression", {
     },
 });
 
-var AST_Unary = DEFNODE("Unary", "operator expression", {
+var AST_Unary = DEFNODE("Unary", "operator expression", function AST_Unary(props) {
+    if (props) {
+        this.operator = props.operator;
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for unary expressions",
     $propdoc: {
         operator: "[string] the operator",
@@ -1096,15 +1795,43 @@ var AST_Unary = DEFNODE("Unary", "operator expression", {
     },
 });
 
-var AST_UnaryPrefix = DEFNODE("UnaryPrefix", null, {
+var AST_UnaryPrefix = DEFNODE("UnaryPrefix", null, function AST_UnaryPrefix(props) {
+    if (props) {
+        this.operator = props.operator;
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Unary prefix expression, i.e. `typeof i` or `++i`"
 }, AST_Unary);
 
-var AST_UnaryPostfix = DEFNODE("UnaryPostfix", null, {
+var AST_UnaryPostfix = DEFNODE("UnaryPostfix", null, function AST_UnaryPostfix(props) {
+    if (props) {
+        this.operator = props.operator;
+        this.expression = props.expression;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Unary postfix expression, i.e. `i++`"
 }, AST_Unary);
 
-var AST_Binary = DEFNODE("Binary", "operator left right", {
+var AST_Binary = DEFNODE("Binary", "operator left right", function AST_Binary(props) {
+    if (props) {
+        this.operator = props.operator;
+        this.left = props.left;
+        this.right = props.right;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Binary expression, i.e. `a + b`",
     $propdoc: {
         left: "[AST_Node] left-hand side expression",
@@ -1123,41 +1850,85 @@ var AST_Binary = DEFNODE("Binary", "operator left right", {
     },
 });
 
-var AST_Conditional = DEFNODE("Conditional", "condition consequent alternative", {
-    $documentation: "Conditional expression using the ternary operator, i.e. `a ? b : c`",
-    $propdoc: {
-        condition: "[AST_Node]",
-        consequent: "[AST_Node]",
-        alternative: "[AST_Node]"
-    },
-    _walk: function(visitor) {
-        return visitor._visit(this, function() {
-            this.condition._walk(visitor);
-            this.consequent._walk(visitor);
-            this.alternative._walk(visitor);
-        });
-    },
-    _children_backwards(push) {
-        push(this.alternative);
-        push(this.consequent);
-        push(this.condition);
-    },
-});
+var AST_Conditional = DEFNODE(
+    "Conditional",
+    "condition consequent alternative",
+    function AST_Conditional(props) {
+        if (props) {
+            this.condition = props.condition;
+            this.consequent = props.consequent;
+            this.alternative = props.alternative;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-var AST_Assign = DEFNODE("Assign", "logical", {
+        this.flags = 0;
+    },
+    {
+        $documentation: "Conditional expression using the ternary operator, i.e. `a ? b : c`",
+        $propdoc: {
+            condition: "[AST_Node]",
+            consequent: "[AST_Node]",
+            alternative: "[AST_Node]"
+        },
+        _walk: function(visitor) {
+            return visitor._visit(this, function() {
+                this.condition._walk(visitor);
+                this.consequent._walk(visitor);
+                this.alternative._walk(visitor);
+            });
+        },
+        _children_backwards(push) {
+            push(this.alternative);
+            push(this.consequent);
+            push(this.condition);
+        },
+    }
+);
+
+var AST_Assign = DEFNODE("Assign", "logical", function AST_Assign(props) {
+    if (props) {
+        this.logical = props.logical;
+        this.operator = props.operator;
+        this.left = props.left;
+        this.right = props.right;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An assignment expression — `a = b + 5`",
     $propdoc: {
         logical: "Whether it's a logical assignment"
     }
 }, AST_Binary);
 
-var AST_DefaultAssign = DEFNODE("DefaultAssign", null, {
+var AST_DefaultAssign = DEFNODE("DefaultAssign", null, function AST_DefaultAssign(props) {
+    if (props) {
+        this.operator = props.operator;
+        this.left = props.left;
+        this.right = props.right;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A default assignment expression like in `(a = 3) => a`"
 }, AST_Binary);
 
 /* -----[ LITERALS ]----- */
 
-var AST_Array = DEFNODE("Array", "elements", {
+var AST_Array = DEFNODE("Array", "elements", function AST_Array(props) {
+    if (props) {
+        this.elements = props.elements;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An array literal",
     $propdoc: {
         elements: "[AST_Node*] array of elements"
@@ -1176,7 +1947,15 @@ var AST_Array = DEFNODE("Array", "elements", {
     },
 });
 
-var AST_Object = DEFNODE("Object", "properties", {
+var AST_Object = DEFNODE("Object", "properties", function AST_Object(props) {
+    if (props) {
+        this.properties = props.properties;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "An object literal",
     $propdoc: {
         properties: "[AST_ObjectProperty*] array of properties"
@@ -1195,7 +1974,16 @@ var AST_Object = DEFNODE("Object", "properties", {
     },
 });
 
-var AST_ObjectProperty = DEFNODE("ObjectProperty", "key value", {
+var AST_ObjectProperty = DEFNODE("ObjectProperty", "key value", function AST_ObjectProperty(props) {
+    if (props) {
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for literal object properties",
     $propdoc: {
         key: "[string|AST_Node] property name. For ObjectKeyVal this is a string. For getters, setters and computed property this is an AST_Node.",
@@ -1214,7 +2002,17 @@ var AST_ObjectProperty = DEFNODE("ObjectProperty", "key value", {
     }
 });
 
-var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote", {
+var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote", function AST_ObjectKeyVal(props) {
+    if (props) {
+        this.quote = props.quote;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A key: value object property",
     $propdoc: {
         quote: "[string] the original quote character"
@@ -1224,7 +2022,17 @@ var AST_ObjectKeyVal = DEFNODE("ObjectKeyVal", "quote", {
     }
 }, AST_ObjectProperty);
 
-var AST_PrivateSetter = DEFNODE("PrivateSetter", "static", {
+var AST_PrivateSetter = DEFNODE("PrivateSetter", "static", function AST_PrivateSetter(props) {
+    if (props) {
+        this.static = props.static;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         static: "[boolean] whether this is a static private setter"
     },
@@ -1234,7 +2042,17 @@ var AST_PrivateSetter = DEFNODE("PrivateSetter", "static", {
     }
 }, AST_ObjectProperty);
 
-var AST_PrivateGetter = DEFNODE("PrivateGetter", "static", {
+var AST_PrivateGetter = DEFNODE("PrivateGetter", "static", function AST_PrivateGetter(props) {
+    if (props) {
+        this.static = props.static;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         static: "[boolean] whether this is a static private getter"
     },
@@ -1244,7 +2062,18 @@ var AST_PrivateGetter = DEFNODE("PrivateGetter", "static", {
     }
 }, AST_ObjectProperty);
 
-var AST_ObjectSetter = DEFNODE("ObjectSetter", "quote static", {
+var AST_ObjectSetter = DEFNODE("ObjectSetter", "quote static", function AST_ObjectSetter(props) {
+    if (props) {
+        this.quote = props.quote;
+        this.static = props.static;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         quote: "[string|undefined] the original quote character, if any",
         static: "[boolean] whether this is a static setter (classes only)"
@@ -1255,7 +2084,18 @@ var AST_ObjectSetter = DEFNODE("ObjectSetter", "quote static", {
     }
 }, AST_ObjectProperty);
 
-var AST_ObjectGetter = DEFNODE("ObjectGetter", "quote static", {
+var AST_ObjectGetter = DEFNODE("ObjectGetter", "quote static", function AST_ObjectGetter(props) {
+    if (props) {
+        this.quote = props.quote;
+        this.static = props.static;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         quote: "[string|undefined] the original quote character, if any",
         static: "[boolean] whether this is a static getter (classes only)"
@@ -1266,24 +2106,75 @@ var AST_ObjectGetter = DEFNODE("ObjectGetter", "quote static", {
     }
 }, AST_ObjectProperty);
 
-var AST_ConciseMethod = DEFNODE("ConciseMethod", "quote static is_generator async", {
-    $propdoc: {
-        quote: "[string|undefined] the original quote character, if any",
-        static: "[boolean] is this method static (classes only)",
-        is_generator: "[boolean] is this a generator method",
-        async: "[boolean] is this method async",
-    },
-    $documentation: "An ES6 concise method inside an object or class",
-    computed_key() {
-        return !(this.key instanceof AST_SymbolMethod);
-    }
-}, AST_ObjectProperty);
+var AST_ConciseMethod = DEFNODE(
+    "ConciseMethod",
+    "quote static is_generator async",
+    function AST_ConciseMethod(props) {
+        if (props) {
+            this.quote = props.quote;
+            this.static = props.static;
+            this.is_generator = props.is_generator;
+            this.async = props.async;
+            this.key = props.key;
+            this.value = props.value;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-var AST_PrivateMethod = DEFNODE("PrivateMethod", "", {
+        this.flags = 0;
+    },
+    {
+        $propdoc: {
+            quote: "[string|undefined] the original quote character, if any",
+            static: "[boolean] is this method static (classes only)",
+            is_generator: "[boolean] is this a generator method",
+            async: "[boolean] is this method async",
+        },
+        $documentation: "An ES6 concise method inside an object or class",
+        computed_key() {
+            return !(this.key instanceof AST_SymbolMethod);
+        }
+    },
+    AST_ObjectProperty
+);
+
+var AST_PrivateMethod = DEFNODE("PrivateMethod", "", function AST_PrivateMethod(props) {
+    if (props) {
+        this.quote = props.quote;
+        this.static = props.static;
+        this.is_generator = props.is_generator;
+        this.async = props.async;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A private class method inside a class",
 }, AST_ConciseMethod);
 
-var AST_Class = DEFNODE("Class", "name extends properties", {
+var AST_Class = DEFNODE("Class", "name extends properties", function AST_Class(props) {
+    if (props) {
+        this.name = props.name;
+        this.extends = props.extends;
+        this.properties = props.properties;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         name: "[AST_SymbolClass|AST_SymbolDefClass?] optional class name.",
         extends: "[AST_Node]? optional parent class",
@@ -1309,7 +2200,18 @@ var AST_Class = DEFNODE("Class", "name extends properties", {
     },
 }, AST_Scope /* TODO a class might have a scope but it's not a scope */);
 
-var AST_ClassProperty = DEFNODE("ClassProperty", "static quote", {
+var AST_ClassProperty = DEFNODE("ClassProperty", "static quote", function AST_ClassProperty(props) {
+    if (props) {
+        this.static = props.static;
+        this.quote = props.quote;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A class property",
     $propdoc: {
         static: "[boolean] whether this is a static key",
@@ -1332,19 +2234,78 @@ var AST_ClassProperty = DEFNODE("ClassProperty", "static quote", {
     }
 }, AST_ObjectProperty);
 
-var AST_ClassPrivateProperty = DEFNODE("ClassPrivateProperty", "", {
+var AST_ClassPrivateProperty = DEFNODE("ClassPrivateProperty", "", function AST_ClassPrivateProperty(props) {
+    if (props) {
+        this.static = props.static;
+        this.quote = props.quote;
+        this.key = props.key;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A class property for a private property",
 }, AST_ClassProperty);
 
-var AST_DefClass = DEFNODE("DefClass", null, {
+var AST_DefClass = DEFNODE("DefClass", null, function AST_DefClass(props) {
+    if (props) {
+        this.name = props.name;
+        this.extends = props.extends;
+        this.properties = props.properties;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A class definition",
 }, AST_Class);
 
-var AST_ClassExpression = DEFNODE("ClassExpression", null, {
+var AST_ClassExpression = DEFNODE("ClassExpression", null, function AST_ClassExpression(props) {
+    if (props) {
+        this.name = props.name;
+        this.extends = props.extends;
+        this.properties = props.properties;
+        this.variables = props.variables;
+        this.functions = props.functions;
+        this.uses_with = props.uses_with;
+        this.uses_eval = props.uses_eval;
+        this.parent_scope = props.parent_scope;
+        this.enclosed = props.enclosed;
+        this.cname = props.cname;
+        this.body = props.body;
+        this.block_scope = props.block_scope;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A class expression."
 }, AST_Class);
 
-var AST_Symbol = DEFNODE("Symbol", "scope name thedef", {
+var AST_Symbol = DEFNODE("Symbol", "scope name thedef", function AST_Symbol(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $propdoc: {
         name: "[string] name of this symbol",
         scope: "[AST_Scope/S] the current scope (not necessarily the definition scope)",
@@ -1353,71 +2314,258 @@ var AST_Symbol = DEFNODE("Symbol", "scope name thedef", {
     $documentation: "Base class for all symbols"
 });
 
-var AST_NewTarget = DEFNODE("NewTarget", null, {
+var AST_NewTarget = DEFNODE("NewTarget", null, function AST_NewTarget(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A reference to new.target"
 });
 
-var AST_SymbolDeclaration = DEFNODE("SymbolDeclaration", "init", {
+var AST_SymbolDeclaration = DEFNODE("SymbolDeclaration", "init", function AST_SymbolDeclaration(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A declaration symbol (symbol in var/const, function name or argument, symbol in catch)",
 }, AST_Symbol);
 
-var AST_SymbolVar = DEFNODE("SymbolVar", null, {
+var AST_SymbolVar = DEFNODE("SymbolVar", null, function AST_SymbolVar(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol defining a variable",
 }, AST_SymbolDeclaration);
 
-var AST_SymbolBlockDeclaration = DEFNODE("SymbolBlockDeclaration", null, {
-    $documentation: "Base class for block-scoped declaration symbols"
-}, AST_SymbolDeclaration);
+var AST_SymbolBlockDeclaration = DEFNODE(
+    "SymbolBlockDeclaration",
+    null,
+    function AST_SymbolBlockDeclaration(props) {
+        if (props) {
+            this.init = props.init;
+            this.scope = props.scope;
+            this.name = props.name;
+            this.thedef = props.thedef;
+            this.start = props.start;
+            this.end = props.end;
+        }
 
-var AST_SymbolConst = DEFNODE("SymbolConst", null, {
+        this.flags = 0;
+    },
+    {
+        $documentation: "Base class for block-scoped declaration symbols"
+    },
+    AST_SymbolDeclaration
+);
+
+var AST_SymbolConst = DEFNODE("SymbolConst", null, function AST_SymbolConst(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A constant declaration"
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolLet = DEFNODE("SymbolLet", null, {
+var AST_SymbolLet = DEFNODE("SymbolLet", null, function AST_SymbolLet(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A block-scoped `let` declaration"
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolFunarg = DEFNODE("SymbolFunarg", null, {
+var AST_SymbolFunarg = DEFNODE("SymbolFunarg", null, function AST_SymbolFunarg(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming a function argument",
 }, AST_SymbolVar);
 
-var AST_SymbolDefun = DEFNODE("SymbolDefun", null, {
+var AST_SymbolDefun = DEFNODE("SymbolDefun", null, function AST_SymbolDefun(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol defining a function",
 }, AST_SymbolDeclaration);
 
-var AST_SymbolMethod = DEFNODE("SymbolMethod", null, {
+var AST_SymbolMethod = DEFNODE("SymbolMethod", null, function AST_SymbolMethod(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol in an object defining a method",
 }, AST_Symbol);
 
-var AST_SymbolClassProperty = DEFNODE("SymbolClassProperty", null, {
+var AST_SymbolClassProperty = DEFNODE("SymbolClassProperty", null, function AST_SymbolClassProperty(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol for a class property",
 }, AST_Symbol);
 
-var AST_SymbolLambda = DEFNODE("SymbolLambda", null, {
+var AST_SymbolLambda = DEFNODE("SymbolLambda", null, function AST_SymbolLambda(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming a function expression",
 }, AST_SymbolDeclaration);
 
-var AST_SymbolDefClass = DEFNODE("SymbolDefClass", null, {
+var AST_SymbolDefClass = DEFNODE("SymbolDefClass", null, function AST_SymbolDefClass(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming a class's name in a class declaration. Lexically scoped to its containing scope, and accessible within the class."
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolClass = DEFNODE("SymbolClass", null, {
+var AST_SymbolClass = DEFNODE("SymbolClass", null, function AST_SymbolClass(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming a class's name. Lexically scoped to the class."
 }, AST_SymbolDeclaration);
 
-var AST_SymbolCatch = DEFNODE("SymbolCatch", null, {
+var AST_SymbolCatch = DEFNODE("SymbolCatch", null, function AST_SymbolCatch(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming the exception in catch",
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolImport = DEFNODE("SymbolImport", null, {
+var AST_SymbolImport = DEFNODE("SymbolImport", null, function AST_SymbolImport(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol referring to an imported name",
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolImportForeign = DEFNODE("SymbolImportForeign", null, {
+var AST_SymbolImportForeign = DEFNODE("SymbolImportForeign", null, function AST_SymbolImportForeign(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A symbol imported from a module, but it is defined in the other module, and its real name is irrelevant for this module's purposes",
 }, AST_Symbol);
 
-var AST_Label = DEFNODE("Label", "references", {
+var AST_Label = DEFNODE("Label", "references", function AST_Label(props) {
+    if (props) {
+        this.references = props.references;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+        this.initialize();
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol naming a label (declaration)",
     $propdoc: {
         references: "[AST_LoopControl*] a list of nodes referring to this label"
@@ -1428,38 +2576,114 @@ var AST_Label = DEFNODE("Label", "references", {
     }
 }, AST_Symbol);
 
-var AST_SymbolRef = DEFNODE("SymbolRef", null, {
+var AST_SymbolRef = DEFNODE("SymbolRef", null, function AST_SymbolRef(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Reference to some symbol (not definition/declaration)",
 }, AST_Symbol);
 
-var AST_SymbolExport = DEFNODE("SymbolExport", null, {
+var AST_SymbolExport = DEFNODE("SymbolExport", null, function AST_SymbolExport(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Symbol referring to a name to export",
 }, AST_SymbolRef);
 
-var AST_SymbolExportForeign = DEFNODE("SymbolExportForeign", null, {
+var AST_SymbolExportForeign = DEFNODE("SymbolExportForeign", null, function AST_SymbolExportForeign(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A symbol exported from this module, but it is used in the other module, and its real name is irrelevant for this module's purposes",
 }, AST_Symbol);
 
-var AST_LabelRef = DEFNODE("LabelRef", null, {
+var AST_LabelRef = DEFNODE("LabelRef", null, function AST_LabelRef(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Reference to a label symbol",
 }, AST_Symbol);
 
-var AST_This = DEFNODE("This", null, {
+var AST_This = DEFNODE("This", null, function AST_This(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `this` symbol",
 }, AST_Symbol);
 
-var AST_Super = DEFNODE("Super", null, {
+var AST_Super = DEFNODE("Super", null, function AST_Super(props) {
+    if (props) {
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `super` symbol",
 }, AST_This);
 
-var AST_Constant = DEFNODE("Constant", null, {
+var AST_Constant = DEFNODE("Constant", null, function AST_Constant(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for all constants",
     getValue: function() {
         return this.value;
     }
 });
 
-var AST_String = DEFNODE("String", "value quote", {
+var AST_String = DEFNODE("String", "value quote", function AST_String(props) {
+    if (props) {
+        this.value = props.value;
+        this.quote = props.quote;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A string literal",
     $propdoc: {
         value: "[string] the contents of this string",
@@ -1467,7 +2691,16 @@ var AST_String = DEFNODE("String", "value quote", {
     }
 }, AST_Constant);
 
-var AST_Number = DEFNODE("Number", "value raw", {
+var AST_Number = DEFNODE("Number", "value raw", function AST_Number(props) {
+    if (props) {
+        this.value = props.value;
+        this.raw = props.raw;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A number literal",
     $propdoc: {
         value: "[number] the numeric value",
@@ -1475,59 +2708,138 @@ var AST_Number = DEFNODE("Number", "value raw", {
     }
 }, AST_Constant);
 
-var AST_BigInt = DEFNODE("BigInt", "value", {
+var AST_BigInt = DEFNODE("BigInt", "value", function AST_BigInt(props) {
+    if (props) {
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A big int literal",
     $propdoc: {
         value: "[string] big int value"
     }
 }, AST_Constant);
 
-var AST_RegExp = DEFNODE("RegExp", "value", {
+var AST_RegExp = DEFNODE("RegExp", "value", function AST_RegExp(props) {
+    if (props) {
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A regexp literal",
     $propdoc: {
         value: "[RegExp] the actual regexp",
     }
 }, AST_Constant);
 
-var AST_Atom = DEFNODE("Atom", null, {
+var AST_Atom = DEFNODE("Atom", null, function AST_Atom(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for atoms",
 }, AST_Constant);
 
-var AST_Null = DEFNODE("Null", null, {
+var AST_Null = DEFNODE("Null", null, function AST_Null(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `null` atom",
     value: null
 }, AST_Atom);
 
-var AST_NaN = DEFNODE("NaN", null, {
+var AST_NaN = DEFNODE("NaN", null, function AST_NaN(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The impossible value",
     value: 0/0
 }, AST_Atom);
 
-var AST_Undefined = DEFNODE("Undefined", null, {
+var AST_Undefined = DEFNODE("Undefined", null, function AST_Undefined(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `undefined` value",
     value: (function() {}())
 }, AST_Atom);
 
-var AST_Hole = DEFNODE("Hole", null, {
+var AST_Hole = DEFNODE("Hole", null, function AST_Hole(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "A hole in an array",
     value: (function() {}())
 }, AST_Atom);
 
-var AST_Infinity = DEFNODE("Infinity", null, {
+var AST_Infinity = DEFNODE("Infinity", null, function AST_Infinity(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `Infinity` value",
     value: 1/0
 }, AST_Atom);
 
-var AST_Boolean = DEFNODE("Boolean", null, {
+var AST_Boolean = DEFNODE("Boolean", null, function AST_Boolean(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "Base class for booleans",
 }, AST_Atom);
 
-var AST_False = DEFNODE("False", null, {
+var AST_False = DEFNODE("False", null, function AST_False(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `false` atom",
     value: false
 }, AST_Boolean);
 
-var AST_True = DEFNODE("True", null, {
+var AST_True = DEFNODE("True", null, function AST_True(props) {
+    if (props) {
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
     $documentation: "The `true` atom",
     value: true
 }, AST_Boolean);

--- a/lib/equivalent-to.js
+++ b/lib/equivalent-to.js
@@ -97,24 +97,6 @@ export const equivalent_to = (tree1, tree2) => {
     return walk_1_state.length == 0 && walk_2_state.length == 0;
 };
 
-// Creates a shallow compare function
-const mkshallow = (props) => {
-    const comparisons = Object
-        .keys(props)
-        .map(key => {
-            if (props[key] === "eq") {
-                return `this.${key} === other.${key}`;
-            } else if (props[key] === "exist") {
-                return `(this.${key} == null ? other.${key} == null : this.${key} === other.${key})`;
-            } else {
-                throw new Error(`mkshallow: Unexpected instruction: ${props[key]}`);
-            }
-        })
-        .join(" && ");
-
-    return new Function("other", "return " + comparisons);
-};
-
 const pass_through = () => true;
 
 AST_Node.prototype.shallow_cmp = function () {
@@ -123,7 +105,9 @@ AST_Node.prototype.shallow_cmp = function () {
 
 AST_Debugger.prototype.shallow_cmp = pass_through;
 
-AST_Directive.prototype.shallow_cmp = mkshallow({ value: "eq" });
+AST_Directive.prototype.shallow_cmp = function(other) {
+    return this.value === other.value;
+};
 
 AST_SimpleStatement.prototype.shallow_cmp = pass_through;
 
@@ -131,17 +115,17 @@ AST_Block.prototype.shallow_cmp = pass_through;
 
 AST_EmptyStatement.prototype.shallow_cmp = pass_through;
 
-AST_LabeledStatement.prototype.shallow_cmp = mkshallow({ "label.name": "eq" });
+AST_LabeledStatement.prototype.shallow_cmp = function(other) {
+    return this.label.name === other.label.name;
+};
 
 AST_Do.prototype.shallow_cmp = pass_through;
 
 AST_While.prototype.shallow_cmp = pass_through;
 
-AST_For.prototype.shallow_cmp = mkshallow({
-    init: "exist",
-    condition: "exist",
-    step: "exist"
-});
+AST_For.prototype.shallow_cmp = function(other) {
+    return (this.init == null ? other.init == null : this.init === other.init) && (this.condition == null ? other.condition == null : this.condition === other.condition) && (this.step == null ? other.step == null : this.step === other.step);
+};
 
 AST_ForIn.prototype.shallow_cmp = pass_through;
 
@@ -153,22 +137,21 @@ AST_Toplevel.prototype.shallow_cmp = pass_through;
 
 AST_Expansion.prototype.shallow_cmp = pass_through;
 
-AST_Lambda.prototype.shallow_cmp = mkshallow({
-    is_generator: "eq",
-    async: "eq"
-});
+AST_Lambda.prototype.shallow_cmp = function(other) {
+    return this.is_generator === other.is_generator && this.async === other.async;
+};
 
-AST_Destructuring.prototype.shallow_cmp = mkshallow({
-    is_array: "eq"
-});
+AST_Destructuring.prototype.shallow_cmp = function(other) {
+    return this.is_array === other.is_array;
+};
 
 AST_PrefixedTemplateString.prototype.shallow_cmp = pass_through;
 
 AST_TemplateString.prototype.shallow_cmp = pass_through;
 
-AST_TemplateSegment.prototype.shallow_cmp = mkshallow({
-    "value": "eq"
-});
+AST_TemplateSegment.prototype.shallow_cmp = function(other) {
+    return this.value === other.value;
+};
 
 AST_Jump.prototype.shallow_cmp = pass_through;
 
@@ -176,51 +159,45 @@ AST_LoopControl.prototype.shallow_cmp = pass_through;
 
 AST_Await.prototype.shallow_cmp = pass_through;
 
-AST_Yield.prototype.shallow_cmp = mkshallow({
-    is_star: "eq"
-});
+AST_Yield.prototype.shallow_cmp = function(other) {
+    return this.is_star === other.is_star;
+};
 
-AST_If.prototype.shallow_cmp = mkshallow({
-    alternative: "exist"
-});
+AST_If.prototype.shallow_cmp = function(other) {
+    return this.alternative == null ? other.alternative == null : this.alternative === other.alternative;
+};
 
 AST_Switch.prototype.shallow_cmp = pass_through;
 
 AST_SwitchBranch.prototype.shallow_cmp = pass_through;
 
-AST_Try.prototype.shallow_cmp = mkshallow({
-    bcatch: "exist",
-    bfinally: "exist"
-});
+AST_Try.prototype.shallow_cmp = function(other) {
+    return (this.bcatch == null ? other.bcatch == null : this.bcatch === other.bcatch) && (this.bfinally == null ? other.bfinally == null : this.bfinally === other.bfinally);
+};
 
-AST_Catch.prototype.shallow_cmp = mkshallow({
-    argname: "exist"
-});
+AST_Catch.prototype.shallow_cmp = function(other) {
+    return this.argname == null ? other.argname == null : this.argname === other.argname;
+};
 
 AST_Finally.prototype.shallow_cmp = pass_through;
 
 AST_Definitions.prototype.shallow_cmp = pass_through;
 
-AST_VarDef.prototype.shallow_cmp = mkshallow({
-    value: "exist"
-});
+AST_VarDef.prototype.shallow_cmp = function(other) {
+    return this.value == null ? other.value == null : this.value === other.value;
+};
 
 AST_NameMapping.prototype.shallow_cmp = pass_through;
 
-AST_Import.prototype.shallow_cmp = mkshallow({
-    imported_name: "exist",
-    imported_names: "exist"
-});
+AST_Import.prototype.shallow_cmp = function(other) {
+    return (this.imported_name == null ? other.imported_name == null : this.imported_name === other.imported_name) && (this.imported_names == null ? other.imported_names == null : this.imported_names === other.imported_names);
+};
 
 AST_ImportMeta.prototype.shallow_cmp = pass_through;
 
-AST_Export.prototype.shallow_cmp = mkshallow({
-    exported_definition: "exist",
-    exported_value: "exist",
-    exported_names: "exist",
-    module_name: "eq",
-    is_default: "eq",
-});
+AST_Export.prototype.shallow_cmp = function(other) {
+    return (this.exported_definition == null ? other.exported_definition == null : this.exported_definition === other.exported_definition) && (this.exported_value == null ? other.exported_value == null : this.exported_value === other.exported_value) && (this.exported_names == null ? other.exported_names == null : this.exported_names === other.exported_names) && this.module_name === other.module_name && this.is_default === other.is_default;
+};
 
 AST_Call.prototype.shallow_cmp = pass_through;
 
@@ -230,21 +207,21 @@ AST_PropAccess.prototype.shallow_cmp = pass_through;
 
 AST_Chain.prototype.shallow_cmp = pass_through;
 
-AST_Dot.prototype.shallow_cmp = mkshallow({
-    property: "eq"
-});
+AST_Dot.prototype.shallow_cmp = function(other) {
+    return this.property === other.property;
+};
 
-AST_DotHash.prototype.shallow_cmp = mkshallow({
-    property: "eq"
-});
+AST_DotHash.prototype.shallow_cmp = function(other) {
+    return this.property === other.property;
+};
 
-AST_Unary.prototype.shallow_cmp = mkshallow({
-    operator: "eq"
-});
+AST_Unary.prototype.shallow_cmp = function(other) {
+    return this.operator === other.operator;
+};
 
-AST_Binary.prototype.shallow_cmp = mkshallow({
-    operator: "eq"
-});
+AST_Binary.prototype.shallow_cmp = function(other) {
+    return this.operator === other.operator;
+};
 
 AST_Conditional.prototype.shallow_cmp = pass_through;
 
@@ -254,36 +231,33 @@ AST_Object.prototype.shallow_cmp = pass_through;
 
 AST_ObjectProperty.prototype.shallow_cmp = pass_through;
 
-AST_ObjectKeyVal.prototype.shallow_cmp = mkshallow({
-    key: "eq"
-});
+AST_ObjectKeyVal.prototype.shallow_cmp = function(other) {
+    return this.key === other.key;
+};
 
-AST_ObjectSetter.prototype.shallow_cmp = mkshallow({
-    static: "eq"
-});
+AST_ObjectSetter.prototype.shallow_cmp = function(other) {
+    return this.static === other.static;
+};
 
-AST_ObjectGetter.prototype.shallow_cmp = mkshallow({
-    static: "eq"
-});
+AST_ObjectGetter.prototype.shallow_cmp = function(other) {
+    return this.static === other.static;
+};
 
-AST_ConciseMethod.prototype.shallow_cmp = mkshallow({
-    static: "eq",
-    is_generator: "eq",
-    async: "eq",
-});
+AST_ConciseMethod.prototype.shallow_cmp = function(other) {
+    return this.static === other.static && this.is_generator === other.is_generator && this.async === other.async;
+};
 
-AST_Class.prototype.shallow_cmp = mkshallow({
-    name: "exist",
-    extends: "exist",
-});
+AST_Class.prototype.shallow_cmp = function(other) {
+    return (this.name == null ? other.name == null : this.name === other.name) && (this.extends == null ? other.extends == null : this.extends === other.extends);
+};
 
-AST_ClassProperty.prototype.shallow_cmp = mkshallow({
-    static: "eq"
-});
+AST_ClassProperty.prototype.shallow_cmp = function(other) {
+    return this.static === other.static;
+};
 
-AST_Symbol.prototype.shallow_cmp = mkshallow({
-    name: "eq"
-});
+AST_Symbol.prototype.shallow_cmp = function(other) {
+    return this.name === other.name;
+};
 
 AST_NewTarget.prototype.shallow_cmp = pass_through;
 
@@ -291,17 +265,17 @@ AST_This.prototype.shallow_cmp = pass_through;
 
 AST_Super.prototype.shallow_cmp = pass_through;
 
-AST_String.prototype.shallow_cmp = mkshallow({
-    value: "eq"
-});
+AST_String.prototype.shallow_cmp = function(other) {
+    return this.value === other.value;
+};
 
-AST_Number.prototype.shallow_cmp = mkshallow({
-    value: "eq"
-});
+AST_Number.prototype.shallow_cmp = function(other) {
+    return this.value === other.value;
+};
 
-AST_BigInt.prototype.shallow_cmp = mkshallow({
-    value: "eq"
-});
+AST_BigInt.prototype.shallow_cmp = function(other) {
+    return this.value === other.value;
+};
 
 AST_RegExp.prototype.shallow_cmp = function (other) {
     return (

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -41,7 +41,6 @@
 
  ***********************************************************************/
 
-import * as ast from "./ast.js";
 import { make_node } from "./utils/index.js";
 import {
     AST_Accessor,
@@ -206,6 +205,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 body: normalize_directives(M.body.map(from_moz))
             });
         },
+
         ArrayPattern: function(M) {
             return new AST_Destructuring({
                 start: my_start_token(M),
@@ -219,6 +219,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 is_array: true
             });
         },
+
         ObjectPattern: function(M) {
             return new AST_Destructuring({
                 start: my_start_token(M),
@@ -227,6 +228,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 is_array: false
             });
         },
+
         AssignmentPattern: function(M) {
             return new AST_DefaultAssign({
                 start: my_start_token(M),
@@ -236,6 +238,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 right: from_moz(M.right)
             });
         },
+
         SpreadElement: function(M) {
             return new AST_Expansion({
                 start: my_start_token(M),
@@ -243,6 +246,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 expression: from_moz(M.argument)
             });
         },
+
         RestElement: function(M) {
             return new AST_Expansion({
                 start: my_start_token(M),
@@ -250,6 +254,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 expression: from_moz(M.argument)
             });
         },
+
         TemplateElement: function(M) {
             return new AST_TemplateSegment({
                 start: my_start_token(M),
@@ -258,6 +263,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 raw: M.value.raw
             });
         },
+
         TemplateLiteral: function(M) {
             var segments = [];
             for (var i = 0; i < M.quasis.length; i++) {
@@ -272,6 +278,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 segments: segments
             });
         },
+
         TaggedTemplateExpression: function(M) {
             return new AST_PrefixedTemplateString({
                 start: my_start_token(M),
@@ -280,6 +287,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 prefix: from_moz(M.tag)
             });
         },
+
         FunctionDeclaration: function(M) {
             return new AST_Defun({
                 start: my_start_token(M),
@@ -291,6 +299,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 body: normalize_directives(from_moz(M.body).body)
             });
         },
+
         FunctionExpression: function(M) {
             return new AST_Function({
                 start: my_start_token(M),
@@ -302,6 +311,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 body: normalize_directives(from_moz(M.body).body)
             });
         },
+
         ArrowFunctionExpression: function(M) {
             const body = M.body.type === "BlockStatement"
                 ? from_moz(M.body).body
@@ -314,6 +324,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 async: M.async,
             });
         },
+
         ExpressionStatement: function(M) {
             return new AST_SimpleStatement({
                 start: my_start_token(M),
@@ -321,6 +332,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 body: from_moz(M.expression)
             });
         },
+
         TryStatement: function(M) {
             var handlers = M.handlers || [M.handler];
             if (handlers.length > 1 || M.guardedHandlers && M.guardedHandlers.length) {
@@ -334,6 +346,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 bfinally : M.finalizer ? new AST_Finally(from_moz(M.finalizer)) : null
             });
         },
+
         Property: function(M) {
             var key = M.key;
             var args = {
@@ -376,6 +389,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 return new AST_ConciseMethod(args);
             }
         },
+
         MethodDefinition: function(M) {
             var args = {
                 start    : my_start_token(M),
@@ -394,6 +408,7 @@ import { is_basic_identifier_string } from "./parse.js";
             args.async = M.value.async;
             return new AST_ConciseMethod(args);
         },
+
         FieldDefinition: function(M) {
             let key;
             if (M.computed) {
@@ -410,6 +425,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 static   : M.static,
             });
         },
+
         PropertyDefinition: function(M) {
             let key;
             if (M.computed) {
@@ -427,6 +443,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 static   : M.static,
             });
         },
+
         ArrayExpression: function(M) {
             return new AST_Array({
                 start    : my_start_token(M),
@@ -436,6 +453,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 })
             });
         },
+
         ObjectExpression: function(M) {
             return new AST_Object({
                 start      : my_start_token(M),
@@ -449,6 +467,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 })
             });
         },
+
         SequenceExpression: function(M) {
             return new AST_Sequence({
                 start      : my_start_token(M),
@@ -456,6 +475,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 expressions: M.expressions.map(from_moz)
             });
         },
+
         MemberExpression: function(M) {
             return new (M.computed ? AST_Sub : AST_Dot)({
                 start      : my_start_token(M),
@@ -465,6 +485,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 optional   : M.optional || false
             });
         },
+
         ChainExpression: function(M) {
             return new AST_Chain({
                 start      : my_start_token(M),
@@ -472,6 +493,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 expression : from_moz(M.expression)
             });
         },
+
         SwitchCase: function(M) {
             return new (M.test ? AST_Case : AST_Default)({
                 start      : my_start_token(M),
@@ -480,6 +502,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 body       : M.consequent.map(from_moz)
             });
         },
+
         VariableDeclaration: function(M) {
             return new (M.kind === "const" ? AST_Const :
                         M.kind === "let" ? AST_Let : AST_Var)({
@@ -522,6 +545,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 assert_clause: assert_clause_from_moz(M.assertions)
             });
         },
+
         ExportAllDeclaration: function(M) {
             return new AST_Export({
                 start: my_start_token(M),
@@ -536,6 +560,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 assert_clause: assert_clause_from_moz(M.assertions)
             });
         },
+
         ExportNamedDeclaration: function(M) {
             return new AST_Export({
                 start: my_start_token(M),
@@ -551,6 +576,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 assert_clause: assert_clause_from_moz(M.assertions)
             });
         },
+
         ExportDefaultDeclaration: function(M) {
             return new AST_Export({
                 start: my_start_token(M),
@@ -559,6 +585,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 is_default: true
             });
         },
+
         Literal: function(M) {
             var val = M.value, args = {
                 start  : my_start_token(M),
@@ -594,6 +621,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 return new (val ? AST_True : AST_False)(args);
             }
         },
+
         MetaProperty: function(M) {
             if (M.meta.name === "new" && M.property.name === "target") {
                 return new AST_NewTarget({
@@ -607,6 +635,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 });
             }
         },
+
         Identifier: function(M) {
             var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
             return new (  p.type == "LabeledStatement" ? AST_Label
@@ -629,11 +658,261 @@ import { is_basic_identifier_string } from "./parse.js";
                             name  : M.name
                         });
         },
+
         BigIntLiteral(M) {
             return new AST_BigInt({
                 start : my_start_token(M),
                 end   : my_end_token(M),
                 value : M.value
+            });
+        },
+
+        EmptyStatement: function(M) {
+            return new AST_EmptyStatement({
+                start: my_start_token(M),
+                end: my_end_token(M)
+            });
+        },
+
+        BlockStatement: function(M) {
+            return new AST_BlockStatement({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                body: M.body.map(from_moz)
+            });
+        },
+
+        IfStatement: function(M) {
+            return new AST_If({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                condition: from_moz(M.test),
+                body: from_moz(M.consequent),
+                alternative: from_moz(M.alternate)
+            });
+        },
+
+        LabeledStatement: function(M) {
+            return new AST_LabeledStatement({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                label: from_moz(M.label),
+                body: from_moz(M.body)
+            });
+        },
+
+        BreakStatement: function(M) {
+            return new AST_Break({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                label: from_moz(M.label)
+            });
+        },
+
+        ContinueStatement: function(M) {
+            return new AST_Continue({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                label: from_moz(M.label)
+            });
+        },
+
+        WithStatement: function(M) {
+            return new AST_With({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.object),
+                body: from_moz(M.body)
+            });
+        },
+
+        SwitchStatement: function(M) {
+            return new AST_Switch({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.discriminant),
+                body: M.cases.map(from_moz)
+            });
+        },
+
+        ReturnStatement: function(M) {
+            return new AST_Return({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                value: from_moz(M.argument)
+            });
+        },
+
+        ThrowStatement: function(M) {
+            return new AST_Throw({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                value: from_moz(M.argument)
+            });
+        },
+
+        WhileStatement: function(M) {
+            return new AST_While({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                condition: from_moz(M.test),
+                body: from_moz(M.body)
+            });
+        },
+
+        DoWhileStatement: function(M) {
+            return new AST_Do({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                condition: from_moz(M.test),
+                body: from_moz(M.body)
+            });
+        },
+
+        ForStatement: function(M) {
+            return new AST_For({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                init: from_moz(M.init),
+                condition: from_moz(M.test),
+                step: from_moz(M.update),
+                body: from_moz(M.body)
+            });
+        },
+
+        ForInStatement: function(M) {
+            return new AST_ForIn({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                init: from_moz(M.left),
+                object: from_moz(M.right),
+                body: from_moz(M.body)
+            });
+        },
+
+        ForOfStatement: function(M) {
+            return new AST_ForOf({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                init: from_moz(M.left),
+                object: from_moz(M.right),
+                body: from_moz(M.body),
+                await: M.await
+            });
+        },
+
+        AwaitExpression: function(M) {
+            return new AST_Await({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.argument)
+            });
+        },
+
+        YieldExpression: function(M) {
+            return new AST_Yield({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.argument),
+                is_star: M.delegate
+            });
+        },
+
+        DebuggerStatement: function(M) {
+            return new AST_Debugger({
+                start: my_start_token(M),
+                end: my_end_token(M)
+            });
+        },
+
+        VariableDeclarator: function(M) {
+            return new AST_VarDef({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                name: from_moz(M.id),
+                value: from_moz(M.init)
+            });
+        },
+
+        CatchClause: function(M) {
+            return new AST_Catch({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                argname: from_moz(M.param),
+                body: from_moz(M.body).body
+            });
+        },
+
+        ThisExpression: function(M) {
+            return new AST_This({
+                start: my_start_token(M),
+                end: my_end_token(M)
+            });
+        },
+
+        Super: function(M) {
+            return new AST_Super({
+                start: my_start_token(M),
+                end: my_end_token(M)
+            });
+        },
+
+        BinaryExpression: function(M) {
+            return new AST_Binary({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                operator: M.operator,
+                left: from_moz(M.left),
+                right: from_moz(M.right)
+            });
+        },
+
+        LogicalExpression: function(M) {
+            return new AST_Binary({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                operator: M.operator,
+                left: from_moz(M.left),
+                right: from_moz(M.right)
+            });
+        },
+
+        AssignmentExpression: function(M) {
+            return new AST_Assign({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                operator: M.operator,
+                left: from_moz(M.left),
+                right: from_moz(M.right)
+            });
+        },
+
+        ConditionalExpression: function(M) {
+            return new AST_Conditional({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                condition: from_moz(M.test),
+                consequent: from_moz(M.consequent),
+                alternative: from_moz(M.alternate)
+            });
+        },
+
+        NewExpression: function(M) {
+            return new AST_New({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.callee),
+                args: M.arguments.map(from_moz)
+            });
+        },
+
+        CallExpression: function(M) {
+            return new AST_Call({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                expression: from_moz(M.callee),
+                optional: M.optional,
+                args: M.arguments.map(from_moz)
             });
         }
     };
@@ -661,35 +940,200 @@ import { is_basic_identifier_string } from "./parse.js";
         });
     };
 
-    map("EmptyStatement", AST_EmptyStatement);
-    map("BlockStatement", AST_BlockStatement, "body@body");
-    map("IfStatement", AST_If, "test>condition, consequent>body, alternate>alternative");
-    map("LabeledStatement", AST_LabeledStatement, "label>label, body>body");
-    map("BreakStatement", AST_Break, "label>label");
-    map("ContinueStatement", AST_Continue, "label>label");
-    map("WithStatement", AST_With, "object>expression, body>body");
-    map("SwitchStatement", AST_Switch, "discriminant>expression, cases@body");
-    map("ReturnStatement", AST_Return, "argument>value");
-    map("ThrowStatement", AST_Throw, "argument>value");
-    map("WhileStatement", AST_While, "test>condition, body>body");
-    map("DoWhileStatement", AST_Do, "test>condition, body>body");
-    map("ForStatement", AST_For, "init>init, test>condition, update>step, body>body");
-    map("ForInStatement", AST_ForIn, "left>init, right>object, body>body");
-    map("ForOfStatement", AST_ForOf, "left>init, right>object, body>body, await=await");
-    map("AwaitExpression", AST_Await, "argument>expression");
-    map("YieldExpression", AST_Yield, "argument>expression, delegate=is_star");
-    map("DebuggerStatement", AST_Debugger);
-    map("VariableDeclarator", AST_VarDef, "id>name, init>value");
-    map("CatchClause", AST_Catch, "param>argname, body%body");
+    def_to_moz(AST_EmptyStatement, function To_Moz_EmptyStatement() {
+        return {
+            type: "EmptyStatement"
+        };
+    });
+    def_to_moz(AST_BlockStatement, function To_Moz_BlockStatement(M) {
+        return {
+            type: "BlockStatement",
+            body: M.body.map(to_moz)
+        };
+    });
+    def_to_moz(AST_If, function To_Moz_IfStatement(M) {
+        return {
+            type: "IfStatement",
+            test: to_moz(M.condition),
+            consequent: to_moz(M.body),
+            alternate: to_moz(M.alternative)
+        };
+    });
+    def_to_moz(AST_LabeledStatement, function To_Moz_LabeledStatement(M) {
+        return {
+            type: "LabeledStatement",
+            label: to_moz(M.label),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_Break, function To_Moz_BreakStatement(M) {
+        return {
+            type: "BreakStatement",
+            label: to_moz(M.label)
+        };
+    });
+    def_to_moz(AST_Continue, function To_Moz_ContinueStatement(M) {
+        return {
+            type: "ContinueStatement",
+            label: to_moz(M.label)
+        };
+    });
+    def_to_moz(AST_With, function To_Moz_WithStatement(M) {
+        return {
+            type: "WithStatement",
+            object: to_moz(M.expression),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_Switch, function To_Moz_SwitchStatement(M) {
+        return {
+            type: "SwitchStatement",
+            discriminant: to_moz(M.expression),
+            cases: M.body.map(to_moz)
+        };
+    });
+    def_to_moz(AST_Return, function To_Moz_ReturnStatement(M) {
+        return {
+            type: "ReturnStatement",
+            argument: to_moz(M.value)
+        };
+    });
+    def_to_moz(AST_Throw, function To_Moz_ThrowStatement(M) {
+        return {
+            type: "ThrowStatement",
+            argument: to_moz(M.value)
+        };
+    });
+    def_to_moz(AST_While, function To_Moz_WhileStatement(M) {
+        return {
+            type: "WhileStatement",
+            test: to_moz(M.condition),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_Do, function To_Moz_DoWhileStatement(M) {
+        return {
+            type: "DoWhileStatement",
+            test: to_moz(M.condition),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_For, function To_Moz_ForStatement(M) {
+        return {
+            type: "ForStatement",
+            init: to_moz(M.init),
+            test: to_moz(M.condition),
+            update: to_moz(M.step),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_ForIn, function To_Moz_ForInStatement(M) {
+        return {
+            type: "ForInStatement",
+            left: to_moz(M.init),
+            right: to_moz(M.object),
+            body: to_moz(M.body)
+        };
+    });
+    def_to_moz(AST_ForOf, function To_Moz_ForOfStatement(M) {
+        return {
+            type: "ForOfStatement",
+            left: to_moz(M.init),
+            right: to_moz(M.object),
+            body: to_moz(M.body),
+            await: M.await
+        };
+    });
+    def_to_moz(AST_Await, function To_Moz_AwaitExpression(M) {
+        return {
+            type: "AwaitExpression",
+            argument: to_moz(M.expression)
+        };
+    });
+    def_to_moz(AST_Yield, function To_Moz_YieldExpression(M) {
+        return {
+            type: "YieldExpression",
+            argument: to_moz(M.expression),
+            delegate: M.is_star
+        };
+    });
+    def_to_moz(AST_Debugger, function To_Moz_DebuggerStatement() {
+        return {
+            type: "DebuggerStatement"
+        };
+    });
+    def_to_moz(AST_VarDef, function To_Moz_VariableDeclarator(M) {
+        return {
+            type: "VariableDeclarator",
+            id: to_moz(M.name),
+            init: to_moz(M.value)
+        };
+    });
+    def_to_moz(AST_Catch, function To_Moz_CatchClause(M) {
+        return {
+            type: "CatchClause",
+            param: to_moz(M.argname),
+            body: to_moz_block(M)
+        };
+    });
 
-    map("ThisExpression", AST_This);
-    map("Super", AST_Super);
-    map("BinaryExpression", AST_Binary, "operator=operator, left>left, right>right");
-    map("LogicalExpression", AST_Binary, "operator=operator, left>left, right>right");
-    map("AssignmentExpression", AST_Assign, "operator=operator, left>left, right>right");
-    map("ConditionalExpression", AST_Conditional, "test>condition, consequent>consequent, alternate>alternative");
-    map("NewExpression", AST_New, "callee>expression, arguments@args");
-    map("CallExpression", AST_Call, "callee>expression, optional=optional, arguments@args");
+    def_to_moz(AST_This, function To_Moz_ThisExpression() {
+        return {
+            type: "ThisExpression"
+        };
+    });
+    def_to_moz(AST_Super, function To_Moz_Super() {
+        return {
+            type: "Super"
+        };
+    });
+    def_to_moz(AST_Binary, function To_Moz_BinaryExpression(M) {
+        return {
+            type: "BinaryExpression",
+            operator: M.operator,
+            left: to_moz(M.left),
+            right: to_moz(M.right)
+        };
+    });
+    def_to_moz(AST_Binary, function To_Moz_LogicalExpression(M) {
+        return {
+            type: "LogicalExpression",
+            operator: M.operator,
+            left: to_moz(M.left),
+            right: to_moz(M.right)
+        };
+    });
+    def_to_moz(AST_Assign, function To_Moz_AssignmentExpression(M) {
+        return {
+            type: "AssignmentExpression",
+            operator: M.operator,
+            left: to_moz(M.left),
+            right: to_moz(M.right)
+        };
+    });
+    def_to_moz(AST_Conditional, function To_Moz_ConditionalExpression(M) {
+        return {
+            type: "ConditionalExpression",
+            test: to_moz(M.condition),
+            consequent: to_moz(M.consequent),
+            alternate: to_moz(M.alternative)
+        };
+    });
+    def_to_moz(AST_New, function To_Moz_NewExpression(M) {
+        return {
+            type: "NewExpression",
+            callee: to_moz(M.expression),
+            arguments: M.args.map(to_moz)
+        };
+    });
+    def_to_moz(AST_Call, function To_Moz_CallExpression(M) {
+        return {
+            type: "CallExpression",
+            callee: to_moz(M.expression),
+            optional: M.optional,
+            arguments: M.args.map(to_moz)
+        };
+    });
 
     def_to_moz(AST_Toplevel, function To_Moz_Program(M) {
         return to_moz_scope("Program", M);
@@ -1238,57 +1682,6 @@ import { is_basic_identifier_string } from "./parse.js";
             [],
             loc && loc.source,
         );
-    }
-
-    function map(moztype, mytype, propmap) {
-        var moz_to_me = "function From_Moz_" + moztype + "(M){\n";
-        moz_to_me += "return new U2." + mytype.name + "({\n" +
-            "start: my_start_token(M),\n" +
-            "end: my_end_token(M)";
-
-        var me_to_moz = "function To_Moz_" + moztype + "(M){\n";
-        me_to_moz += "return {\n" +
-            "type: " + JSON.stringify(moztype);
-
-        if (propmap) propmap.split(/\s*,\s*/).forEach(function(prop) {
-            var m = /([a-z0-9$_]+)([=@>%])([a-z0-9$_]+)/i.exec(prop);
-            if (!m) throw new Error("Can't understand property map: " + prop);
-            var moz = m[1], how = m[2], my = m[3];
-            moz_to_me += ",\n" + my + ": ";
-            me_to_moz += ",\n" + moz + ": ";
-            switch (how) {
-                case "@":
-                    moz_to_me += "M." + moz + ".map(from_moz)";
-                    me_to_moz += "M." +  my + ".map(to_moz)";
-                    break;
-                case ">":
-                    moz_to_me += "from_moz(M." + moz + ")";
-                    me_to_moz += "to_moz(M." + my + ")";
-                    break;
-                case "=":
-                    moz_to_me += "M." + moz;
-                    me_to_moz += "M." + my;
-                    break;
-                case "%":
-                    moz_to_me += "from_moz(M." + moz + ").body";
-                    me_to_moz += "to_moz_block(M)";
-                    break;
-                default:
-                    throw new Error("Can't understand operator in propmap: " + prop);
-            }
-        });
-
-        moz_to_me += "\n})\n}";
-        me_to_moz += "\n}\n}";
-
-        moz_to_me = new Function("U2", "my_start_token", "my_end_token", "from_moz", "return(" + moz_to_me + ")")(
-            ast, my_start_token, my_end_token, from_moz
-        );
-        me_to_moz = new Function("to_moz", "to_moz_block", "to_moz_scope", "return(" + me_to_moz + ")")(
-            to_moz, to_moz_block, to_moz_scope
-        );
-        MOZ_TO_ME[moztype] = moz_to_me;
-        def_to_moz(mytype, me_to_moz);
     }
 
     var FROM_MOZ_STACK = null;


### PR DESCRIPTION
Remove all the places where code is built as a string and then evaled to make a function. This improves compatibility with runtimes where eval is banned.

The codeshift does the minimal set of changes to make this work, and I have manually fixed a couple of things after running the codeshift.

* Fix the DEFNODE function for the new param order.
* Remove the map/mkshallow functions.

The source for the codeshift is here: https://github.com/sgoo/ast-fixer

I did have a go at replacing the calls to DEFNODE with `class` declarations, I got the code to run, but I got test failures where the minified output was slightly wrong, I'm not sure what caused that.
My results from that attempt are here: https://github.com/sgoo/ast-fixer/commit/f77472eeb89b96925034d43f305203e642f099b3

Fixes #925