### PR TITLE
Remove last new Function() call

### DIFF
--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -78,7 +78,7 @@ function find_builtins(reserved) {
     var global_ref = typeof global === "object" ? global : self;
 
     new_globals.forEach(function (new_global) {
-        objects[new_global] = global_ref[new_global] || new Function();
+        objects[new_global] = global_ref[new_global] || function() {};
     });
 
     [


### PR DESCRIPTION
This is treated as an eval call by V8, and can't be executed in environments where eval is blocked.

Fixes #925