### PR TITLE
include types export for ts4.7 nodenext resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     ".": [
       {
         "import": "./main.js",
-        "require": "./dist/bundle.min.js"
+        "require": "./dist/bundle.min.js",
+        "types": "tools/terser.d.ts"
       },
       "./dist/bundle.min.js"
     ],


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/47792#issuecomment-1043819482

otherwise, building with nodenext resolution results in:
```
.yarn/__virtual__/terser-webpack-plugin-virtual-7ea69a4a8a/2/.yarn/berry/cache/terser-webpack-plugin-npm-5.3.1-0c0596f996-9.zip/node_modules/terser-webpack-plugin/types/index.d.ts:116:39 - error TS7016: Could not find a declaration file for module 'terser'. '/home/lizf/.yarn/berry/cache/terser-npm-5.7.2-c24448e930-9.zip/node_modules/terser/dist/bundle.min.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/terser` if it exists or add a new declaration (.d.ts) file containing `declare module 'terser';`

116 declare class TerserPlugin<T = import("terser").MinifyOptions> {
                                          ~~~~~~~~

.yarn/__virtual__/terser-webpack-plugin-virtual-7ea69a4a8a/2/.yarn/berry/cache/terser-webpack-plugin-npm-5.3.1-0c0596f996-9.zip/node_modules/terser-webpack-plugin/types/index.d.ts:293:17 - error TS7016: Could not find a declaration file for module 'terser'. '/home/lizf/.yarn/berry/cache/terser-npm-5.7.2-c24448e930-9.zip/node_modules/terser/dist/bundle.min.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/terser` if it exists or add a new declaration (.d.ts) file containing `declare module 'terser';`

293   ecma?: import("terser").ECMA | undefined;
                    ~~~~~~~~

.yarn/__virtual__/terser-webpack-plugin-virtual-7ea69a4a8a/2/.yarn/berry/cache/terser-webpack-plugin-npm-5.3.1-0c0596f996-9.zip/node_modules/terser-webpack-plugin/types/utils.d.ts:3:42 - error TS7016: Could not find a declaration file for module 'terser'. '/home/lizf/.yarn/berry/cache/terser-npm-5.7.2-c24448e930-9.zip/node_modules/terser/dist/bundle.min.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/terser` if it exists or add a new declaration (.d.ts) file containing `declare module 'terser';`

3 export type TerserFormatOptions = import("terser").FormatOptions;
                                           ~~~~~~~~

.yarn/__virtual__/terser-webpack-plugin-virtual-7ea69a4a8a/2/.yarn/berry/cache/terser-webpack-plugin-npm-5.3.1-0c0596f996-9.zip/node_modules/terser-webpack-plugin/types/utils.d.ts:4:36 - error TS7016: Could not find a declaration file for module 'terser'. '/home/lizf/.yarn/berry/cache/terser-npm-5.7.2-c24448e930-9.zip/node_modules/terser/dist/bundle.min.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/terser` if it exists or add a new declaration (.d.ts) file containing `declare module 'terser';`

4 export type TerserOptions = import("terser").MinifyOptions;
                                     ~~~~~~~~

.yarn/__virtual__/terser-webpack-plugin-virtual-7ea69a4a8a/2/.yarn/berry/cache/terser-webpack-plugin-npm-5.3.1-0c0596f996-9.zip/node_modules/terser-webpack-plugin/types/utils.d.ts:5:33 - error TS7016: Could not find a declaration file for module 'terser'. '/home/lizf/.yarn/berry/cache/terser-npm-5.7.2-c24448e930-9.zip/node_modules/terser/dist/bundle.min.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/terser` if it exists or add a new declaration (.d.ts) file containing `declare module 'terser';`

5 export type TerserECMA = import("terser").ECMA;
                                  ~~~~~~~~

```