### PR TITLE
fix: throw error when using private field in an object (#1011)

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2442,7 +2442,9 @@ function parse($TEXT, options) {
                 }));
                 continue;
             }
-
+            if(is("privatename")) {
+                croak("private fields are not allowed in an object");
+            }
             var name = as_property_name();
             var value;
 

--- a/test/compress/syntax-errors.js
+++ b/test/compress/syntax-errors.js
@@ -332,3 +332,18 @@ big_int_scientific_format: {
         col: 8
     })
 }
+
+invalid_privatename_in_object: {
+    input: `
+        const myObject = {
+            foo: 'bar',
+            #something: 5,
+        }
+    `
+    expect_error: ({
+        name: "SyntaxError",
+        message: "private fields are not allowed in an object",
+        line: 4,
+        col: 12
+    })
+}


### PR DESCRIPTION
Fix Issue #1011 

I don't know if I add test case in the correct place. Maybe I should put the test case in `test/compress/issue-1011.js`?
