### PR TITLE
Fix/issue 1124

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1041,7 +1041,7 @@ var PRECEDENCE = (function(a, ret) {
     {}
 );
 
-var ATOMIC_START_TOKEN = makePredicate([ "atom", "num", "big_int", "string", "regexp", "name" ]);
+var ATOMIC_START_TOKEN = makePredicate([ "atom", "num", "big_int", "string", "regexp", "name", "privatename"]);
 
 /* -----[ Parser ]----- */
 
@@ -1213,6 +1213,9 @@ function parse($TEXT, options) {
             return simple_statement();
 
           case "name":
+          case "privatename":
+            if(is("privatename") && !S.in_class)
+                croak("Private field must be declared in an enclosing class");
             if (S.token.value == "async" && is_token(peek(), "keyword", "function")) {
                 next();
                 next();
@@ -2176,6 +2179,11 @@ function parse($TEXT, options) {
           case "name":
             ret = _make_symbol(AST_SymbolRef);
             break;
+          case "privatename":
+            if(!S.in_class) 
+                croak("Private field must be declared in an enclosing class");
+            ret = _make_symbol(AST_SymbolRef);
+            break;
           case "num":
             ret = new AST_Number({
                 start: tok,
@@ -2518,7 +2526,8 @@ function parse($TEXT, options) {
         }
 
         expect("{");
-
+        // mark in class feild,
+        S.in_class = true;
         while (is("punc", ";")) { next(); }  // Leading semicolons are okay in class bodies.
         while (!is("punc", "}")) {
             start = S.token;
@@ -2527,6 +2536,8 @@ function parse($TEXT, options) {
             a.push(method);
             while (is("punc", ";")) { next(); }
         }
+        // mark in class feild,
+        S.in_class = false;
 
         S.input.pop_directives_stack();
 
@@ -3033,6 +3044,8 @@ function parse($TEXT, options) {
         var start = expr.start;
         if (is("punc", ".")) {
             next();
+            if(is("privatename") && !S.in_class) 
+                croak("Private field must be declared in an enclosing class");
             const AST_DotVariant = is("privatename") ? AST_DotHash : AST_Dot;
             return subscripts(new AST_DotVariant({
                 start      : start,
@@ -3086,6 +3099,8 @@ function parse($TEXT, options) {
 
                 chain_contents = subscripts(call, true, true);
             } else if (is("name") || is("privatename")) {
+                if(is("privatename") && !S.in_class) 
+                    croak("Private field must be declared in an enclosing class");
                 const AST_DotVariant = is("privatename") ? AST_DotHash : AST_Dot;
                 chain_contents = subscripts(new AST_DotVariant({
                     start,
@@ -3131,7 +3146,6 @@ function parse($TEXT, options) {
                 end: prev()
             }), allow_calls);
         }
-
         return expr;
     };
 
@@ -3206,6 +3220,9 @@ function parse($TEXT, options) {
             && left.operator !== "--" && left.operator !== "++")
                 unexpected(left.start);
         var prec = op != null ? PRECEDENCE[op] : null;
+        // #<privatename> without subscription should only legel in `#<privatename> in <expression>` when exist in class feild.
+        if(left instanceof AST_SymbolRef && left.start.type === "privatename" && S.in_class && op !== "in")
+            croak("Unexpected privatename token");
         if (prec != null && (prec > min_prec || (op === "**" && min_prec === prec))) {
             next();
             var right = expr_op(maybe_unary(true), prec, no_in);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1215,7 +1215,7 @@ function parse($TEXT, options) {
           case "name":
           case "privatename":
             if(is("privatename") && !S.in_class)
-                croak("Private field must be declared in an enclosing class");
+                croak("Private field must be used in an enclosing class");
             if (S.token.value == "async" && is_token(peek(), "keyword", "function")) {
                 next();
                 next();
@@ -2181,7 +2181,7 @@ function parse($TEXT, options) {
             break;
           case "privatename":
             if(!S.in_class) 
-                croak("Private field must be declared in an enclosing class");
+                croak("Private field must be used in an enclosing class");
             ret = _make_symbol(AST_SymbolRef);
             break;
           case "num":
@@ -3045,7 +3045,7 @@ function parse($TEXT, options) {
         if (is("punc", ".")) {
             next();
             if(is("privatename") && !S.in_class) 
-                croak("Private field must be declared in an enclosing class");
+                croak("Private field must be used in an enclosing class");
             const AST_DotVariant = is("privatename") ? AST_DotHash : AST_Dot;
             return subscripts(new AST_DotVariant({
                 start      : start,
@@ -3100,7 +3100,7 @@ function parse($TEXT, options) {
                 chain_contents = subscripts(call, true, true);
             } else if (is("name") || is("privatename")) {
                 if(is("privatename") && !S.in_class) 
-                    croak("Private field must be declared in an enclosing class");
+                    croak("Private field must be used in an enclosing class");
                 const AST_DotVariant = is("privatename") ? AST_DotHash : AST_Dot;
                 chain_contents = subscripts(new AST_DotVariant({
                     start,
@@ -3220,7 +3220,7 @@ function parse($TEXT, options) {
             && left.operator !== "--" && left.operator !== "++")
                 unexpected(left.start);
         var prec = op != null ? PRECEDENCE[op] : null;
-        // #<privatename> without subscription should only legel in `#<privatename> in <expression>` when exist in class feild.
+        // #<privatename> without subscription is only legal in `#<privatename> in <expression>` when inside a class.
         if(left instanceof AST_SymbolRef && left.start.type === "privatename" && S.in_class && op !== "in")
             croak("Unexpected privatename token");
         if (prec != null && (prec > min_prec || (op === "**" && min_prec === prec))) {

--- a/test/compress/class-properties.js
+++ b/test/compress/class-properties.js
@@ -344,15 +344,6 @@ optional_chaining_private_fields: {
     // expect_stdout: "PASS" // < tested in chrome, fails with nodejs 14 (current LTS)
 }
 
-tolerate_out_of_class_private_fields: {
-    no_mozilla_ast = true;
-    node_version = ">=12"
-    input: {
-        Bar.#foo = "bad"
-    }
-    expect_exact: 'Bar.#foo="bad";'
-}
-
 private_properties_can_be_mangled: {
     no_mozilla_ast = true;
     node_version = ">=12"
@@ -454,4 +445,41 @@ nested_private_properties_can_be_mangled: {
         }
         new X().log();
     }
+}
+
+allow_private_field_with_in_operator : {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    mangle = {
+        properties: true
+    }
+    input: {
+        class A {
+            #p;
+            isA (input) {
+                #p in input; 
+                #p in this;
+                return #p in this; 
+            }
+        }
+    }
+    expect:{class A{#i;i(i){p in i;p in this;return p in this}}}
+}
+
+allow_subscript_private_field: {
+    no_mozilla_ast = true;
+    node_version = ">=12"
+    mangle = {
+        properties: true
+    }
+    input: {
+        class A {
+            #p;
+            isA (input) {
+                console.log(input.#p);
+                return this.#p; 
+            }
+        }
+    }
+    expect: {class A{#s;i(s){console.log(s.#s);return this.#s}}}
 }

--- a/test/compress/syntax-errors.js
+++ b/test/compress/syntax-errors.js
@@ -347,3 +347,50 @@ invalid_privatename_in_object: {
         col: 12
     })
 }
+
+private_field_out_of_class_field: {
+    input: `
+        function test() {
+            return this.#p;
+        }
+    `
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Private field must be declared in an enclosing class",
+        line: 3,
+        col: 24
+    })
+}
+
+private_field_out_of_class_field_in_operator: {
+    input: `
+        function test(input) {
+            #p in input;
+            return 10;
+        }
+    `
+    expect_error:({
+        name: "SyntaxError",
+        message: "Private field must be declared in an enclosing class",
+        line: 3,
+        col: 12
+    })
+}
+
+invaild__in_operator_expression_in_class_field: {
+    input: `
+        class A {
+            #p;
+            isA () { 
+                #p + 10;
+                return this.#p;
+            } 
+        }
+    `
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected privatename token",
+        line: 5,
+        col: 19
+    })
+}


### PR DESCRIPTION
fix issue #1124 

---

I fix this issue by adding a context to determine if the current expression is under the class field. if is true, then it is legal to use an `in` operator with `privatename` token. if is false. parse would throw an error.

And I find a problem is that terser allow `parse` function to accept private field even out of class field, which should be a syntax error. so I add a condition to `subscripts` function to determine if the current subscript is under class feild. if is true, parse would parse it correctly, if is false it would throw an error.

To pass the test, I delete one test from `/compress/class-properity` which allows `parse` function to accept private fields even out of class field, which should be a syntax error.

I also add a condition to binary expression, because even class field can use in operation with privatename, other expressions like add can’t use privatename without subscript. for example :
```js
// in class field
 #p in this // pass
 this.#p + 10 // pass
 input.#p + 10 // pass, input can be a param
 #p + 10 // error

```



