### PR TITLE
docs: fix simple typo, concatentation -> concatenation

### DIFF
--- a/test/compress/concat-strings.js
+++ b/test/compress/concat-strings.js
@@ -12,7 +12,7 @@ concat_1: {
 
         var e = 1 + x() + 2 + "X" + 3 + "boo";
 
-        // be careful with concatentation with "\0" with octal-looking strings.
+        // be careful with concatenation with "\0" with octal-looking strings.
         var f = "\0" + 360 + "\0" + 8 + "\0";
     }
     expect: {

--- a/test/compress/template-string.js
+++ b/test/compress/template-string.js
@@ -119,7 +119,7 @@ template_string_with_predefined_constants: {
         var barber = 'This is ${0/0}';
 
         var a = "4194304";
-        var b = "16777216"; // Potential for further concatentation
+        var b = "16777216"; // Potential for further concatenation
         var c = `${4**14}`; // Not worth converting
     }
 }


### PR DESCRIPTION
There is a small typo in test/compress/concat-strings.js, test/compress/template-string.js.

Should read `concatenation` rather than `concatentation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md