### PR TITLE
Draft: Encode escape for btoa (request help)

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -32,7 +32,7 @@ function read_source_map(code) {
         console.warn("inline source map not found");
         return null;
     }
-    return to_ascii(match[2]);
+    return decodeURIComponent(escape(to_ascii(match[2])));
 }
 
 function set_shorthand(name, options, keys) {
@@ -331,7 +331,7 @@ async function minify(files, options, _fs_module) {
             result.decoded_map = options.format.source_map.getDecoded();
             if (options.sourceMap.url == "inline") {
                 var sourceMap = typeof result.map === "object" ? JSON.stringify(result.map) : result.map;
-                result.code += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," + to_base64(sourceMap);
+                result.code += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64," + to_base64(unescape(encodeURIComponent(sourceMap)));
             } else if (options.sourceMap.url) {
                 result.code += "\n//# sourceMappingURL=" + options.sourceMap.url;
             }

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -294,7 +294,7 @@ describe("sourcemaps", function() {
             map = JSON.parse(result.map);
             assert.strictEqual(map.names.length, 2);
             assert.strictEqual(map.names[0], "tëst");
-            assert.strictEqual(map.names[0], "alert");
+            assert.strictEqual(map.names[1], "alert");
         });
         it("Should append source map to file when asObject is present", async function() {
             var result = await minify("var a = function(foo) { return foo; };", {

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -265,7 +265,7 @@ describe("sourcemaps", function() {
         // TODO skipped for 2 reasons:
         //  - atob/btoa fail with unicode characters
         //  - names output has changed and excludes unicode names
-        it.skip("Should work with unicode characters", async function() {
+        it("Should work with unicode characters", async function() {
             var code = [
                 "var tëst = '→unicøde←';",
                 "alert(tëst);",
@@ -281,7 +281,7 @@ describe("sourcemaps", function() {
             assert.strictEqual(map.sourcesContent.length, 1);
             assert.strictEqual(map.sourcesContent[0], code);
             var encoded = result.code.slice(result.code.lastIndexOf(",") + 1);
-            map = JSON.parse(to_ascii(encoded).toString());
+            map = JSON.parse(decodeURIComponent(escape(to_ascii(encoded))).toString());
             assert.strictEqual(map.sourcesContent.length, 1);
             assert.strictEqual(map.sourcesContent[0], code);
             result = await minify(result.code, {


### PR DESCRIPTION
Attempting to fix https://github.com/terser/terser/issues/1018
Due to a bug on our services here: https://github.com/playcanvas/editor/issues/950

By encoding and escaping the string before btoa, we can encode the content correctly and this fixes half the tests.

However, I don't understand enough about the second lot of tests regarding the map names. Can someone help point me how these map names are generated please
```
            result = await minify(result.code, {
                sourceMap: {
                    content: "inline",
                    includeSources: true,
                }
            });
            if (result.error) throw result.error;
            map = JSON.parse(result.map);
            assert.strictEqual(map.names.length, 2);
            assert.strictEqual(map.names[0], "tëst");
            assert.strictEqual(map.names[1], "alert");
```
