### PR TITLE
fix: add asObject to SourceMapOptions definition

### DIFF
--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -204,6 +204,7 @@ export interface SourceMapOptions {
     includeSources?: boolean;
     filename?: string;
     root?: string;
+    asObject?: boolean;
     url?: string | 'inline';
 }
 


### PR DESCRIPTION
Aligning the TS definition for source map option with the docs:

https://terser.org/docs/api-reference#source-map-options