### PR TITLE
Remove extraneous `)` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,4 +153,4 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage], versi
 available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/)
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION
This PR removes extraneous `)` in `CONTRIBUTING.md` to fix the link.