### PR TITLE
Support string module name and export * as

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2588,6 +2588,7 @@ var AST_SymbolImportForeign = DEFNODE("SymbolImportForeign", null, function AST_
         this.scope = props.scope;
         this.name = props.name;
         this.thedef = props.thedef;
+        this.quote = props.quote;
         this.start = props.start;
         this.end = props.end;
     }
@@ -2639,6 +2640,7 @@ var AST_SymbolExport = DEFNODE("SymbolExport", null, function AST_SymbolExport(p
         this.scope = props.scope;
         this.name = props.name;
         this.thedef = props.thedef;
+        this.quote = props.quote;
         this.start = props.start;
         this.end = props.end;
     }
@@ -2653,6 +2655,7 @@ var AST_SymbolExportForeign = DEFNODE("SymbolExportForeign", null, function AST_
         this.scope = props.scope;
         this.name = props.name;
         this.thedef = props.thedef;
+        this.quote = props.quote;
         this.start = props.start;
         this.end = props.end;
     }

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -1363,10 +1363,14 @@ import { is_basic_identifier_string } from "./parse.js";
             var first_exported = M.exported_names[0];
             var first_exported_name = first_exported.name;
             if (first_exported_name.name === "*" && !first_exported_name.quote) {
+                var foreign_name = first_exported.foreign_name;
+                var exported = foreign_name.name === "*" && !foreign_name.quote
+                    ? null
+                    : to_moz(foreign_name);
                 return {
                     type: "ExportAllDeclaration",
                     source: to_moz(M.module_name),
-                    exported: to_moz(first_exported.foreign_name),
+                    exported: exported,
                     assertions: assert_clause_to_moz(M.assert_clause)
                 };
             }

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -529,24 +529,11 @@ import { is_basic_identifier_string } from "./parse.js";
             var imported_name = null;
             var imported_names = null;
             M.specifiers.forEach(function (specifier) {
-                if (specifier.type === "ImportSpecifier") {
+                if (specifier.type === "ImportSpecifier" || specifier.type === "ImportNamespaceSpecifier") {
                     if (!imported_names) { imported_names = []; }
-                    imported_names.push(new AST_NameMapping({
-                        start: my_start_token(specifier),
-                        end: my_end_token(specifier),
-                        foreign_name: from_moz(specifier.imported),
-                        name: from_moz(specifier.local)
-                    }));
+                    imported_names.push(from_moz(specifier));
                 } else if (specifier.type === "ImportDefaultSpecifier") {
-                    imported_name = from_moz(specifier.local);
-                } else if (specifier.type === "ImportNamespaceSpecifier") {
-                    if (!imported_names) { imported_names = []; }
-                    imported_names.push(new AST_NameMapping({
-                        start: my_start_token(specifier),
-                        end: my_end_token(specifier),
-                        foreign_name: new AST_SymbolImportForeign({ name: "*" }),
-                        name: from_moz(specifier.local)
-                    }));
+                    imported_name = from_moz(specifier);
                 }
             });
             return new AST_Import({
@@ -556,6 +543,28 @@ import { is_basic_identifier_string } from "./parse.js";
                 imported_names : imported_names,
                 module_name : from_moz(M.source),
                 assert_clause: assert_clause_from_moz(M.assertions)
+            });
+        },
+
+        ImportSpecifier: function(M) {
+            return new AST_NameMapping({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                foreign_name: from_moz(M.imported),
+                name: from_moz(M.local)
+            });
+        },
+
+        ImportDefaultSpecifier: function(M) {
+            return from_moz(M.local);
+        },
+
+        ImportNamespaceSpecifier: function(M) {
+            return new AST_NameMapping({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                foreign_name: new AST_SymbolImportForeign({ name: "*" }),
+                name: from_moz(M.local)
             });
         },
 
@@ -580,10 +589,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 end: my_end_token(M),
                 exported_definition: from_moz(M.declaration),
                 exported_names: M.specifiers && M.specifiers.length ? M.specifiers.map(function (specifier) {
-                    return new AST_NameMapping({
-                        foreign_name: from_moz(specifier.exported),
-                        name: from_moz(specifier.local)
-                    });
+                    return from_moz(specifier);
                 }) : null,
                 module_name: from_moz(M.source),
                 assert_clause: assert_clause_from_moz(M.assertions)
@@ -596,6 +602,13 @@ import { is_basic_identifier_string } from "./parse.js";
                 end: my_end_token(M),
                 exported_value: from_moz(M.declaration),
                 is_default: true
+            });
+        },
+
+        ExportSpecifier: function(M) {
+            return new AST_NameMapping({
+                foreign_name: from_moz(M.exported),
+                name: from_moz(M.local)
             });
         },
 
@@ -624,6 +637,19 @@ import { is_basic_identifier_string } from "./parse.js";
             if (val === null) return new AST_Null(args);
             switch (typeof val) {
               case "string":
+                args.quote = "\"";
+                var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
+                if (p.type == "ImportSpecifier") {
+                    args.name = val;
+                    return new AST_SymbolImportForeign(args);
+                } else if (p.type == "ExportSpecifier") {
+                    args.name = val;
+                    if (M == p.exported) {
+                        return new AST_SymbolExportForeign(args);
+                    } else {
+                        return new AST_SymbolExport(args);
+                    }
+                }
                 args.value = val;
                 return new AST_String(args);
               case "number":
@@ -1328,7 +1354,8 @@ import { is_basic_identifier_string } from "./parse.js";
 
     def_to_moz(AST_Export, function To_Moz_ExportDeclaration(M) {
         if (M.exported_names) {
-            if (M.exported_names[0].name.name === "*") {
+            var first_exported_name = M.exported_names[0].name;
+            if (first_exported_name.name === "*" && !first_exported_name.quote) {
                 return {
                     type: "ExportAllDeclaration",
                     source: to_moz(M.module_name),
@@ -1363,19 +1390,22 @@ import { is_basic_identifier_string } from "./parse.js";
                 local: to_moz(M.imported_name)
             });
         }
-        if (M.imported_names && M.imported_names[0].foreign_name.name === "*") {
-            specifiers.push({
-                type: "ImportNamespaceSpecifier",
-                local: to_moz(M.imported_names[0].name)
-            });
-        } else if (M.imported_names) {
-            M.imported_names.forEach(function(name_mapping) {
+        if (M.imported_names) {
+            var first_imported_foreign_name = M.imported_names[0].foreign_name;
+            if (first_imported_foreign_name.name === "*" && !first_imported_foreign_name.quote) {
                 specifiers.push({
-                    type: "ImportSpecifier",
-                    local: to_moz(name_mapping.name),
-                    imported: to_moz(name_mapping.foreign_name)
+                    type: "ImportNamespaceSpecifier",
+                    local: to_moz(M.imported_names[0].name)
                 });
-            });
+            } else {
+                M.imported_names.forEach(function(name_mapping) {
+                    specifiers.push({
+                        type: "ImportSpecifier",
+                        local: to_moz(name_mapping.name),
+                        imported: to_moz(name_mapping.foreign_name)
+                    });
+                });
+            }
         }
         return {
             type: "ImportDeclaration",
@@ -1639,7 +1669,14 @@ import { is_basic_identifier_string } from "./parse.js";
     });
 
     def_to_moz(AST_Symbol, function To_Moz_Identifier(M, parent) {
-        if (M instanceof AST_SymbolMethod && parent.quote) {
+        if (
+            (M instanceof AST_SymbolMethod && parent.quote) ||
+            ((
+                M instanceof AST_SymbolImportForeign ||
+                M instanceof AST_SymbolExportForeign ||
+                M instanceof AST_SymbolExport
+                ) && M.quote)
+         ) {
             return {
                 type: "Literal",
                 value: M.name

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -569,13 +569,16 @@ import { is_basic_identifier_string } from "./parse.js";
         },
 
         ExportAllDeclaration: function(M) {
+            var foreign_name = M.exported == null ? 
+                new AST_SymbolExportForeign({ name: "*" }) :
+                from_moz(M.exported);
             return new AST_Export({
                 start: my_start_token(M),
                 end: my_end_token(M),
                 exported_names: [
                     new AST_NameMapping({
                         name: new AST_SymbolExportForeign({ name: "*" }),
-                        foreign_name: new AST_SymbolExportForeign({ name: "*" })
+                        foreign_name: foreign_name
                     })
                 ],
                 module_name: from_moz(M.source),
@@ -649,6 +652,9 @@ import { is_basic_identifier_string } from "./parse.js";
                     } else {
                         return new AST_SymbolExport(args);
                     }
+                } else if (p.type == "ExportAllDeclaration" && M == p.exported) {
+                    args.name = val;
+                    return new AST_SymbolExportForeign(args);
                 }
                 args.value = val;
                 return new AST_String(args);
@@ -1354,11 +1360,13 @@ import { is_basic_identifier_string } from "./parse.js";
 
     def_to_moz(AST_Export, function To_Moz_ExportDeclaration(M) {
         if (M.exported_names) {
-            var first_exported_name = M.exported_names[0].name;
+            var first_exported = M.exported_names[0];
+            var first_exported_name = first_exported.name;
             if (first_exported_name.name === "*" && !first_exported_name.quote) {
                 return {
                     type: "ExportAllDeclaration",
                     source: to_moz(M.module_name),
+                    exported: to_moz(first_exported.foreign_name),
                     assertions: assert_clause_to_moz(M.assert_clause)
                 };
             }

--- a/lib/output.js
+++ b/lib/output.js
@@ -1681,7 +1681,9 @@ function OutputStream(options) {
             output.space();
         }
         if (self.imported_names) {
-            if (self.imported_names.length === 1 && self.imported_names[0].foreign_name.name === "*") {
+            if (self.imported_names.length === 1 &&
+                self.imported_names[0].foreign_name.name === "*" &&
+                !self.imported_names[0].foreign_name.quote) {
                 self.imported_names[0].print(output);
             } else {
                 output.print("{");
@@ -1715,14 +1717,25 @@ function OutputStream(options) {
     DEFPRINT(AST_NameMapping, function(self, output) {
         var is_import = output.parent() instanceof AST_Import;
         var definition = self.name.definition();
+        var foreign_name = self.foreign_name;
         var names_are_different =
             (definition && definition.mangled_name || self.name.name) !==
-            self.foreign_name.name;
+            foreign_name.name;
+        var foreign_name_is_name = foreign_name.quote == null;
         if (names_are_different) {
             if (is_import) {
-                output.print(self.foreign_name.name);
+                if (foreign_name_is_name) {
+                    output.print(foreign_name.name);
+                } else {
+                    output.print_string(foreign_name.name, foreign_name.quote);
+                }
             } else {
-                self.name.print(output);
+                if (self.name.quote == null) {
+                    self.name.print(output);
+                } else {
+                    output.print_string(self.name.name, self.name.quote);
+                }
+                
             }
             output.space();
             output.print("as");
@@ -1730,10 +1743,18 @@ function OutputStream(options) {
             if (is_import) {
                 self.name.print(output);
             } else {
-                output.print(self.foreign_name.name);
+                if (foreign_name_is_name) {
+                    output.print(foreign_name.name);
+                } else {
+                    output.print_string(foreign_name.name, foreign_name.quote);
+                }
             }
         } else {
-            self.name.print(output);
+            if (self.name.quote == null) {
+                self.name.print(output);
+            } else {
+                output.print_string(self.name.name, self.name.quote);
+            }
         }
     });
 
@@ -1745,8 +1766,10 @@ function OutputStream(options) {
             output.space();
         }
         if (self.exported_names) {
-            if (self.exported_names.length === 1 && self.exported_names[0].name.name === "*") {
-                self.exported_names[0].print(output);
+            if (self.exported_names.length === 1 &&
+                self.exported_names[0].name.name === "*" &&
+                !self.exported_names[0].name.quote) {
+                    self.exported_names[0].print(output);
             } else {
                 output.print("{");
                 self.exported_names.forEach(function(name_export, i) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1721,6 +1721,12 @@ function OutputStream(options) {
         var names_are_different =
             (definition && definition.mangled_name || self.name.name) !==
             foreign_name.name;
+        if (!names_are_different &&
+            foreign_name.name === "*" &&
+            foreign_name.quote != self.name.quote) {
+                // export * as "*"
+            names_are_different = true;
+        }
         var foreign_name_is_name = foreign_name.quote == null;
         if (names_are_different) {
             if (is_import) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2829,12 +2829,18 @@ function parse($TEXT, options) {
         });
     }
 
-    function map_nameAsterisk(is_import, name) {
+    function map_nameAsterisk(is_import, import_or_export_foreign_name) {
         var foreign_type = is_import ? AST_SymbolImportForeign : AST_SymbolExportForeign;
         var type = is_import ? AST_SymbolImport : AST_SymbolExport;
         var start = S.token;
-        var foreign_name;
+        var name, foreign_name;
         var end = prev();
+
+        if (is_import) {
+            name = import_or_export_foreign_name;
+        } else {
+            foreign_name = import_or_export_foreign_name;
+        }
 
         name = name || new type({
             start: start,
@@ -2842,7 +2848,7 @@ function parse($TEXT, options) {
             end: end,
         });
 
-        foreign_name = new foreign_type({
+        foreign_name = foreign_name || new foreign_type({
             start: start,
             name: "*",
             end: end,
@@ -2871,9 +2877,9 @@ function parse($TEXT, options) {
         } else if (is("operator", "*")) {
             var name;
             next();
-            if (is_import && is("name", "as")) {
+            if (is("name", "as")) {
                 next();  // The "as" word
-                name = as_symbol(is_import ? AST_SymbolImport : AST_SymbolExportForeign);
+                name = is_import ? as_symbol(AST_SymbolImport) : as_symbol_or_string(AST_SymbolExportForeign);
             }
             names = [map_nameAsterisk(is_import, name)];
         }
@@ -3031,6 +3037,27 @@ function parse($TEXT, options) {
         if (!is("name")) {
             if (!noerror) croak("Name expected");
             return null;
+        }
+        var sym = _make_symbol(type);
+        _verify_symbol(sym);
+        next();
+        return sym;
+    }
+
+    function as_symbol_or_string(type) {
+        if (!is("name")) {
+            if (!is("string")) {
+                croak("Name or string expected");
+            }
+            var tok = S.token;
+            var ret = new type({
+                start : tok,
+                end   : tok,
+                name : tok.value,
+                quote : tok.quote
+            });
+            next();
+            return ret;
         }
         var sym = _make_symbol(type);
         _verify_symbol(sym);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2811,7 +2811,7 @@ function parse($TEXT, options) {
         if (is("name", "as")) {
             next();  // The "as" word
             if (is_import) {
-                name = make_symbol(type, S.token.quote);
+                name = make_symbol(type);
             } else {
                 foreign_name = make_symbol(foreign_type, S.token.quote);
             }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2788,9 +2788,10 @@ function parse($TEXT, options) {
     }
 
     function map_name(is_import) {
-        function make_symbol(type) {
+        function make_symbol(type, quote) {
             return new type({
                 name: as_property_name(),
+                quote: quote || undefined,
                 start: prev(),
                 end: prev()
             });
@@ -2803,16 +2804,16 @@ function parse($TEXT, options) {
         var name;
 
         if (is_import) {
-            foreign_name = make_symbol(foreign_type);
+            foreign_name = make_symbol(foreign_type, start.quote);
         } else {
-            name = make_symbol(type);
+            name = make_symbol(type, start.quote);
         }
         if (is("name", "as")) {
             next();  // The "as" word
             if (is_import) {
-                name = make_symbol(type);
+                name = make_symbol(type, S.token.quote);
             } else {
-                foreign_name = make_symbol(foreign_type);
+                foreign_name = make_symbol(foreign_type, S.token.quote);
             }
         } else if (is_import) {
             name = new type(foreign_name);

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -1010,3 +1010,17 @@ export_multiple_named_default_string: {
     }
     expect_exact: 'export{default as"F-oo",default as"*"};export{Foo as"F-oo",Bar as"B-ar",star as"*","B-ax","B-ar"as"F-oo","*","*"as star,"*"as"s-tar",default as"F-oo",default as"*"}from"lel";'
 }
+
+export_namespace_as: {
+    input: {
+        export * as foo from "lel";
+    }
+    expect_exact: 'export*as foo from"lel";'
+}
+
+export_namespace_as_string: {
+    input: {
+        export * as "f-oo" from "lel";
+    }
+    expect_exact: 'export*as"f-oo"from"lel";'
+}

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -952,3 +952,61 @@ export_object_property_mangle_2: {
         export {o};
     }
 }
+
+import_string: {
+    input: {
+        import { "F-oo" as Foo } from "lel";
+        import { "*" as Bar } from "lel";
+    }
+    expect_exact: 'import{"F-oo"as Foo}from"lel";import{"*"as Bar}from"lel";'
+}
+
+import_multiple_string: {
+    input: {
+        import { "F-oo" as Foo, "*" as Bar } from "lel";
+    }
+    expect_exact: 'import{"F-oo"as Foo,"*"as Bar}from"lel";'
+}
+
+export_named_string: {
+    input: {
+        export { Foo as "F-oo" };
+        export { Bar as "B-ar" } from "lel";
+        export { star as "*" } from "lel";
+        export { "B-ax" } from "lel";
+        export { "B-ar" as "F-oo" } from "lel";
+        export { "*" } from "lel";
+        export { "*" as star } from "lel";
+        export { "*" as "s-tar" } from "lel";
+    }
+    expect_exact: 'export{Foo as"F-oo"};export{Bar as"B-ar"}from"lel";export{star as"*"}from"lel";export{"B-ax"}from"lel";export{"B-ar"as"F-oo"}from"lel";export{"*"}from"lel";export{"*"as star}from"lel";export{"*"as"s-tar"}from"lel";'
+}
+
+export_default_string: {
+    input: {
+        export { default as "F-oo" };
+        export { default as "*" };
+        export { default as "B-ar" } from "lel";
+        export { default as "*" } from "lel";
+    }
+    expect_exact: 'export{default as"F-oo"};export{default as"*"};export{default as"B-ar"}from"lel";export{default as"*"}from"lel";'
+}
+
+export_multiple_named_default_string: {
+    input: {
+        export { default as "F-oo", default as "*" };
+        export {
+            Foo as "F-oo",
+            Bar as "B-ar",
+            star as "*",
+            "B-ax",
+            "B-ar" as "F-oo",
+            "*",
+            "*" as star,
+            "*" as "s-tar",
+            default as "F-oo",
+            default as "*",
+        } from "lel";
+    }
+    expect_exact: 'export{default as"F-oo",default as"*"};export{Foo as"F-oo",Bar as"B-ar",star as"*","B-ax","B-ar"as"F-oo","*","*"as star,"*"as"s-tar",default as"F-oo",default as"*"}from"lel";'
+}

--- a/test/compress/export.js
+++ b/test/compress/export.js
@@ -1021,6 +1021,7 @@ export_namespace_as: {
 export_namespace_as_string: {
     input: {
         export * as "f-oo" from "lel";
+        export * as "*" from "lel";
     }
-    expect_exact: 'export*as"f-oo"from"lel";'
+    expect_exact: 'export*as"f-oo"from"lel";export*as"*"from"lel";'
 }

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -135,7 +135,7 @@ describe("spidermonkey export/import sanity test", function() {
 
     it("should correctly minify AST from from_moz_ast with default destructure", async () => {
         const code = "const { a = 1, b: [b = 2] = []} = {}";
-        const acornAst = acornParse(code, { locations: true });
+        const acornAst = acornParse(code, { locations: true, ecmaVersion: 2015 });
         const terserAst = AST.AST_Node.from_mozilla_ast(acornAst);
         const result = await minify(terserAst, {ecma: 2015});
         assert.strictEqual(
@@ -146,7 +146,7 @@ describe("spidermonkey export/import sanity test", function() {
 
     it("should correctly minify AST from from_moz_ast with default function parameter", async () => {
         const code = "function run(x = 2){}";
-        const acornAst = acornParse(code, { locations: true });
+        const acornAst = acornParse(code, { locations: true, ecmaVersion: 2020 });
         const terserAst = AST.AST_Node.from_mozilla_ast(acornAst);
         const result = await minify(terserAst);
         assert.strictEqual(


### PR DESCRIPTION
In this PR we implement the support of ES2022 string module names and ES2020 `export * as ns`. These two features are highly related so it end up in a single PR.

## Summary
- AST changes: `.quote` is introduced to `AST_SymbolImportForeign`, `AST_SymbolExportForeign` and `AST_SymbolExport`. It will be `"` or `'` if the module name is a string, otherwise it is `undefined`. I am not sure if we want to stick with the `AST_Symbol` prefix now that it can be a string, too. Anyway I will wait for more feedback before any drastic AST change
- Added new parser method `as_symbol_or_string` to handle `export * as "f-oo"`
- Added specific handling to differentiate between `import { * as foo }` and `import { "*" as foo }`

## Limitation
The parser currently do not validate that module names should be a valid UTF16 string (no lone surrogate). It seems good to me since our parser is already a bit loose: cases like `export { * as foo } from "x"` will not throw.

Fixes https://github.com/terser/terser/issues/1137
Fixes https://github.com/terser/terser/issues/1231