### PR TITLE
Fix version number in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v5.16.7
+## v5.16.6
 
  - Become less conservative with analyzing function definitions for `reduce_vars`
  - Parse `import.meta` as a real AST node and not an `object.property`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v5.16.6
+## v5.16.8
 
  - Become less conservative with analyzing function definitions for `reduce_vars`
  - Parse `import.meta` as a real AST node and not an `object.property`


### PR DESCRIPTION
Hi! It appears that the changelog is incorrectly referring to a version v5.16.7 which hasn't been released. If I understood correctly, the intention was to add changelog entries for v5.16.6 but that one was skipped by accident ☺️ 