### PR TITLE
Add @__KEY__ annotation to mangle string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,6 +1188,7 @@ Annotations in Terser are a way to tell it to treat a certain function call diff
  * `/*@__INLINE__*/` - forces a function to be inlined somewhere.
  * `/*@__NOINLINE__*/` - Makes sure the called function is not inlined into the call site.
  * `/*@__PURE__*/` - Marks a function call as pure. That means, it can safely be dropped.
+ * `/*@__KEY__*/` - Marks a string literal as a property to also mangle it when mangling properties.
 
 You can use either a `@` sign at the start, or a `#`.
 
@@ -1201,6 +1202,9 @@ function_always_inlined_here()
 function_cant_be_inlined_into_here()
 
 const x = /*#__PURE__*/i_am_dropped_if_x_is_not_used()
+
+function lookup(object, key) { return object[key]; }
+lookup({ i_will_be_mangled_too: "bar" }, /*@__KEY__*/ "i_will_be_mangled_too");
 ```
 
 ### ESTree / SpiderMonkey AST

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -3134,6 +3134,7 @@ class TreeTransformer extends TreeWalker {
 const _PURE     = 0b00000001;
 const _INLINE   = 0b00000010;
 const _NOINLINE = 0b00000100;
+const _KEY      = 0b00001000;
 
 export {
     AST_Accessor,
@@ -3278,4 +3279,5 @@ export {
     _INLINE,
     _NOINLINE,
     _PURE,
+    _KEY,
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -162,7 +162,8 @@ import {
     AST_Yield,
     _INLINE,
     _NOINLINE,
-    _PURE
+    _PURE,
+    _KEY
 } from "./ast.js";
 
 var LATEST_RAW = "";  // Only used for numbers and template strings
@@ -2225,6 +2226,7 @@ function parse($TEXT, options) {
                 value : tok.value,
                 quote : tok.quote
             });
+            annotate(ret)            
             break;
           case "regexp":
             const [_, source, flags] = tok.value.match(/^\/(.*)\/(\w*)$/);
@@ -3109,6 +3111,10 @@ function parse($TEXT, options) {
                 }
                 if (/[@#]__NOINLINE__/.test(comment.value)) {
                     set_annotation(node, _NOINLINE);
+                    break;
+                }
+                if (/[@#]__KEY__/.test(comment.value)) {
+                    set_annotation(node, _KEY);
                     break;
                 }
             }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2226,7 +2226,7 @@ function parse($TEXT, options) {
                 value : tok.value,
                 quote : tok.quote
             });
-            annotate(ret)            
+            annotate(ret);            
             break;
           case "regexp":
             const [_, source, flags] = tok.value.match(/^\/(.*)\/(\w*)$/);

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -47,6 +47,7 @@
 import {
     defaults,
     push_uniq,
+    has_annotation,
 } from "./utils/index.js";
 import { base54 } from "./scope.js";
 import {
@@ -67,6 +68,7 @@ import {
     AST_Sub,
     TreeTransformer,
     TreeWalker,
+    _KEY,
 } from "./ast.js";
 import { domprops } from "../tools/domprops.js";
 
@@ -263,6 +265,8 @@ function mangle_properties(ast, options) {
             addStrings(node.args[1], add);
         } else if (node instanceof AST_Binary && node.operator === "in") {
             addStrings(node.left, add);
+        } else if (node instanceof AST_String && has_annotation(node, _KEY)) {
+            add(node.value);
         }
     }));
 
@@ -296,6 +300,8 @@ function mangle_properties(ast, options) {
             node.args[1] = mangleStrings(node.args[1]);
         } else if (node instanceof AST_Binary && node.operator === "in") {
             node.left = mangleStrings(node.left);
+        } else if (node instanceof AST_String && has_annotation(node, _KEY)) {
+            node.value = mangle(node.value);
         }
     }));
 

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -48,6 +48,7 @@ import {
     defaults,
     push_uniq,
     has_annotation,
+    clear_annotation,
 } from "./utils/index.js";
 import { base54 } from "./scope.js";
 import {
@@ -301,6 +302,8 @@ function mangle_properties(ast, options) {
         } else if (node instanceof AST_Binary && node.operator === "in") {
             node.left = mangleStrings(node.left);
         } else if (node instanceof AST_String && has_annotation(node, _KEY)) {
+            // Clear _KEY annotation to prevent double mangling
+            clear_annotation(node, _KEY);
             node.value = mangle(node.value);
         }
     }));
@@ -367,6 +370,8 @@ function mangle_properties(ast, options) {
                 var last = node.expressions.length - 1;
                 node.expressions[last] = mangleStrings(node.expressions[last]);
             } else if (node instanceof AST_String) {
+                // Clear _KEY annotation to prevent double mangling
+                clear_annotation(node, _KEY);
                 node.value = mangle(node.value);
             } else if (node instanceof AST_Conditional) {
                 node.consequent = mangleStrings(node.consequent);

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -262,6 +262,10 @@ function set_annotation(node, annotation) {
     node._annotations |= annotation;
 }
 
+function clear_annotation(node, annotation) {
+    node._annotations &= ~annotation;
+}
+
 export {
     characters,
     defaults,
@@ -286,5 +290,6 @@ export {
     sort_regexp_flags,
     string_template,
     has_annotation,
-    set_annotation
+    set_annotation,
+    clear_annotation,
 };

--- a/test/compress/mangleprops-key-annotation.js
+++ b/test/compress/mangleprops-key-annotation.js
@@ -1,0 +1,83 @@
+key_annotation_negative_case: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: true,
+    };
+    input: {
+        function lookup(object, key) {
+            return object[key];
+        }
+        lookup({ someprop: "bar" }, "someprop");
+    }
+    expect: {
+        function lookup(o, p) {
+            return o[p];
+        }
+        lookup({ o: "bar" }, "someprop");
+    }
+}
+
+key_annotation_basic_use: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: true,
+    };
+    input: {
+        function lookup(object, key) {
+            return object[key];
+        }
+        lookup({ someprop: "bar" }, /*@__KEY__*/ "someprop");
+    }
+    expect: {
+        function lookup(o,p){
+            return o[p]
+        }
+        lookup({o:"bar"},"o");
+    }
+}
+
+key_annotation_in_operator: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: true,
+    };
+    input: {
+        const object = { someprop: "bar", o: true}
+        "someprop" in object;
+        /*@__KEY__*/ "someprop" in object;
+    }
+    expect: {
+        const object={o:"bar", p : true};
+        "o"in object;
+        "o"in object;
+    }
+}
+key_annotation_in_operator_tricky_case: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: true,
+    };
+    input: {
+        // By default someprop mangles to "o", add key "o" to try and trip up the mangler
+        const object = { someprop: "bar", o: true}
+        "someprop" in object;
+        /*@__KEY__*/ "someprop" in object;
+    }
+    expect: {
+        const object={o:"bar", p: true};
+        "o"in object;
+        "o"in object;
+    }
+}


### PR DESCRIPTION
Here I add a new annotation `@__KEY__`  that when placed before a string literal causes it to be mangled like a property.

Example:
```js
function lookup(object, key) {
   return object[key]
}
let result = lookup({ somekey: 5}, /*@__KEY__*/ "somekey") 
console.log(result) // prints 5 even if somekey was mangled
```

Do you think this should be part of Terser? Are you happy with the annotation name?

I'm leaving the readme and tests until it is decided that this is a useful feature...