### PR TITLE
Fix for #1371/#1372

### DIFF
--- a/lib/compress/common.js
+++ b/lib/compress/common.js
@@ -46,6 +46,7 @@ import {
     AST_Arrow,
     AST_BlockStatement,
     AST_Call,
+    AST_Chain,
     AST_Class,
     AST_Const,
     AST_Constant,
@@ -226,7 +227,8 @@ export function maintain_this_binding(parent, orig, val) {
         parent instanceof AST_UnaryPrefix && parent.operator == "delete"
         || parent instanceof AST_Call && parent.expression === orig
             && (
-                val instanceof AST_PropAccess
+                val instanceof AST_Chain
+                || val instanceof AST_PropAccess
                 || val instanceof AST_SymbolRef && val.name == "eval"
             )
     ) {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1080,6 +1080,12 @@ function OutputStream(options) {
             return true;
     });
 
+    PARENS(AST_Chain, function(output) {
+        var p = output.parent();
+        if (!(p instanceof AST_Call || p instanceof AST_PropAccess)) return false;
+        return p.expression === this;
+    });
+
     PARENS(AST_PropAccess, function(output) {
         var p = output.parent();
         if (p instanceof AST_New && p.expression === this) {

--- a/test/compress/issue-t1371.js
+++ b/test/compress/issue-t1371.js
@@ -1,0 +1,53 @@
+issue_t1321: {
+    options = {
+    }
+    input: {
+        (foo?.bar()).baz = true;
+        ((foo?.bar())).baz = true;
+        (foo?.bar)();
+        (foo?.bar).baz;
+        new (foo?.bar)();
+        (foo?.())();
+        (foo?.()).bar;
+        new (foo?.())();        
+        
+        (foo?.bar());
+        (foo?.bar) + 42;
+        (foo?.bar), 42;
+    }
+    expect: {
+        (foo?.bar()).baz = true;
+        (foo?.bar()).baz = true;
+        (foo?.bar)();
+        (foo?.bar).baz;
+        new (foo?.bar)();
+        (foo?.())();
+        (foo?.()).bar;
+        new (foo?.())();        
+
+        foo?.bar();
+        foo?.bar + 42;
+        foo?.bar, 42;
+    }
+}
+
+issue_t1321_call_parentheses: {
+    options = {
+    }
+    input: {
+        (function(o) {
+            console.log(o.f("FAIL"), (o.f)("FAIL"), (0, o.f)(42));
+            console.log(o?.f("FAIL"), (o?.f)("FAIL"), (0, o?.f)(42));
+        })({
+            a: "PASS",
+            f(b) {
+                return this.a || b;
+            },
+        });
+    }
+    expect_exact: '(function(o){console.log(o.f("FAIL"),o.f("FAIL"),(0,o.f)(42));console.log(o?.f("FAIL"),(o?.f)("FAIL"),(0,o?.f)(42))})({a:"PASS",f(b){return this.a||b}});'
+    expect_stdout: [
+        "PASS PASS 42",
+        "PASS PASS 42",
+    ]
+}

--- a/test/compress/issue-t1372.js
+++ b/test/compress/issue-t1372.js
@@ -1,0 +1,29 @@
+
+issue_t1372_maintain_this_binding: {
+    options = {
+        side_effects: true,
+    }
+    input: {
+        (function(o) {
+            console.log((0, o.f)("PASS"), (0, o?.f)("PASS"));
+        })({
+            a: "FAIL",
+            f(b) {
+                return this.a || b;
+            },
+        });
+    }
+    expect: {
+        (function(o) {
+            console.log((0, o.f)("PASS"), (0, o?.f)("PASS"));
+        })({
+            a: "FAIL",
+            f(b) {
+                return this.a || b;
+            },
+        });
+    }
+    expect_stdout: [
+        "PASS PASS",
+    ]
+}


### PR DESCRIPTION
This fixes both #1371 and #1372. This patch is based on UglifyJS's fixes for the same issue. I'd normally submit two pull requests, but the `issue_t1321_call_parentheses` test needs the fix for #1372 in order to pass.