### PR TITLE
@__KEY__: Correctly copy annotations when cloning AST_string

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2762,6 +2762,7 @@ var AST_String = DEFNODE("String", "value quote", function AST_String(props) {
         this.quote = props.quote;
         this.start = props.start;
         this.end = props.end;
+        this._annotations = props._annotations;
     }
 
     this.flags = 0;


### PR DESCRIPTION
I noticed that in some rare cases, Terser does not mangle a `@__KEY__` annotated string literal.

I traced this to the annotations not being copied in the AST_String constructor.

It is not clear to me when Terser decides to clone a node, so I wasn't able to construct a minimal test case for this. But testing on a real code-base showed that this change does fix the issue.
