### PR TITLE
add MANGLEPROP annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ a double dash to prevent input files being used as option arguments:
                                                `strict` disables quoted properties
                                                being automatically reserved.
                                 `regex`  Only mangle matched property names.
+                                `only_annotated` Only mangle properties defined with /*@__PROPMANGLE__*/.
                                 `reserved`  List of names that should not be mangled.
     -f, --format [options]      Specify format options.
                                 `preamble`  Preamble to prepend to the output. You

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -3177,10 +3177,11 @@ class TreeTransformer extends TreeWalker {
     }
 }
 
-const _PURE     = 0b00000001;
-const _INLINE   = 0b00000010;
-const _NOINLINE = 0b00000100;
-const _KEY      = 0b00001000;
+const _PURE       = 0b00000001;
+const _INLINE     = 0b00000010;
+const _NOINLINE   = 0b00000100;
+const _KEY        = 0b00001000;
+const _MANGLEPROP = 0b00010000;
 
 export {
     AST_Accessor,
@@ -3326,4 +3327,5 @@ export {
     _NOINLINE,
     _PURE,
     _KEY,
+    _MANGLEPROP,
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -163,7 +163,8 @@ import {
     _INLINE,
     _NOINLINE,
     _PURE,
-    _KEY
+    _KEY,
+    _MANGLEPROP,
 } from "./ast.js";
 
 var LATEST_RAW = "";  // Only used for numbers and template strings
@@ -2226,7 +2227,7 @@ function parse($TEXT, options) {
                 value : tok.value,
                 quote : tok.quote
             });
-            annotate(ret);            
+            annotate(ret);
             break;
           case "regexp":
             const [_, source, flags] = tok.value.match(/^\/(.*)\/(\w*)$/);
@@ -2538,13 +2539,14 @@ function parse($TEXT, options) {
             }
 
             // Create property
-            a.push(new AST_ObjectKeyVal({
+            const kv = new AST_ObjectKeyVal({
                 start: start,
                 quote: start.quote,
                 key: name instanceof AST_Node ? name : "" + name,
                 value: value,
                 end: prev()
-            }));
+            });
+            a.push(annotate(kv));
         }
         next();
         return new AST_Object({ properties: a });
@@ -2657,26 +2659,26 @@ function parse($TEXT, options) {
                     : AST_ObjectSetter;
 
                 name = get_symbol_ast(name);
-                return new AccessorClass({
+                return annotate(new AccessorClass({
                     start,
                     static: is_static,
                     key: name,
                     quote: name instanceof AST_SymbolMethod ? property_token.quote : undefined,
                     value: create_accessor(),
                     end: prev()
-                });
+                }));
             } else {
                 const AccessorClass = accessor_type === "get"
                     ? AST_PrivateGetter
                     : AST_PrivateSetter;
 
-                return new AccessorClass({
+                return annotate(new AccessorClass({
                     start,
                     static: is_static,
                     key: get_symbol_ast(name),
                     value: create_accessor(),
                     end: prev(),
-                });
+                }));
             }
         }
 
@@ -2696,7 +2698,7 @@ function parse($TEXT, options) {
                 value       : create_accessor(is_generator, is_async),
                 end         : prev()
             });
-            return node;
+            return annotate(node);
         }
 
         if (is_class) {
@@ -2709,14 +2711,16 @@ function parse($TEXT, options) {
                 : AST_ClassProperty;
             if (is("operator", "=")) {
                 next();
-                return new AST_ClassPropertyVariant({
-                    start,
-                    static: is_static,
-                    quote,
-                    key,
-                    value: expression(false),
-                    end: prev()
-                });
+                return annotate(
+                    new AST_ClassPropertyVariant({
+                        start,
+                        static: is_static,
+                        quote,
+                        key,
+                        value: expression(false),
+                        end: prev()
+                    })
+                );
             } else if (
                 is("name")
                 || is("privatename")
@@ -2724,13 +2728,15 @@ function parse($TEXT, options) {
                 || is("punc", ";")
                 || is("punc", "}")
             ) {
-                return new AST_ClassPropertyVariant({
-                    start,
-                    static: is_static,
-                    quote,
-                    key,
-                    end: prev()
-                });
+                return annotate(
+                    new AST_ClassPropertyVariant({
+                        start,
+                        static: is_static,
+                        quote,
+                        key,
+                        end: prev()
+                    })
+                );
             }
         }
     }
@@ -3093,10 +3099,9 @@ function parse($TEXT, options) {
     }
 
     // Annotate AST_Call, AST_Lambda or AST_New with the special comments
-    function annotate(node) {
-        var start = node.start;
-        var comments = start.comments_before;
-        const comments_outside_parens = outer_comments_before_counts.get(start);
+    function annotate(node, before_token = node.start) {
+        var comments = before_token.comments_before;
+        const comments_outside_parens = outer_comments_before_counts.get(before_token);
         var i = comments_outside_parens != null ? comments_outside_parens : comments.length;
         while (--i >= 0) {
             var comment = comments[i];
@@ -3117,8 +3122,13 @@ function parse($TEXT, options) {
                     set_annotation(node, _KEY);
                     break;
                 }
+                if (/[@#]__MANGLEPROP__/.test(comment.value)) {
+                    set_annotation(node, _MANGLEPROP);
+                    break;
+                }
             }
         }
+        return node;
     }
 
     var subscripts = function(expr, allow_calls, is_chain) {

--- a/lib/propmangle.js
+++ b/lib/propmangle.js
@@ -70,6 +70,9 @@ import {
     TreeTransformer,
     TreeWalker,
     _KEY,
+    _MANGLEPROP,
+
+    walk,
 } from "./ast.js";
 import { domprops } from "../tools/domprops.js";
 
@@ -188,6 +191,7 @@ function mangle_properties(ast, options) {
         regex: null,
         reserved: null,
         undeclared: false,
+        only_annotated: false,
     }, true);
 
     var nth_identifier = options.nth_identifier;
@@ -206,6 +210,7 @@ function mangle_properties(ast, options) {
         cache = new Map();
     }
 
+    var only_annotated = options.only_annotated;
     var regex = options.regex && new RegExp(options.regex);
 
     // note debug is either false (disabled), or a string of the debug suffix to use (enabled).
@@ -217,6 +222,7 @@ function mangle_properties(ast, options) {
         debug_name_suffix = (options.debug === true ? "" : options.debug);
     }
 
+    var annotated_names = new Set();
     var names_to_mangle = new Set();
     var unmangleable = new Set();
     // Track each already-mangled name to prevent nth_identifier from generating
@@ -225,7 +231,36 @@ function mangle_properties(ast, options) {
 
     var keep_quoted = !!options.keep_quoted;
 
-    // step 1: find candidates to mangle
+    // Step 1: Find all annotated /*@__MANGLEPROP__*/
+    walk(ast, node => {
+        if (
+            node instanceof AST_ClassPrivateProperty
+            || node instanceof AST_PrivateMethod
+            || node instanceof AST_PrivateGetter
+            || node instanceof AST_PrivateSetter
+            || node instanceof AST_DotHash
+        ) {
+            // handled by mangle_private_properties
+        } else if (node instanceof AST_ObjectKeyVal) {
+            if (
+                typeof node.key == "string"
+                && has_annotation(node, _MANGLEPROP)
+                && can_mangle(node.key)
+            ) {
+                annotated_names.add(node.key);
+            }
+        } else if (node instanceof AST_ObjectProperty) {
+            // setter or getter, since KeyVal is handled above
+            if (
+                has_annotation(node, _MANGLEPROP)
+                && can_mangle(node.key.name)
+            ) {
+                annotated_names.add(node.key.name);
+            }
+        }
+    });
+
+    // step 2: find candidates to mangle
     ast.walk(new TreeWalker(function(node) {
         if (
             node instanceof AST_ClassPrivateProperty
@@ -321,15 +356,19 @@ function mangle_properties(ast, options) {
     }
 
     function should_mangle(name) {
-        if (regex && !regex.test(name)) return false;
+        if (only_annotated && !annotated_names.has(name)) return false;
+        if (regex && !regex.test(name)) {
+            return annotated_names.has(name);
+        }
         if (reserved.has(name)) return false;
         return cache.has(name)
             || names_to_mangle.has(name);
     }
 
     function add(name) {
-        if (can_mangle(name))
+        if (can_mangle(name)) {
             names_to_mangle.add(name);
+        }
 
         if (!should_mangle(name)) {
             unmangleable.add(name);

--- a/test/compress/mangleprops-mangleprop-annotation.js
+++ b/test/compress/mangleprops-mangleprop-annotation.js
@@ -1,0 +1,147 @@
+mangleprop_annotation: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: {
+            only_annotated: true,
+        },
+    };
+    input: {
+        class Foo {
+            /*@__MANGLEPROP__*/ prop = "prop"
+            /*@__MANGLEPROP__*/ static static_prop = "static_prop"
+            /*@__MANGLEPROP__*/ meth() {return "meth"}
+            /*@__MANGLEPROP__*/ async meth2() {}
+            /*@__MANGLEPROP__*/ async *meth3() {}
+            /*@__MANGLEPROP__*/ *gen() { return "gen" }
+        }
+
+        const foo = {
+            /*@__MANGLEPROP__*/ prop: "prop",
+            /*@__MANGLEPROP__*/ meth() {return "meth"},
+            /*@__MANGLEPROP__*/ async meth2() {},
+            /*@__MANGLEPROP__*/ async *meth3() {},
+            /*@__MANGLEPROP__*/ *gen() { return "gen" },
+        }
+
+        console.log(new Foo().prop, foo.prop);
+        console.log(new Foo().meth(), foo.meth());
+        console.log(new Foo().gen().next().value, foo.gen().next().value);
+    }
+    expect_stdout: [
+        "prop prop",
+        "meth meth",
+        "gen gen",
+    ]
+}
+
+mangleprop_annotation_partial: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: {
+            only_annotated: true,
+        },
+    };
+    input: {
+        class Foo {
+            /*@__MANGLEPROP__*/ manglethis = "manglethis"
+            manglethistoo = "manglethistoo"
+            dontmanglethis = "dontmanglethis"
+        }
+
+        const foo = {
+            manglethis: "manglethis",
+            /*@__MANGLEPROP__*/ manglethistoo: "manglethistoo",
+            dontmanglethis: "dontmanglethis"
+        }
+
+        console.log(new Foo().manglethis, foo.manglethis);
+        console.log(new Foo().manglethistoo, foo.manglethistoo);
+        console.log(new Foo().dontmanglethis, foo.dontmanglethis);
+    }
+    expect: {
+        class Foo {
+            /*@__MANGLEPROP__*/ o = "manglethis"
+            t = "manglethistoo"
+            dontmanglethis = "dontmanglethis"
+        }
+
+        const foo = {
+            o: "manglethis",
+            /*@__MANGLEPROP__*/ t: "manglethistoo",
+            dontmanglethis: "dontmanglethis"
+        }
+
+        console.log(new Foo().o, foo.o);
+        console.log(new Foo().t, foo.t);
+        console.log(new Foo().dontmanglethis, foo.dontmanglethis);
+    }
+    expect_stdout: [
+        "manglethis manglethis",
+        "manglethistoo manglethistoo",
+        "dontmanglethis dontmanglethis",
+    ]
+}
+
+mangleprop_annotation_wrongregex: {
+    options = {
+        defaults: false,
+        inline: false,
+    };
+    mangle = {
+        properties: {
+            regex: /matchedbyregex/
+        },
+    };
+    input: {
+        class Foo {
+            /*@__MANGLEPROP__*/ manglethis = "manglethis"
+            manglethistoo = "manglethistoo"
+            dontmanglethis = "dontmanglethis"
+            matchedbyregex = "matchedbyregex"
+        }
+
+        const foo = {
+            manglethis: "manglethis",
+            /*@__MANGLEPROP__*/ manglethistoo: "manglethistoo",
+            dontmanglethis: "dontmanglethis",
+            matchedbyregex: "matchedbyregex",
+        }
+
+        console.log(new Foo().manglethis, foo.manglethis);
+        console.log(new Foo().manglethistoo, foo.manglethistoo);
+        console.log(new Foo().dontmanglethis, foo.dontmanglethis);
+        console.log(new Foo().matchedbyregex, foo.matchedbyregex);
+    }
+    expect: {
+        class Foo {
+            /*@__MANGLEPROP__*/ o = "manglethis"
+            t = "manglethistoo"
+            dontmanglethis = "dontmanglethis"
+            l = "matchedbyregex"
+        }
+
+        const foo = {
+            o: "manglethis",
+            /*@__MANGLEPROP__*/ t: "manglethistoo",
+            dontmanglethis: "dontmanglethis",
+            l: "matchedbyregex",
+        }
+
+        console.log(new Foo().o, foo.o);
+        console.log(new Foo().t, foo.t);
+        console.log(new Foo().dontmanglethis, foo.dontmanglethis);
+        console.log(new Foo().l, foo.l);
+    }
+    expect_stdout: [
+        "manglethis manglethis",
+        "manglethistoo manglethistoo",
+        "dontmanglethis dontmanglethis",
+        "matchedbyregex matchedbyregex",
+    ]
+}


### PR DESCRIPTION
Adds a `@__MANGLEPROP__` annotation to annotate object/class properties at declare-time.

To do:

 - [ ] Check how this intersects with `@__KEY__`
 - [ ] More tests (involving the compressor)
 - [ ] Document