### PR TITLE
Simplify normalize directives

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -166,17 +166,15 @@ import { is_basic_identifier_string } from "./parse.js";
 (function() {
 
     var normalize_directives = function(body) {
-        var in_directive = true;
-
         for (var i = 0; i < body.length; i++) {
-            if (in_directive && body[i] instanceof AST_Statement && body[i].body instanceof AST_String) {
+            if (body[i] instanceof AST_Statement && body[i].body instanceof AST_String) {
                 body[i] = new AST_Directive({
                     start: body[i].start,
                     end: body[i].end,
                     value: body[i].body.value
                 });
-            } else if (in_directive && !(body[i] instanceof AST_Statement && body[i].body instanceof AST_String)) {
-                in_directive = false;
+            } else {
+                return body;
             }
         }
 


### PR DESCRIPTION
I removed needless check for `in_directive`. It is not necessary because after `in_directive = false;` all code inside `for` is not reachable.