### PR TITLE
feat(terser - compress): drop_consle supports passing in an array of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,9 +729,8 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `directives` (default: `true`) -- remove redundant or non-standard directives
 
 - `drop_console` (default: `false`) -- Pass `true` to discard calls to
-  `console.*` functions. If you wish to drop a specific function call
-  such as `console.info` and/or retain side effects from function arguments
-  after dropping the function call then use `pure_funcs` instead.
+  `console.*` functions. If you only want to discard a portion of console, 
+   you can pass an array like this `['log', 'info']`, which will only discard `console.log`、 `console.info`.
 
 - `drop_debugger` (default: `true`) -- remove `debugger;` statements
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -465,10 +465,7 @@ def_optimize(AST_Node, function(self) {
 });
 
 AST_Toplevel.DEFMETHOD("drop_console", function(options) {
-    var isBoolean = typeof options === "boolean";
     var isArray = Array.isArray(options);
-
-    if (!isArray && !isBoolean) return;
 
     return this.transform(new TreeTransformer(function(self) {
         if (self.TYPE !== 'Call') {
@@ -481,19 +478,7 @@ AST_Toplevel.DEFMETHOD("drop_console", function(options) {
             return;
         }
 
-        if (isBoolean) {
-            var name = exp.expression;
-            while (name.expression) {
-                name = name.expression;
-            }
-            if (is_undeclared_ref(name) && name.name == "console") {
-                return make_node(AST_Undefined, self);
-            }
-
-            return;
-        }
-
-        if (options.indexOf(exp.property) === -1) {
+        if (isArray && options.indexOf(exp.property) === -1) {
             return;
         }
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -385,7 +385,7 @@ class Compressor extends TreeWalker {
             this._toplevel.figure_out_scope(mangle);
             if (pass === 0 && this.option("drop_console")) {
                 // must be run before reduce_vars and compress pass
-                this._toplevel = this._toplevel.drop_console();
+                this._toplevel = this._toplevel.drop_console(this.option("drop_console"));
             }
             if (pass > 0 || this.option("reduce_vars")) {
                 this._toplevel.reset_opt_flags(this);
@@ -464,19 +464,45 @@ def_optimize(AST_Node, function(self) {
     return self;
 });
 
-AST_Toplevel.DEFMETHOD("drop_console", function() {
+AST_Toplevel.DEFMETHOD("drop_console", function(options) {
+    var isBoolean = typeof options === "boolean";
+    var isArray = Array.isArray(options);
+
+    if (!isArray && !isBoolean) return;
+
     return this.transform(new TreeTransformer(function(self) {
-        if (self.TYPE == "Call") {
-            var exp = self.expression;
-            if (exp instanceof AST_PropAccess) {
-                var name = exp.expression;
-                while (name.expression) {
-                    name = name.expression;
-                }
-                if (is_undeclared_ref(name) && name.name == "console") {
-                    return make_node(AST_Undefined, self);
-                }
+        if (self.TYPE !== 'Call') {
+            return;
+        }
+
+        var exp = self.expression;
+
+        if (!(exp instanceof AST_PropAccess)) {
+            return;
+        }
+
+        if (isBoolean) {
+            var name = exp.expression;
+            while (name.expression) {
+                name = name.expression;
             }
+            if (is_undeclared_ref(name) && name.name == "console") {
+                return make_node(AST_Undefined, self);
+            }
+
+            return;
+        }
+
+        if (options.indexOf(exp.property) === -1) {
+            return;
+        }
+
+        var name = exp.expression;
+        while (name.expression) {
+            name = name.expression;
+        }
+        if (is_undeclared_ref(name) && name.name == "console") {
+            return make_node(AST_Undefined, self);
         }
     }));
 });

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -4,6 +4,9 @@ import { SectionedSourceMapInput, EncodedSourceMap, DecodedSourceMap } from '@jr
 
 export type ECMA = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
 
+export type ConsoleProperty = keyof typeof console;
+type DropConsoleOption = boolean | ConsoleProperty[];
+
 export interface ParseOptions {
     bare_returns?: boolean;
     /** @deprecated legacy option. Currently, all supported EcmaScript is valid to parse. */
@@ -24,7 +27,7 @@ export interface CompressOptions {
     dead_code?: boolean;
     defaults?: boolean;
     directives?: boolean;
-    drop_console?: boolean;
+    drop_console?: DropConsoleOption;
     drop_debugger?: boolean;
     ecma?: ECMA;
     evaluate?: boolean;


### PR DESCRIPTION
Now drop_console can only pass Boolean values.

<img width="1300" alt="image" src="https://github.com/terser/terser/assets/145088780/eafccdcc-20a1-4045-a227-b57f489b997a">

This is the code in vtk.js, and Vtk Global is window;. If drop_console: true is configured, the console of window will be set to undefined. Because the addition of drop_console: true can also handle console.hasOwnProperty;, I think I can add an array option while supporting the boolean type, so that only the property contained in the array can be handled.


```
{
   drop_console:  ['log', 'debug', 'info', 'warn', 'error', 'time', 'timeEnd', 'group', 'groupEnd']
}
```

like this....