### PR TITLE
raise clean exception for no files to minify

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -230,6 +230,8 @@ async function minify(files, options, _fs_module) {
                 }
             }
         }
+        if(options.parse.toplevel === null) 
+            throw new Error("no source file given");
 
         toplevel = options.parse.toplevel;
     }


### PR DESCRIPTION
Better having a exact exception instead of non helping exception in compress:
```
Fatal error: Cannot read properties of null (reading 'resolve_defines')
TypeError: Cannot read properties of null (reading 'resolve_defines')
    at Compressor.compress (\node_modules\terser\dist\bundle.min.js:18446:29)
    at minify (\node_modules\terser\dist\bundle.min.js:30387:12)
```

fixes #1449