### PR TITLE
Remove needless wrapper for from_moz

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -618,9 +618,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 start: my_start_token(M),
                 end: my_end_token(M),
                 exported_definition: from_moz(M.declaration),
-                exported_names: M.specifiers && M.specifiers.length ? M.specifiers.map(function (specifier) {
-                    return from_moz(specifier);
-                }) : null,
+                exported_names: M.specifiers && M.specifiers.length ? M.specifiers.map(from_moz) : null,
                 module_name: from_moz(M.source),
                 assert_clause: assert_clause_from_moz(M.assertions)
             });


### PR DESCRIPTION
Minor fix. I've removed needless wrapper for `map`.