### PR TITLE
Missing parentheses around private name in inverted "in" operator

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1205,6 +1205,13 @@ function OutputStream(options) {
             return true;
     });
 
+    PARENS(AST_PrivateIn, function(output) {
+        var p = output.parent();
+
+        // !(#a in this)
+        return p instanceof AST_Unary && p.operator === "!";
+    });
+
     /* -----[ PRINTERS ]----- */
 
     DEFPRINT(AST_Directive, function(self, output) {

--- a/test/compress/issue-1516.js
+++ b/test/compress/issue-1516.js
@@ -1,0 +1,35 @@
+parentheses_around_inverted_private_in: {
+    input: {
+        class X {
+            #y;
+
+            z() {
+                if(!(#y in this)) {
+                    return 0;
+                }
+            }
+        }
+    }
+
+    expect: {
+        class X{#y;z(){if(!(#y in this))return 0}}
+    }
+}
+
+no_parentheses_around_private_in: {
+    input: {
+        class X {
+            #y;
+
+            z() {
+                if(#y in this) {
+                    return 0;
+                }
+            }
+        }
+    }
+
+    expect: {
+        class X{#y;z(){if(#y in this)return 0}}
+    }
+}


### PR DESCRIPTION
This should fixes #1516