### PR TITLE
Ensure parent directory exists when using --output on CLI

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -307,6 +307,7 @@ export async function run_cli({ program, packageJson, fs, path }) {
                 return;
             }
         } else if (program.output) {
+            fs.mkdirSync(path.dirname(program.output), { recursive: true });
             fs.writeFileSync(program.output, result.code);
             if (options.sourceMap && options.sourceMap.url !== "inline" && result.map) {
                 fs.writeFileSync(program.output + ".map", result.map);

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -266,4 +266,14 @@ describe("bin/terser", function() {
             done();
         });
     });
+    it("Should output even when parent directory doesn't exist", function(done) {
+        var outputFile = 'tmp/does-not-exist/out.js';
+        var command = tersercmd + ' test/input/defaults/input.js -o ' + outputFile;
+
+        exec(command, function (err) {
+            if (err) throw err;
+            assert.strictEqual(fs.readFileSync(outputFile, 'utf8'), 'if(true){console.log(1+2)}')
+            done();
+        });
+    });
 });

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -267,12 +267,12 @@ describe("bin/terser", function() {
         });
     });
     it("Should output even when parent directory doesn't exist", function(done) {
-        var outputFile = 'tmp/does-not-exist/out.js';
-        var command = tersercmd + ' test/input/defaults/input.js -o ' + outputFile;
+        var outputFile = "tmp/does-not-exist/out.js";
+        var command = tersercmd + " test/input/defaults/input.js -o " + outputFile;
 
         exec(command, function (err) {
             if (err) throw err;
-            assert.strictEqual(fs.readFileSync(outputFile, 'utf8'), 'if(true){console.log(1+2)}')
+            assert.strictEqual(fs.readFileSync(outputFile, "utf8"), "if(true){console.log(1+2)}")
             done();
         });
     });


### PR DESCRIPTION
Resolves #962

Happy to add tests for this, but I didn't see any existing tests for the `--output` CLI option; am I missing them?