### PR TITLE
Enable `mangle.reserved` option to stop labeled statement from being renamed

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -868,7 +868,9 @@ AST_Toplevel.DEFMETHOD("mangle_names", function(options) {
             do {
                 name = nth_identifier.get(++lname);
             } while (ALL_RESERVED_WORDS.has(name));
-            node.mangled_name = name;
+            if (!options.reserved.has(node.name)) {
+                node.mangled_name = name;
+            }
             return true;
         }
         if (!(options.ie8 || options.safari10) && node instanceof AST_SymbolCatch) {

--- a/test/input/issue-1465/input.js
+++ b/test/input/issue-1465/input.js
@@ -1,0 +1,4 @@
+function example() {
+  DEV: doAnExpensiveCheck();
+  return normalCodePath();
+}

--- a/test/mocha/cli-2.js
+++ b/test/mocha/cli-2.js
@@ -82,6 +82,16 @@ describe("bin/terser (2)", function() {
             done();
         });
     });
+    it("Should work with --mangle reserved=[] for labeled statement", function(done) {
+        var command = tersercmd + " test/input/issue-1465/input.js --module -m reserved=['DEV','example']";
+
+        exec(command, function (err, stdout) {
+            if (err) throw err;
+
+            assert.strictEqual(stdout, "function example(){DEV:doAnExpensiveCheck();return normalCodePath()}\n");
+            done();
+        });
+    });
     it("Should work with --mangle reserved=false", function(done) {
         var command = tersercmd + " test/input/issue-505/input.js -m reserved=false";
 


### PR DESCRIPTION
resolve: https://github.com/terser/terser/issues/1465

Although there is a comment for the logic that needs to be updated at https://github.com/terser/terser/issues/1465#issuecomment-1773117699, I can't understand how to update it for this issue.
So I fixed it with other solution.

