### PR TITLE
Add unadjustedMovement to domprops

### DIFF
--- a/tools/domprops.js
+++ b/tools/domprops.js
@@ -8225,6 +8225,7 @@ export var domprops = [
     "uint32",
     "uint8",
     "uint8Clamped",
+    "unadjustedMovement",
     "unclippedDepth",
     "unconfigure",
     "undefined",


### PR DESCRIPTION
`unadjustedMovement` is an option of the [`element.requestPointerLock()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestPointerLock#unadjustedmovement) api.
```js
canvas.requestPointerLock({
    unadjustedMovement: true,
});
```
It is not widely supported though and on MDN it's still flagged as non-standard. But I'm not sure what the requirements are for something to be added to domprops.