### PR TITLE
Don't add parens when arrow function is part of a default assign

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1501,7 +1501,9 @@ function OutputStream(options) {
     AST_Arrow.DEFMETHOD("_do_print", function(output) {
         var self = this;
         var parent = output.parent();
-        var needs_parens = (parent instanceof AST_Binary && !(parent instanceof AST_Assign)) ||
+        var needs_parens = (parent instanceof AST_Binary &&
+                !(parent instanceof AST_Assign) &&
+                !(parent instanceof AST_DefaultAssign)) ||
             parent instanceof AST_Unary ||
             (parent instanceof AST_Call && self === parent.expression);
         if (needs_parens) { output.print("("); }


### PR DESCRIPTION
In the case of this code snippet:

```js
const myFunction = (callback = () => {}) {
  callback();
}
```

Terser would insert parenthesis in the default parameter like this:
```js
const myFunction = (callback = (() => {})) {
  callback();
}
```

They aren't needed, so don't generate them.