### PR TITLE
reduce variables when functions have indirect calls

### DIFF
--- a/lib/compress/common.js
+++ b/lib/compress/common.js
@@ -333,9 +333,9 @@ export function is_reachable(scope_node, defs) {
 }
 
 /** Check if a ref refers to the name of a function/class it's defined within */
-export function is_recursive_ref(compressor, def) {
+export function is_recursive_ref(tw, def) {
     var node;
-    for (var i = 0; node = compressor.parent(i); i++) {
+    for (var i = 0; node = tw.parent(i); i++) {
         if (node instanceof AST_Lambda || node instanceof AST_Class) {
             var name = node.name;
             if (name && name.definition() === def) {

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -529,9 +529,9 @@ function handle_defined_after_hoist(parent) {
     });
 
     // `defun` id to array of `defun` it uses
-    const enclosing_defuns_map = new Map();
+    const defun_dependencies_map = new Map();
     // `defun` id to array of enclosing `def` that are used by the function
-    const defun_enclosing_defs_map = new Map();
+    const dependencies_map = new Map();
     // all symbol ids that will be tracked for read/write
     const symbols_of_interest = new Set();
     const defuns_of_interest = new Set();
@@ -557,13 +557,16 @@ function handle_defined_after_hoist(parent) {
                 && def.orig.length === 1
                 && def.orig[0] instanceof AST_SymbolDefun
             ) {
+                defuns_of_interest.add(def.id);
+                symbols_of_interest.add(def.id);
+
                 defuns_of_interest.add(fname_def.id);
                 symbols_of_interest.add(fname_def.id);
 
-                if (!enclosing_defuns_map.has(fname_def.id)) {
-                    enclosing_defuns_map.set(fname_def.id, []);
+                if (!defun_dependencies_map.has(fname_def.id)) {
+                    defun_dependencies_map.set(fname_def.id, []);
                 }
-                enclosing_defuns_map.get(fname_def.id).push(def.id);
+                defun_dependencies_map.get(fname_def.id).push(def.id);
 
                 continue;
             }
@@ -572,14 +575,14 @@ function handle_defined_after_hoist(parent) {
         }
 
         if (enclosing_defs.length) {
-            defun_enclosing_defs_map.set(fname_def.id, enclosing_defs);
+            dependencies_map.set(fname_def.id, enclosing_defs);
             defuns_of_interest.add(fname_def.id);
             symbols_of_interest.add(fname_def.id);
         }
     }
 
     // No defuns use outside constants
-    if (!defun_enclosing_defs_map.size) {
+    if (!dependencies_map.size) {
         return;
     }
 
@@ -616,7 +619,7 @@ function handle_defined_after_hoist(parent) {
     // Refine `defun_first_read_map` to be as high as possible
     for (const [defun, defun_first_read] of defun_first_read_map) {
         // Update all depdencies of `defun`
-        const queue = new Set(enclosing_defuns_map.get(defun));
+        const queue = new Set(defun_dependencies_map.get(defun));
         for (const enclosed_defun of queue) {
             let enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun);
             if (enclosed_defun_first_read != null && enclosed_defun_first_read < defun_first_read) {
@@ -625,7 +628,7 @@ function handle_defined_after_hoist(parent) {
 
             defun_first_read_map.set(enclosed_defun, defun_first_read);
 
-            for (const enclosed_enclosed_defun of enclosing_defuns_map.get(enclosed_defun) || []) {
+            for (const enclosed_enclosed_defun of defun_dependencies_map.get(enclosed_defun) || []) {
                 queue.add(enclosed_enclosed_defun);
             }
         }
@@ -633,7 +636,7 @@ function handle_defined_after_hoist(parent) {
 
     // ensure write-then-read order, otherwise clear `fixed`
     // This is safe because last-writes (found_symbol_writes) are assumed to be as late as possible, and first-reads (defun_first_read_map) are assumed to be as early as possible.
-    for (const [defun, defs] of defun_enclosing_defs_map) {
+    for (const [defun, defs] of dependencies_map) {
         const defun_first_read = defun_first_read_map.get(defun);
         if (defun_first_read === undefined) {
             continue;

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -638,7 +638,8 @@ function handle_defined_after_hoist(parent) {
         defun_first_read_map.set(defun, defun_first_read);
 
         // Update all depdencies of `defun`
-        const queue = enclosing_defuns_map.get(defun)?.slice() ?? [];
+        let queue = enclosing_defuns_map.get(defun);
+        queue = queue ? queue.slice() : [];
         const visited = new Set();
         while (queue.length) {
             const enclosed_defun = queue.pop();
@@ -672,9 +673,12 @@ function handle_defined_after_hoist(parent) {
                 continue;
             }
 
-            const def_last_write = found_symbols.findLastIndex(
-                (sym, index) => sym === def.id && found_symbol_writes.has(index)
-            );
+            let def_last_write = found_symbols.length;
+            while (--def_last_write >= 0) {
+                if (found_symbols[def_last_write] === def.id && found_symbol_writes.has(def_last_write)) {
+                    break;
+                }
+            }
 
             if (defun_first_read < def_last_write) {
                 def.fixed = false;

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -576,18 +576,14 @@ function handle_defined_after_hoist(parent) {
     // `defun` id to array of enclsoing `defun` id
     // reverse of `defun_dependents_map`, used to speed up updating `defun_first_read_map`
     const enclosing_defuns_map = new Map();
-    // temp work queue
-    const defun_queue = Array.from(defun_enclosing_defs_map.keys());
     // `defun` ids to be tracked for definition location
-    const defuns_of_interest = new Set(defun_queue);
-    while (defun_queue.length) {
-        const defun_id = defun_queue.pop();
+    const defuns_of_interest = new Set(defun_enclosing_defs_map.keys());
+    for (const defun_id of defuns_of_interest) {
         symbols_of_interest.add(defun_id);
 
         for (const dependent of defun_dependents_map.get(defun_id) || []) {
             if (!defuns_of_interest.has(dependent)) {
                 defuns_of_interest.add(dependent);
-                defun_queue.push(dependent);
 
                 if (!enclosing_defuns_map.has(dependent)) {
                     enclosing_defuns_map.set(dependent, []);
@@ -600,8 +596,8 @@ function handle_defined_after_hoist(parent) {
     // All "symbols of interest", that is, defuns or defs, that we found.
     // These are placed in order so we can check which is after which.
     const found_symbols = [];
-    // Indices of `found_symbols` which are writes
-    const found_symbol_writes = new Set();
+    // Map a symbol ID to its last write (a `found_symbols` index)
+    const symbol_last_write_map = new Map();
     // Defun ranges are recorded because we don't care if a function uses the def internally
     const defun_ranges = new Map();
 
@@ -624,7 +620,8 @@ function handle_defined_after_hoist(parent) {
             const id = node.definition().id;
             if (symbols_of_interest.has(id)) {
                 if (node instanceof AST_SymbolDeclaration || is_lhs(node, tw)) {
-                    found_symbol_writes.add(found_symbols.length);
+                    // `found_symbols.length` only becomes larger
+                    symbol_last_write_map.set(id, found_symbols.length);
                 }
                 found_symbols.push(id);
             }
@@ -645,17 +642,8 @@ function handle_defined_after_hoist(parent) {
         defun_first_read_map.set(defun, defun_first_read);
 
         // Update all depdencies of `defun`
-        let queue = enclosing_defuns_map.get(defun);
-        queue = queue ? queue.slice() : [];
-        const visited = new Set();
-        while (queue.length) {
-            const enclosed_defun = queue.pop();
-            // bail out on circular dependencies
-            if (visited.has(enclosed_defun)) {
-                continue;
-            }
-            visited.add(enclosed_defun);
-
+        const queue = new Set(enclosing_defuns_map.get(defun));
+        for (const enclosed_defun of queue) {
             let enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun);
             if (enclosed_defun_first_read != null && enclosed_defun_first_read < defun_first_read) {
                 continue;
@@ -664,12 +652,13 @@ function handle_defined_after_hoist(parent) {
             defun_first_read_map.set(enclosed_defun, defun_first_read);
 
             for (const enclosed_enclosed_defun of enclosing_defuns_map.get(enclosed_defun) || []) {
-                queue.push(enclosed_enclosed_defun);
+                queue.add(enclosed_enclosed_defun);
             }
         }
     }
 
     // ensure write-then-read order, otherwise clear `fixed`
+    // This is safe because last-writes (found_symbol_writes) are assumed to be as late as possible, and first-reads (defun_first_read_map) are assumed to be as early as possible.
     for (const [defun, defs] of defun_enclosing_defs_map) {
         const defun_first_read = defun_first_read_map.get(defun);
         if (defun_first_read === undefined) {
@@ -681,12 +670,7 @@ function handle_defined_after_hoist(parent) {
                 continue;
             }
 
-            let def_last_write = found_symbols.length;
-            while (--def_last_write >= 0) {
-                if (found_symbols[def_last_write] === def.id && found_symbol_writes.has(def_last_write)) {
-                    break;
-                }
-            }
+            let def_last_write = symbol_last_write_map.get(def.id) || 0;
 
             if (defun_first_read < def_last_write) {
                 def.fixed = false;

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -496,7 +496,24 @@ function mark_lambda(tw, descend, compressor) {
  *   // use defined_after
  * }
  *
- * This function is called on the parent to handle this issue.
+ * Or even indirectly:
+ *
+ * B();
+ * var defined_after = true;
+ * function A() {
+ *   // use defined_after
+ * }
+ * function B() {
+ *   A();
+ * }
+ *
+ * Access a variable before declaration will either throw a ReferenceError
+ * (if the variable is declared with `let` or `const`),
+ * or get an `undefined` (if the variable is declared with `var`).
+ *
+ * If the variable is inlined into the function, the behavior will change.
+ *
+ * This function is called on the parent to disallow inlining of such variables,
  */
 function handle_defined_after_hoist(parent) {
     const defuns = [];
@@ -508,16 +525,6 @@ function handle_defined_after_hoist(parent) {
             || node instanceof AST_SimpleStatement
         ) return true;
     });
-
-    // If a function `A` uses an outside variable `B`, calling `A` before `B` is defined
-    // will either cause a ReferenceError (if `B` is declared with `let` or `const`) or
-    // get an `undefined` (if `B` is declared with `var`).
-    //
-    // We want to inline `B` into `A` if `B` is a constant and only used in `A`, but we can't
-    // do that if the above situation happens, as it would change the behavior.
-    //
-    // This function checks for such use-before-define situations, including the case where
-    // `A` is indirectly called by another function `C` that is called before `B` is defined.
 
     // `defun` id to array of `defun` that use the function
     const defun_dependents_map = new Map();

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -630,7 +630,7 @@ function handle_defined_after_hoist(parent) {
         const defun_first_read = found_symbols.findIndex(
             (sym, index) =>
                 sym === defun &&
-                (index < defun_range.start || index > defun_range.end)
+                (defun_range.start === defun_range.end || index < defun_range.start || index >= defun_range.end)
         );
         if (defun_first_read === -1) {
             continue;
@@ -663,6 +663,7 @@ function handle_defined_after_hoist(parent) {
         }
     }
 
+    // ensure write-then-read order, otherwise clear `fixed`
     for (const [defun, defs] of defun_enclosing_defs_map) {
         const defun_first_read = defun_first_read_map.get(defun);
         if (defun_first_read === undefined) {

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -650,8 +650,7 @@ function handle_defined_after_hoist(parent) {
             visited.add(enclosed_defun);
 
             let enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun);
-            if (enclosed_defun_first_read == null) enclosed_defun_first_read = Infinity;
-            if (enclosed_defun_first_read < defun_first_read) {
+            if (enclosed_defun_first_read != null && enclosed_defun_first_read < defun_first_read) {
                 continue;
             }
 

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -94,8 +94,7 @@ import {
 
     walk,
     walk_body,
-
-    TreeWalker,
+    walk_parent,
 } from "../ast.js";
 import { HOP, make_node, noop } from "../utils/index.js";
 
@@ -519,19 +518,23 @@ function handle_defined_after_hoist(parent) {
     const defuns = [];
     walk(parent, node => {
         if (node === parent) return;
-        if (node instanceof AST_Defun) defuns.push(node);
+        if (node instanceof AST_Defun) {
+            defuns.push(node);
+            return true;
+        }
         if (
             node instanceof AST_Scope
             || node instanceof AST_SimpleStatement
         ) return true;
     });
 
-    // `defun` id to array of `defun` that use the function
-    const defun_dependents_map = new Map();
+    // `defun` id to array of `defun` it uses
+    const enclosing_defuns_map = new Map();
     // `defun` id to array of enclosing `def` that are used by the function
     const defun_enclosing_defs_map = new Map();
     // all symbol ids that will be tracked for read/write
     const symbols_of_interest = new Set();
+    const defuns_of_interest = new Set();
 
     for (const defun of defuns) {
         const fname_def = defun.name.definition();
@@ -546,25 +549,32 @@ function handle_defined_after_hoist(parent) {
                 continue;
             }
 
+            symbols_of_interest.add(def.id);
+
             // found a reference to another function
             if (
                 def.assignments === 0
                 && def.orig.length === 1
                 && def.orig[0] instanceof AST_SymbolDefun
             ) {
-                if (!defun_dependents_map.has(def.id)) {
-                    defun_dependents_map.set(def.id, []);
+                defuns_of_interest.add(fname_def.id);
+                symbols_of_interest.add(fname_def.id);
+
+                if (!enclosing_defuns_map.has(fname_def.id)) {
+                    enclosing_defuns_map.set(fname_def.id, []);
                 }
-                defun_dependents_map.get(def.id).push(fname_def.id);
+                enclosing_defuns_map.get(fname_def.id).push(def.id);
+
                 continue;
             }
 
             enclosing_defs.push(def);
-            symbols_of_interest.add(def.id);
         }
 
         if (enclosing_defs.length) {
             defun_enclosing_defs_map.set(fname_def.id, enclosing_defs);
+            defuns_of_interest.add(fname_def.id);
+            symbols_of_interest.add(fname_def.id);
         }
     }
 
@@ -573,74 +583,38 @@ function handle_defined_after_hoist(parent) {
         return;
     }
 
-    // `defun` id to array of enclsoing `defun` id
-    // reverse of `defun_dependents_map`, used to speed up updating `defun_first_read_map`
-    const enclosing_defuns_map = new Map();
-    // `defun` ids to be tracked for definition location
-    const defuns_of_interest = new Set(defun_enclosing_defs_map.keys());
-    for (const defun_id of defuns_of_interest) {
-        symbols_of_interest.add(defun_id);
-
-        for (const dependent of defun_dependents_map.get(defun_id) || []) {
-            if (!defuns_of_interest.has(dependent)) {
-                defuns_of_interest.add(dependent);
-
-                if (!enclosing_defuns_map.has(dependent)) {
-                    enclosing_defuns_map.set(dependent, []);
-                }
-                enclosing_defuns_map.get(dependent).push(defun_id);
-            }
-        }
-    }
-
-    // All "symbols of interest", that is, defuns or defs, that we found.
-    // These are placed in order so we can check which is after which.
-    const found_symbols = [];
-    // Map a symbol ID to its last write (a `found_symbols` index)
+    // Increment to count "symbols of interest" (defuns or defs) that we found.
+    // These are tracked in AST order so we can check which is after which.
+    let symbol_index = 1;
+    // Map a defun ID to its first read (a `symbol_index`)
+    const defun_first_read_map = new Map();
+    // Map a symbol ID to its last write (a `symbol_index`)
     const symbol_last_write_map = new Map();
-    // Defun ranges are recorded because we don't care if a function uses the def internally
-    const defun_ranges = new Map();
 
-    let tw;
-    parent.walk((tw = new TreeWalker((node, descend) => {
-        if (node instanceof AST_Defun) {
-            const id = node.name.definition().id;
-            if (defuns_of_interest.has(id)) {
-                const start = found_symbols.length;
-                descend();
-                const end = found_symbols.length;
-
-                defun_ranges.set(id, { start, end });
-                return true;
-            }
-        }
-        // if we found a defun on the list, mark IN_DEFUN=id and descend
-
+    walk_parent(parent, (node, walk_info) => {
         if (node instanceof AST_Symbol && node.thedef) {
             const id = node.definition().id;
+
+            symbol_index++;
+
+            // Track last-writes to symbols
             if (symbols_of_interest.has(id)) {
-                if (node instanceof AST_SymbolDeclaration || is_lhs(node, tw)) {
-                    // `found_symbols.length` only becomes larger
-                    symbol_last_write_map.set(id, found_symbols.length);
+                if (node instanceof AST_SymbolDeclaration || is_lhs(node, walk_info.parent())) {
+                    symbol_last_write_map.set(id, symbol_index);
                 }
-                found_symbols.push(id);
+            }
+
+            // Track first-reads of defuns (refined later)
+            if (defuns_of_interest.has(id)) {
+                if (!defun_first_read_map.has(id) && !is_recursive_ref(walk_info, id)) {
+                    defun_first_read_map.set(id, symbol_index);
+                }
             }
         }
-    })));
+    });
 
-    const defun_first_read_map = new Map();
-    for (const defun of defuns_of_interest) {
-        const defun_range = defun_ranges.get(defun);
-        const defun_first_read = found_symbols.findIndex(
-            (sym, index) =>
-                sym === defun &&
-                (defun_range.start === defun_range.end || index < defun_range.start || index >= defun_range.end)
-        );
-        if (defun_first_read === -1) {
-            continue;
-        }
-        defun_first_read_map.set(defun, defun_first_read);
-
+    // Refine `defun_first_read_map` to be as high as possible
+    for (const [defun, defun_first_read] of defun_first_read_map) {
         // Update all depdencies of `defun`
         const queue = new Set(enclosing_defuns_map.get(defun));
         for (const enclosed_defun of queue) {

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -649,14 +649,15 @@ function handle_defined_after_hoist(parent) {
             }
             visited.add(enclosed_defun);
 
-            const enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun) ?? Infinity;
+            let enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun);
+            if (enclosed_defun_first_read == null) enclosed_defun_first_read = Infinity;
             if (enclosed_defun_first_read < defun_first_read) {
                 continue;
             }
 
             defun_first_read_map.set(enclosed_defun, defun_first_read);
 
-            for (const enclosed_enclosed_defun of enclosing_defuns_map.get(enclosed_defun) ?? []) {
+            for (const enclosed_enclosed_defun of enclosing_defuns_map.get(enclosed_defun) || []) {
                 queue.push(enclosed_enclosed_defun);
             }
         }

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -509,15 +509,26 @@ function handle_defined_after_hoist(parent) {
         ) return true;
     });
 
+    // If a function `A` uses an outside variable `B`, calling `A` before `B` is defined
+    // will either cause a ReferenceError (if `B` is declared with `let` or `const`) or
+    // get an `undefined` (if `B` is declared with `var`).
+    //
+    // We want to inline `B` into `A` if `B` is a constant and only used in `A`, but we can't
+    // do that if the above situation happens, as it would change the behavior.
+    //
+    // This function checks for such use-before-define situations, including the case where
+    // `A` is indirectly called by another function `C` that is called before `B` is defined.
+
+    // `defun` id to array of `defun` that use the function
+    const defun_dependents_map = new Map();
+    // `defun` id to array of enclosing `def` that are used by the function
+    const defun_enclosing_defs_map = new Map();
+    // all symbol ids that will be tracked for read/write
     const symbols_of_interest = new Set();
-    const defuns_of_interest = new Set();
-    const potential_conflicts = [];
 
     for (const defun of defuns) {
         const fname_def = defun.name.definition();
-        const found_self_ref_in_other_defuns = defuns.some(
-            d => d !== defun && d.enclosed.indexOf(fname_def) !== -1
-        );
+        const enclosing_defs = [];
 
         for (const def of defun.enclosed) {
             if (
@@ -528,93 +539,144 @@ function handle_defined_after_hoist(parent) {
                 continue;
             }
 
-            // defun is hoisted, so always safe
+            // found a reference to another function
             if (
                 def.assignments === 0
                 && def.orig.length === 1
                 && def.orig[0] instanceof AST_SymbolDefun
             ) {
+                if (!defun_dependents_map.has(def.id)) {
+                    defun_dependents_map.set(def.id, []);
+                }
+                defun_dependents_map.get(def.id).push(fname_def.id);
                 continue;
             }
 
-            if (found_self_ref_in_other_defuns) {
-                def.fixed = false;
-                continue;
-            }
-
-            // for the slower checks below this loop
-            potential_conflicts.push({ defun, def, fname_def });
+            enclosing_defs.push(def);
             symbols_of_interest.add(def.id);
-            symbols_of_interest.add(fname_def.id);
-            defuns_of_interest.add(defun);
+        }
+
+        if (enclosing_defs.length) {
+            defun_enclosing_defs_map.set(fname_def.id, enclosing_defs);
         }
     }
 
-    // linearize all symbols, and locate defs that are read after the defun
-    if (potential_conflicts.length) {
-        // All "symbols of interest", that is, defuns or defs, that we found.
-        // These are placed in order so we can check which is after which.
-        const found_symbols = [];
-        // Indices of `found_symbols` which are writes
-        const found_symbol_writes = new Set();
-        // Defun ranges are recorded because we don't care if a function uses the def internally
-        const defun_ranges = new Map();
+    // No defuns use outside constants
+    if (!defun_enclosing_defs_map.size) {
+        return;
+    }
 
-        let tw;
-        parent.walk((tw = new TreeWalker((node, descend) => {
-            if (node instanceof AST_Defun && defuns_of_interest.has(node)) {
+    // `defun` id to array of enclsoing `defun` id
+    // reverse of `defun_dependents_map`, used to speed up updating `defun_first_read_map`
+    const enclosing_defuns_map = new Map();
+    // temp work queue
+    const defun_queue = Array.from(defun_enclosing_defs_map.keys());
+    // `defun` ids to be tracked for definition location
+    const defuns_of_interest = new Set(defun_queue);
+    while (defun_queue.length) {
+        const defun_id = defun_queue.pop();
+        symbols_of_interest.add(defun_id);
+
+        for (const dependent of defun_dependents_map.get(defun_id) || []) {
+            if (!defuns_of_interest.has(dependent)) {
+                defuns_of_interest.add(dependent);
+                defun_queue.push(dependent);
+
+                if (!enclosing_defuns_map.has(dependent)) {
+                    enclosing_defuns_map.set(dependent, []);
+                }
+                enclosing_defuns_map.get(dependent).push(defun_id);
+            }
+        }
+    }
+
+    // All "symbols of interest", that is, defuns or defs, that we found.
+    // These are placed in order so we can check which is after which.
+    const found_symbols = [];
+    // Indices of `found_symbols` which are writes
+    const found_symbol_writes = new Set();
+    // Defun ranges are recorded because we don't care if a function uses the def internally
+    const defun_ranges = new Map();
+
+    let tw;
+    parent.walk((tw = new TreeWalker((node, descend) => {
+        if (node instanceof AST_Defun) {
+            const id = node.name.definition().id;
+            if (defuns_of_interest.has(id)) {
                 const start = found_symbols.length;
                 descend();
                 const end = found_symbols.length;
 
-                defun_ranges.set(node, { start, end });
+                defun_ranges.set(id, { start, end });
                 return true;
             }
-            // if we found a defun on the list, mark IN_DEFUN=id and descend
+        }
+        // if we found a defun on the list, mark IN_DEFUN=id and descend
 
-            if (node instanceof AST_Symbol && node.thedef) {
-                const id = node.definition().id;
-                if (symbols_of_interest.has(id)) {
-                    if (node instanceof AST_SymbolDeclaration || is_lhs(node, tw)) {
-                        found_symbol_writes.add(found_symbols.length);
-                    }
-                    found_symbols.push(id);
+        if (node instanceof AST_Symbol && node.thedef) {
+            const id = node.definition().id;
+            if (symbols_of_interest.has(id)) {
+                if (node instanceof AST_SymbolDeclaration || is_lhs(node, tw)) {
+                    found_symbol_writes.add(found_symbols.length);
                 }
+                found_symbols.push(id);
             }
-        })));
+        }
+    })));
 
-        for (const { def, defun, fname_def } of potential_conflicts) {
-            const defun_range = defun_ranges.get(defun);
+    const defun_first_read_map = new Map();
+    for (const defun of defuns_of_interest) {
+        const defun_range = defun_ranges.get(defun);
+        const defun_first_read = found_symbols.findIndex(
+            (sym, index) =>
+                sym === defun &&
+                (index < defun_range.start || index > defun_range.end)
+        );
+        if (defun_first_read === -1) {
+            continue;
+        }
+        defun_first_read_map.set(defun, defun_first_read);
 
-            // find the index in `found_symbols`, with some special rules:
-            const find = (sym_id, starting_at = 0, must_be_write = false) => {
-                let index = starting_at;
+        // Update all depdencies of `defun`
+        const queue = enclosing_defuns_map.get(defun)?.slice() ?? [];
+        const visited = new Set();
+        while (queue.length) {
+            const enclosed_defun = queue.pop();
+            // bail out on circular dependencies
+            if (visited.has(enclosed_defun)) {
+                continue;
+            }
+            visited.add(enclosed_defun);
 
-                for (;;) {
-                    index = found_symbols.indexOf(sym_id, index);
+            const enclosed_defun_first_read = defun_first_read_map.get(enclosed_defun) ?? Infinity;
+            if (enclosed_defun_first_read < defun_first_read) {
+                continue;
+            }
 
-                    if (index === -1) {
-                        break;
-                    } else if (index >= defun_range.start && index < defun_range.end) {
-                        index = defun_range.end;
-                        continue;
-                    } else if (must_be_write && !found_symbol_writes.has(index)) {
-                        index++;
-                        continue;
-                    } else {
-                        break;
-                    }
-                }
+            defun_first_read_map.set(enclosed_defun, defun_first_read);
 
-                return index;
-            };
+            for (const enclosed_enclosed_defun of enclosing_defuns_map.get(enclosed_defun) ?? []) {
+                queue.push(enclosed_enclosed_defun);
+            }
+        }
+    }
 
-            const read_defun_at = find(fname_def.id);
-            const wrote_def_at = find(def.id, read_defun_at + 1, true);
+    for (const [defun, defs] of defun_enclosing_defs_map) {
+        const defun_first_read = defun_first_read_map.get(defun);
+        if (defun_first_read === undefined) {
+            continue;
+        }
 
-            const wrote_def_after_reading_defun = read_defun_at != -1 && wrote_def_at != -1 && wrote_def_at > read_defun_at;
+        for (const def of defs) {
+            if (def.fixed === false) {
+                continue;
+            }
 
-            if (wrote_def_after_reading_defun) {
+            const def_last_write = found_symbols.findLastIndex(
+                (sym, index) => sym === def.id && found_symbol_writes.has(index)
+            );
+
+            if (defun_first_read < def_last_write) {
                 def.fixed = false;
             }
         }

--- a/test/compress/issue-1338.js
+++ b/test/compress/issue-1338.js
@@ -1,0 +1,52 @@
+comment_1562957781: {
+    options = {
+        unused: true,
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true
+    }
+    input: {
+        'use strict';
+
+        const DEBUG = false;
+
+        function initPlayer() { // eslint-disable-line
+            const player = new createPlayer();
+
+            return player;
+        }
+
+        function createPlayer() {
+            if (DEBUG) {
+                console.log('-> new player');
+            }
+
+            this.destroy = () => {
+                if (DEBUG) {
+                    console.log('-> destroyed player');
+                }
+            };
+        }
+
+        initPlayer();
+    }
+    expect: {
+        'use strict';
+
+        function createPlayer() {
+            if (false)
+                console.log('-> new player');
+
+            this.destroy = () => {
+                if (false)
+                    console.log('-> destroyed player');
+            };
+        }
+
+        (function () { // eslint-disable-line
+            const player = new createPlayer();
+
+            return player;
+        })()
+    }
+}

--- a/test/compress/issue-1429.js
+++ b/test/compress/issue-1429.js
@@ -1,0 +1,95 @@
+variant_1: {
+    options = {
+        unused: true,
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true
+    }
+    input: {
+        const A = 1, B = 0, C = 2, D = 3;
+
+        export function f() {
+            return A * (B + C + 2 * D);
+        }
+    }
+    expect: {
+        export function f() {
+            return 8;
+        }
+    }
+}
+
+variant_2: {
+    options = {
+        unused: true,
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true
+    }
+    input: {
+        const A = 1, B = 0, C = 2, D = 3;
+
+        export function f() {
+            return A * (B + C + 2 * D);
+        }
+
+        export default function () { return f; }
+    }
+    expect: {
+        export function f() {
+            return 8;
+        }
+
+        export default function () { return f; }
+    }
+}
+
+variant_3: {
+    options = {
+        unused: true,
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true
+    }
+    input: {
+        const A = 1, B = 0, C = 2, D = 3;
+
+        export function f() {
+            return A * (B + C + 2 * D);
+        }
+
+        export function g() { return f; }
+    }
+    expect: {
+        export function f() {
+            return 8;
+        }
+
+        export function g() { return f; }
+    }
+}
+
+variant_4: {
+    options = {
+        unused: true,
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true
+    }
+    input: {
+        const A = 1, B = 0, C = 2, D = 3;
+
+        export function f() {
+            return A * (B + C + 2 * D);
+        }
+
+        export default function g() { return f; }
+    }
+    expect: {
+        export function f() {
+            return 8;
+        }
+
+        export default function g() { return f; }
+    }
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -1344,6 +1344,70 @@ defun_reference_indirection_2: {
     expect_stdout: "undefined"
 }
 
+defun_reference_indirection_after_def_1: {
+    options = {
+        toplevel: true,
+        reduce_vars: true,
+        unused: true,
+        evaluate: true
+    }
+    input: {
+        if (id(true)) {
+            var on = true;
+            function log_on() {
+                console.log(on)
+            }
+            indirection_2();
+            function indirection_2() {
+                log_on()
+            }
+        }
+    }
+    expect: {
+        if (id(true)) {
+            function log_on() {
+                console.log(true);
+            }
+            (function () {
+                log_on();
+            })();
+        }
+    }
+    expect_stdout: "true"
+}
+
+defun_reference_indirection_after_def_2: {
+    options = {
+        toplevel: true,
+        reduce_vars: true,
+        unused: true,
+        evaluate: true
+    }
+    input: {
+        if (id(true)) {
+            var on = true;
+            function log_on() {
+                console.log(on)
+            }
+            function indirection_2() {
+                log_on()
+            }
+            indirection_2();
+        }
+    }
+    expect: {
+        if (id(true)) {
+            function log_on() {
+                console.log(true);
+            }
+            (function () {
+                log_on();
+            })();
+        }
+    }
+    expect_stdout: "true"
+}
+
 defun_reference_used_before_def: {
     options = {
         toplevel: true,


### PR DESCRIPTION
Fixes #1429 

This allows variables to be reduced when used in a function that has indirect calls.

I'm new to terser so it might have bugs.

Benchmark result:

| url                                                                                | input size | before output size | after output size | size diff     | before time | after time | time diff |
| ---------------------------------------------------------------------------------- | ---------- | ------------------ | ----------------- | ------------- | ----------- | ---------- | --------- |
| https://code.jquery.com/jquery-3.2.1.js                                            | 268039     | 86877              | 86877             | 0             | 674.72494   | 672.01946  | -0.40%    |
| https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.4/angular.js                 | 1249863    | 174525             | 174482            | -43 (-0.02%)  | 1175.19904  | 1187.24018 | +1.02%    |
| https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.9.0/math.js                        | 1590107    | 466647             | 466637            | -10 (-0.00%)  | 2040.97124  | 1998.89482 | -2.06%    |
| https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.js                    | 69707      | 37046              | 37046             | 0             | 326.45528   | 319.89132  | -2.01%    |
| https://unpkg.com/react@15.3.2/dist/react.js                                       | 701412     | 205980             | 205959            | -21 (-0.01%)  | 1035.3006   | 1031.51174 | -0.37%    |
| http://builds.emberjs.com/tags/v2.11.0/ember.prod.js                               | 1852178    | 528006             | 528006            | 0             | 1900.31164  | 1906.68276 | +0.34%    |
| https://cdn.jsdelivr.net/lodash/4.17.4/lodash.js                                   | 539590     | 70560              | 70560             | 0             | 712.81798   | 717.3766   | +0.64%    |
| https://cdnjs.cloudflare.com/ajax/libs/d3/4.5.0/d3.js                              | 451131     | 212579             | 212498            | -81 (-0.04%)  | 1314.11204  | 1327.10142 | +0.99%    |
| https://raw.githubusercontent.com/kangax/html-minifier/v3.5.7/dist/htmlminifier.js | 1063075    | 511806             | 511105            | -701 (-0.14%) | 2020.1799   | 1999.70882 | -1.01%    |

In my real project it can shave another 1% (20KB).