### PR TITLE
Allow `typeofs` to evaluate typeof on object and array

### DIFF
--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -218,14 +218,22 @@ def_eval(AST_Object, function (compressor, depth) {
 var non_converting_unary = makePredicate("! typeof void");
 def_eval(AST_UnaryPrefix, function (compressor, depth) {
     var e = this.expression;
-    // Function would be evaluated to an array and so typeof would
-    // incorrectly return 'object'. Hence making is a special case.
     if (compressor.option("typeofs")
-        && this.operator == "typeof"
-        && (e instanceof AST_Lambda
+        && this.operator == "typeof") {
+        // Function would be evaluated to an array and so typeof would
+        // incorrectly return 'object'. Hence making is a special case.
+        if (e instanceof AST_Lambda
             || e instanceof AST_SymbolRef
-            && e.fixed_value() instanceof AST_Lambda)) {
-        return typeof function () { };
+            && e.fixed_value() instanceof AST_Lambda) {
+            return typeof function () { };
+        }
+        if (e instanceof AST_Object
+            || e instanceof AST_Array
+            || (e instanceof AST_SymbolRef
+                && (e.fixed_value() instanceof AST_Object
+                    || e.fixed_value() instanceof AST_Array))) {
+            return typeof {};
+        }
     }
     if (!non_converting_unary.has(this.operator))
         depth++;

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -227,11 +227,14 @@ def_eval(AST_UnaryPrefix, function (compressor, depth) {
             && e.fixed_value() instanceof AST_Lambda) {
             return typeof function () { };
         }
-        if (e instanceof AST_Object
-            || e instanceof AST_Array
-            || (e instanceof AST_SymbolRef
-                && (e.fixed_value() instanceof AST_Object
-                    || e.fixed_value() instanceof AST_Array))) {
+        if (
+            (e instanceof AST_Object
+                || e instanceof AST_Array
+                || (e instanceof AST_SymbolRef
+                    && (e.fixed_value() instanceof AST_Object
+                        || e.fixed_value() instanceof AST_Array)))
+            && !e.has_side_effects(compressor)
+        ) {
             return typeof {};
         }
     }

--- a/test/compress/typeof.js
+++ b/test/compress/typeof.js
@@ -12,16 +12,18 @@ typeof_evaluation: {
         f = typeof false;
         g = typeof function(){};
         h = typeof undefined;
+        i = typeof 1n;
     }
     expect: {
         a='number';
         b='string';
-        c=typeof[];
-        d=typeof{};
+        c='object';
+        d='object';
         e=typeof/./;
         f='boolean';
         g='function';
         h='undefined';
+        i='bigint';
     }
 }
 
@@ -294,4 +296,42 @@ issue_2728_6: {
         console.log(typeof arguments, arguments());
     }
     expect_stdout: "function undefined"
+}
+
+issue_250_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        typeofs: true,
+    }
+    input: {
+        const obj = {};
+        if (typeof obj !== "undefined") console.log(typeof obj)
+    }
+    expect: {
+        const obj = {};
+        if (true) console.log("object")
+    }
+    expect_stdout: "object"
+}
+
+issue_250_2: {
+    options = {
+        conditionals: true,
+        evaluate: true,
+        side_effects: true,
+        typeofs: true,
+        unused: true,
+        toplevel: true,
+        global_defs: {
+            window: {},
+            global: {},
+        }
+    }
+    input: {
+        var __window = typeof window !== 'undefined' && window;
+        if (typeof global === 'undefined' || global) { }
+        if (typeof global !== 'undefined' && global) { }
+    }
+    expect: {}
 }


### PR DESCRIPTION
Partialy resolved: #250.

Only fixs `typeof`, because `instanceof`'s behavior is unsafe to be determined on compile time. (E.G. We can use `Symbol.hasInstance` to override)
