### PR TITLE
Fix incorrect bigint literal conversion to/from ESTree

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -662,6 +662,11 @@ import { is_basic_identifier_string } from "./parse.js";
                 args.value = { source, flags };
                 return new AST_RegExp(args);
             }
+            const bi = typeof M.value === "bigint" ? M.value.toString() : M.bigint;
+            if (typeof bi === "string") {
+                args.value = bi;
+                return new AST_BigInt(args);
+            }
             if (val === null) return new AST_Null(args);
             switch (typeof val) {
               case "string":
@@ -689,9 +694,6 @@ import { is_basic_identifier_string } from "./parse.js";
                 return new AST_Number(args);
               case "boolean":
                 return new (val ? AST_True : AST_False)(args);
-              case "bigint":
-                args.value = val;
-                return new AST_BigInt(args);
             }
         },
 
@@ -1750,8 +1752,12 @@ import { is_basic_identifier_string } from "./parse.js";
 
     def_to_moz(AST_BigInt, M => ({
         type: "Literal",
-        value: typeof BigInt === 'function' ? BigInt(M.value) : null,
-        bigint: M.value
+        // value cannot be represented natively
+        // see: https://github.com/estree/estree/blob/master/es2020.md#bigintliteral
+        value: null,
+        // `M.value` is a string that may be a hex number representation.
+        // but "bigint" property should have only decimal digits
+        bigint: typeof BigInt === "function" ? BigInt(M.value).toString() : M.value,
     }));
 
     AST_Boolean.DEFMETHOD("to_mozilla_ast", AST_Constant.prototype.to_mozilla_ast);

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -689,6 +689,9 @@ import { is_basic_identifier_string } from "./parse.js";
                 return new AST_Number(args);
               case "boolean":
                 return new (val ? AST_True : AST_False)(args);
+              case "bigint":
+                args.value = val;
+                return new AST_BigInt(args);
             }
         },
 
@@ -727,14 +730,6 @@ import { is_basic_identifier_string } from "./parse.js";
                             end   : my_end_token(M),
                             name  : M.name
                         });
-        },
-
-        BigIntLiteral(M) {
-            return new AST_BigInt({
-                start : my_start_token(M),
-                end   : my_end_token(M),
-                value : M.value
-            });
         },
 
         EmptyStatement: function(M) {
@@ -1754,8 +1749,9 @@ import { is_basic_identifier_string } from "./parse.js";
     });
 
     def_to_moz(AST_BigInt, M => ({
-        type: "BigIntLiteral",
-        value: M.value
+        type: "Literal",
+        value: M.value,
+        bigint: M.value.toString()
     }));
 
     AST_Boolean.DEFMETHOD("to_mozilla_ast", AST_Constant.prototype.to_mozilla_ast);

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -1750,8 +1750,8 @@ import { is_basic_identifier_string } from "./parse.js";
 
     def_to_moz(AST_BigInt, M => ({
         type: "Literal",
-        value: M.value,
-        bigint: M.value.toString()
+        value: typeof BigInt === 'function' ? BigInt(M.value) : null,
+        bigint: M.value
     }));
 
     AST_Boolean.DEFMETHOD("to_mozilla_ast", AST_Constant.prototype.to_mozilla_ast);

--- a/test/compress.js
+++ b/test/compress.js
@@ -451,6 +451,7 @@ function parse_test(file) {
                         "expect_exact",
                         "expect_stdout",
                         "node_version",
+                        "no_mozilla_ast",
                         "reminify",
                     ].includes(label.name),
                     tmpl("Unsupported label {name} [{line},{col}]", {
@@ -487,6 +488,8 @@ function parse_test(file) {
                     }
                 } else if (label.name === "prepend_code") {
                     test[label.name] = read_string(stat);
+                } else if (label.name === "no_mozilla_ast") {
+                    test[label.name] = read_boolean(stat);
                 } else {
                     test[label.name] = stat;
                 }

--- a/test/compress/big_int.js
+++ b/test/compress/big_int.js
@@ -18,6 +18,7 @@ big_int_hex: {
         0xfabn
     }
     expect_exact: "0x20n;0xfabn;"
+    no_mozilla_ast: true
 }
 
 regression_big_int_hex_lower_with_e: {
@@ -25,6 +26,7 @@ regression_big_int_hex_lower_with_e: {
         0xaefen;
     }
     expect_exact: "0xaefen;"
+    no_mozilla_ast: true
 }
 
 big_int_binary: {
@@ -32,6 +34,7 @@ big_int_binary: {
         0b101n
     }
     expect_exact: "0b101n;"
+    no_mozilla_ast: true
 }
 
 big_int_octal: {
@@ -39,6 +42,7 @@ big_int_octal: {
         0o7n
     }
     expect_exact: "0o7n;"
+    no_mozilla_ast: true
 }
 
 big_int_no_e: {


### PR DESCRIPTION
When working with [ESTrees](https://github.com/estree/estree) (a.k.a. Mozilla/SpiderMonkey ASTs), Terser assumes that bigint literal objects have the following shape:
```
type: "BigIntLiteral",
value: 123n,
```
However, "BigIntLiteral" is just the name of ESTree's internal canonical interface, not the value of the `type` property. [Looking at the specification](https://github.com/estree/estree/blob/master/es2020.md), bigint literals instead have the following shape:
```
type: "Literal",
value: 123n,
bigint: "123",
```
This PR updates the code to match the behavior from the spec and to be compatible with other ESTree-producing/consuming tools.