### PR TITLE
WIP: reactivate 'rename' step

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -150,12 +150,12 @@ function* minify_sync_or_async(files, options, _fs_module) {
     }
     options.format = options.format || options.output || {};
     set_shorthand("ecma", options, [ "parse", "compress", "format" ]);
-    set_shorthand("ie8", options, [ "compress", "mangle", "format" ]);
-    set_shorthand("keep_classnames", options, [ "compress", "mangle" ]);
-    set_shorthand("keep_fnames", options, [ "compress", "mangle" ]);
-    set_shorthand("module", options, [ "parse", "compress", "mangle" ]);
-    set_shorthand("safari10", options, [ "mangle", "format" ]);
-    set_shorthand("toplevel", options, [ "compress", "mangle" ]);
+    set_shorthand("ie8", options, [ "compress", "mangle", "format", "rename" ]);
+    set_shorthand("keep_classnames", options, [ "compress", "mangle", "rename" ]);
+    set_shorthand("keep_fnames", options, [ "compress", "mangle", "rename" ]);
+    set_shorthand("module", options, [ "parse", "compress", "mangle", "rename" ]);
+    set_shorthand("safari10", options, [ "mangle", "format", "rename" ]);
+    set_shorthand("toplevel", options, [ "compress", "mangle", "rename" ]);
     set_shorthand("warnings", options, [ "compress" ]); // legacy
     var quoted_props;
     if (options.mangle) {
@@ -252,9 +252,9 @@ function* minify_sync_or_async(files, options, _fs_module) {
     if (timings) timings.rename = Date.now();
     // disable rename on harmony due to expand_names bug in for-of loops
     // https://github.com/mishoo/UglifyJS2/issues/2794
-    if (0 && options.rename) {
-        toplevel.figure_out_scope(options.mangle);
-        toplevel.expand_names(options.mangle);
+    if (options.rename) {
+        toplevel.figure_out_scope(options.rename);
+        toplevel.expand_names(options.rename);
     }
 
     // -- Compress phase --

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -909,10 +909,11 @@ AST_Toplevel.DEFMETHOD("find_colliding_names", function(options) {
     const avoid = new Set();
     options.reserved.forEach(to_avoid);
     this.globals.forEach(add_def);
-    this.walk(new TreeWalker(function(node) {
+    walk(this, node => {
         if (node instanceof AST_Scope) node.variables.forEach(add_def);
-        if (node instanceof AST_SymbolCatch) add_def(node.definition());
-    }));
+        else if (node.block_scope) node.block_scope.variables.forEach(add_def);
+        else if (node instanceof AST_SymbolCatch) add_def(node.definition());
+    });
     return avoid;
 
     function to_avoid(name) {
@@ -937,10 +938,11 @@ AST_Toplevel.DEFMETHOD("expand_names", function(options) {
     var avoid = this.find_colliding_names(options);
     var cname = 0;
     this.globals.forEach(rename);
-    this.walk(new TreeWalker(function(node) {
+    walk(this, node => {
         if (node instanceof AST_Scope) node.variables.forEach(rename);
-        if (node instanceof AST_SymbolCatch) rename(node.definition());
-    }));
+        else if (node.block_scope) node.block_scope.variables.forEach(rename);
+        else if (node instanceof AST_SymbolCatch) rename(node.definition());
+    });
 
     function next_name() {
         var name;

--- a/test/compress.js
+++ b/test/compress.js
@@ -390,8 +390,8 @@ async function run_compress_tests(test_files, in_child_process) {
                 }
             }
             if (test.rename) {
-                input.figure_out_scope(test.mangle);
-                input.expand_names(test.mangle);
+                input.figure_out_scope(test.rename);
+                input.expand_names(test.rename);
             }
             var cmp = new Compressor(options, {
                 false_by_default: options.defaults === undefined ? true : !options.defaults,


### PR DESCRIPTION
The 'rename' step is one of the major compression steps (among mangle, compress, ...). It was deactivated in UglifyJS before Terser became a fork.

The objective of this branch is to bring it back.