### PR TITLE
fix: correctly remove the console methods when drop_console is an array

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -524,15 +524,17 @@ AST_Toplevel.DEFMETHOD("drop_console", function(options) {
             return;
         }
 
-        if (isArray && !options.includes(exp.property)) {
-            return;
-        }
-
         var name = exp.expression;
+        var property = exp.property;
         var depth = 2;
         while (name.expression) {
+            property = name.property;
             name = name.expression;
             depth++;
+        }
+
+        if (isArray && !options.includes(property)) {
+            return;
         }
 
         if (is_undeclared_ref(name) && name.name == "console") {

--- a/test/compress/drop-console.js
+++ b/test/compress/drop-console.js
@@ -71,3 +71,19 @@ unexpected_returned_value_dropping_console: {
         b.log("hi");
     }
 }
+
+drop_console_with_array_option: {
+    options = {
+        drop_console: ["log"],
+    }
+    input: {
+        console.log("foo");
+        console.log.apply(console, arguments);
+        console.info("foo");
+    }
+    expect: {
+        void 0;
+        void 0;
+        console.info("foo");
+    }
+}


### PR DESCRIPTION
The current `drop_console` implementation only removes direct console method calls (e.g. `console.log()`) but fails to remove chained method calls like `console.log.apply()`.