### PR TITLE
Solving issue-1545

### DIFF
--- a/lib/compress/compressor-flags.js
+++ b/lib/compress/compressor-flags.js
@@ -48,7 +48,6 @@ export const TRUTHY = 0b00000010;
 export const FALSY = 0b00000100;
 export const UNDEFINED = 0b00001000;
 export const INLINED = 0b00010000;
-
 // Nodes to which values are ever written. Used when keep_assign is part of the unused option string.
 export const WRITE_ONLY = 0b00100000;
 

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1729,7 +1729,6 @@ def_optimize(AST_Call, function(self, compressor) {
         && exp.property === "assert"
     ) {
         const condition = self.args[0];
-    
         if (condition) {
             const value = condition.evaluate(compressor);
     

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -188,7 +188,6 @@ import {
     UNUSED,
     TRUTHY,
     FALSY,
-
     has_flag,
     set_flag,
     clear_flag,
@@ -496,6 +495,7 @@ class Compressor extends TreeWalker {
         return is_lhs(self, parent);
     }
 }
+
 
 function def_optimize(node, optimizer) {
     node.DEFMETHOD("optimize", function(compressor) {
@@ -1720,6 +1720,29 @@ def_optimize(AST_Call, function(self, compressor) {
         }
         self.args.length = last;
     }
+
+    if (
+        exp instanceof AST_Dot &&
+        exp.expression instanceof AST_SymbolRef &&
+        exp.expression.name === "console" &&
+        exp.property === "assert"
+    ) {
+        const condition = self.args[0];
+    
+        if (condition) {
+            const value = condition.evaluate(compressor);
+    
+            if (typeof value === "boolean" || value === 0 || value === 1) {
+                if (value === true || value === 1) {
+                    return make_node(AST_Undefined, self);
+                } else {
+                    return self;
+                }
+            } else {
+                console.log("[DEBUG] Skipping console.assert due to unknown condition:", self.print_to_string());
+            }
+        }
+    }    
 
     if (compressor.option("unsafe") && !exp.contains_optional()) {
         if (exp instanceof AST_Dot && exp.start.value === "Array" && exp.property === "from" && self.args.length === 1) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -1722,24 +1722,19 @@ def_optimize(AST_Call, function(self, compressor) {
     }
 
     if (
-        exp instanceof AST_Dot &&
-        exp.expression instanceof AST_SymbolRef &&
-        exp.expression.name === "console" &&
-        exp.property === "assert"
+        exp instanceof AST_Dot
+        && exp.expression instanceof AST_SymbolRef
+        && exp.expression.name === "console"
+        && exp.expression.definition().undeclared
+        && exp.property === "assert"
     ) {
         const condition = self.args[0];
     
         if (condition) {
             const value = condition.evaluate(compressor);
     
-            if (typeof value === "boolean" || value === 0 || value === 1) {
-                if (value === true || value === 1) {
-                    return make_node(AST_Undefined, self);
-                } else {
-                    return self;
-                }
-            } else {
-                console.log("[DEBUG] Skipping console.assert due to unknown condition:", self.print_to_string());
+            if (value === 1 || value === true) {
+                return make_node(AST_Undefined, self);
             }
         }
     }    

--- a/test/compress/issue-1545.js
+++ b/test/compress/issue-1545.js
@@ -1,0 +1,18 @@
+issue_1545: {
+    options = {
+        evaluate: true,
+        unused: true,
+        side_effects: true,
+        toplevel: true, 
+    }
+    input: {
+        console.assert(true, "This should be removed");
+        console.assert(1, "This should be removed too");
+        console.assert(false, "This should remain");
+        console.assert(0, "This should remain as well");
+    }
+    expect: {
+        console.assert(false, "This should remain");
+        console.assert(0, "This should remain as well");
+    }
+}


### PR DESCRIPTION
## Title: Remove unnecessary `console.assert` calls (Issue #1545)

### Description:
This pull request addresses Issue #1545 in the Terser project, which involves removing unnecessary `console.assert` calls from the codebase. Specifically, this PR removes `console.assert` calls with expressions that are always true, ensuring that only relevant assertions remain in the code.

### Changes made:
- Removed `console.assert(true, ...)` and `console.assert(1, ...)` calls, as they don't serve any purpose.
- Kept `console.assert(false, ...)` and `console.assert(0, ...)` calls, as these might be valuable for debugging.

### Test Results:
- The test for Issue #1545 has been updated and successfully passes with the expected output.

### Related Issues:
- Closes #1545
