### PR TITLE
Fix unitialized const declaration when minifying from spidermonkey ast

### DIFF
--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -730,8 +730,9 @@ import { is_basic_identifier_string } from "./parse.js";
 
         Identifier: function(M) {
             var p = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 2];
+            var q = FROM_MOZ_STACK[FROM_MOZ_STACK.length - 3];
             return new (  p.type == "LabeledStatement" ? AST_Label
-                        : p.type == "VariableDeclarator" && p.id === M ? (p.kind == "const" ? AST_SymbolConst : p.kind == "let" ? AST_SymbolLet : AST_SymbolVar)
+                        : p.type == "VariableDeclarator" && p.id === M ? (q.kind == "const" ? AST_SymbolConst : q.kind == "let" ? AST_SymbolLet : AST_SymbolVar)
                         : /Import.*Specifier/.test(p.type) ? (p.local === M ? AST_SymbolImport : AST_SymbolImportForeign)
                         : p.type == "ExportSpecifier" ? (p.local === M ? AST_SymbolExport : AST_SymbolExportForeign)
                         : p.type == "FunctionExpression" ? (p.id === M ? AST_SymbolLambda : AST_SymbolFunarg)

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -145,6 +145,21 @@ describe("spidermonkey export/import sanity test", function() {
         );
     });
 
+    it("should correctly minify spidermonkey AST with condition and inlineable const variable declaration", async () => {
+        const code = "if (a) { const tmp = a; tmp.b(); }";
+        const ast = acornParse(code, { sourceType: 'module', locations: true, ecmaVersion: 2015 });
+        const result = await minify(ast, { ecma: 2015, module: true, parse: { spidermonkey: true } });
+        assert.strictEqual(
+            result.code,
+            "if(a){a.b()}"
+        );
+        const vanilla = await minify(code, { ecma: 2015, module: true });
+        assert.strictEqual(
+            result.code,
+            vanilla.code
+        );
+    });
+
     it("should correctly minify AST from from_moz_ast with default function parameter", async () => {
         const code = "function run(x = 2){}";
         const acornAst = acornParse(code, { locations: true, ecmaVersion: 2023 });


### PR DESCRIPTION
When const assignents are inlined into subsequent expressions, the const declaration were not removed during minifcation in module mode, causing an invalid, unitialized const declaration to be emitted.

Per original spidermonkey specification [1] and estree, the variable declaration `kind` (var, const, let) is not defined in `VariableDeclarator` [1] nodes, but in its parent node `VariableDeclaration` [2]:

```
Node {
  type: 'VariableDeclaration',
  declarations: [
    Node {
      type: 'VariableDeclarator',
      id: …
      init: …
    }
  ],
  kind: 'const'
}
```

The AST converter tried to read `kind` from `VariableDeclarator`, where it is never supplied, causing invalid terser AST: `AST_Const` was combined with `AST_VarDef` instead of `AST_SymbolConst` nodes:

```
AST_Const {
  definitions: [
    AST_VarDef {
      name: AST_SymbolVar {
        init: undefined,
        scope: undefined,
        name: 'tmp',
        thedef: undefined,
        start: [AST_Token `` at 1:15],
        end: [AST_Token `` at 1:18],
        flags: 0
      },
      value: AST_SymbolRef {
        scope: undefined,
        name: 'a',
        thedef: undefined,
        start: [AST_Token `` at 1:21],
        end: [AST_Token `` at 1:22],
        flags: 0
      },
      start: [AST_Token `` at 1:15],
      end: [AST_Token `` at 1:22],
      flags: 0
    }
  ]
}
```

Adapt the spidermonkey/mozilla to terser ast converter to read the variable type from the 'VariableDeclaration' instead of 'VariableDeclarator'.

[1] https://web.archive.org/web/20210314002546/https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API#variableDeclaration(kind_dtors_loc)
[2] https://github.com/estree/estree/blob/master/es5.md#variabledeclarator
[3] https://github.com/estree/estree/blob/master/es5.md#variabledeclaration

Fixes #1598