### PR TITLE
support inlining functions with default parameters

### DIFF
--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -140,6 +140,8 @@ export const is_undeclared_ref = (node) =>
 export const bitwise_binop = makePredicate("<<< >> << & | ^ ~");
 export const lazy_op = makePredicate("&& || ??");
 export const unary_side_effects = makePredicate("delete ++ --");
+const unary_defined = makePredicate("+ - ++ -- ! ~ typeof delete");
+const binary_defined = makePredicate("+ - * / % ** << >> >>> & ^ | || ??");
 
 // methods to determine whether an expression has a boolean result type
 (function(def_is_boolean) {
@@ -320,6 +322,39 @@ export function is_undefined(node, compressor) {
             && !node.expression.has_side_effects(compressor)
     );
 }
+
+// Is the node known to not be undefined
+(function(def_is_defined) {
+    def_is_defined(AST_Node, return_false);
+    def_is_defined(AST_Constant, return_true);
+    def_is_defined(AST_Undefined, return_false);
+    def_is_defined(AST_Array, return_true);
+    def_is_defined(AST_Object, return_true);
+    def_is_defined(AST_Lambda, return_true);
+    def_is_defined(AST_Object, return_true);
+    def_is_defined(AST_Unary, function() {
+        return unary_defined.has(this.operator);
+    });
+    def_is_defined(AST_Binary, function() {
+        if (binary_defined.has(this.operator))
+            return this.left.is_defined() || this.right.is_defined();
+        else if (this.operator == "&&")
+            return this.left.is_defined() && this.right.is_defined();
+        else
+            return false;
+    });
+    def_is_defined(AST_Conditional, function() {
+        return this.consequent.is_defined() && this.alternative.is_defined();
+    });
+    def_is_defined(AST_Assign, function() {
+        return this.operator == "=" && this.right.is_defined();
+    });
+    def_is_defined(AST_Sequence, function() {
+        return this.tail_node().is_defined();
+    });
+}(function (node, func) {
+    node.DEFMETHOD("is_defined", func);
+}));
 
 // Is the node explicitly null or undefined.
 function is_null_or_undefined(node, compressor) {

--- a/lib/compress/inline.js
+++ b/lib/compress/inline.js
@@ -112,6 +112,7 @@ import {
     is_recursive_ref,
     retain_top_func,
 } from "./common.js";
+import { is_undefined } from "./inference.js";
 
 /**
  * Module that contains the inlining logic.
@@ -516,8 +517,12 @@ export function inline_into_call(self, compressor) {
         for (var i = 0, len = fn.argnames.length; i < len; i++) {
             var arg = fn.argnames[i];
             if (arg instanceof AST_DefaultAssign) {
-                if (has_flag(arg.left, UNUSED)) continue;
-                return false;
+                if (has_flag(arg.left, UNUSED)
+                    || !self.args[i]
+                    || is_undefined(self.args[i], compressor)
+                    || self.args[i].is_defined(compressor)) {
+                        arg = arg.left;
+                    } else return false;
             }
             if (arg instanceof AST_Destructuring) return false;
             if (arg instanceof AST_Expansion) {
@@ -618,6 +623,10 @@ export function inline_into_call(self, compressor) {
         for (i = len; --i >= 0;) {
             var name = fn.argnames[i];
             var value = self.args[i];
+            if (name instanceof AST_DefaultAssign) {
+                if (!value || is_undefined(value, compressor)) value = name.right;
+                name = name.left;
+            }
             if (has_flag(name, UNUSED) || !name.name || scope.conflicting_def(name.name)) {
                 if (value) expressions.push(value);
             } else {


### PR DESCRIPTION
Currently, functions with default parameters can't be inlined unless the parameter is unused, which can result in buggy transformations (#1623).

If we can statically determine whether a simple argument uses the default value (no value or always undefined) or a passed value (guaranteed to not be undefined), we can inline the function similarly to regular variables.

This is a partial solution to #1199, if the function can be inlined.

It also partially fixes #1623 for inlined functions. I can reproduce the fix via the cli but cannot create a test case that inlines, no matter the options used.