### PR TITLE
perf: keep numbers during compressing (#1627)

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -214,7 +214,7 @@ import { inline_into_symbolref, inline_into_call } from "./inline.js";
 import "./global-defs.js";
 
 class Compressor extends TreeWalker {
-    constructor(options, { false_by_default = false, mangle_options = false }) {
+    constructor(options, { false_by_default = false, mangle_options = false, format_options = false }) {
         super();
         if (options.defaults !== undefined && !options.defaults) false_by_default = true;
         this.options = defaults(options, {
@@ -327,6 +327,7 @@ class Compressor extends TreeWalker {
         this._mangle_options = mangle_options
             ? format_mangler_options(mangle_options)
             : mangle_options;
+        this._format_options = format_options;
     }
 
     mangle_options() {
@@ -334,6 +335,8 @@ class Compressor extends TreeWalker {
         var module = this._mangle_options && this._mangle_options.module || this.option("module");
         return { ie8: this.option("ie8"), nth_identifier, module };
     }
+
+    format_options() { return this._format_options; }
 
     option(key) {
         return this.options[key];
@@ -1964,13 +1967,15 @@ def_optimize(AST_Call, function(self, compressor) {
                 }).join(",") + "){" + self.args[self.args.length - 1].value + "})";
                 var ast = parse(code);
                 var mangle = compressor.mangle_options();
+                var format = compressor.format_options();
                 ast.figure_out_scope(mangle);
                 var comp = new Compressor(compressor.options, {
-                    mangle_options: compressor._mangle_options
+                    mangle_options: compressor._mangle_options,
+                    format_options: format
                 });
                 ast = ast.transform(comp);
                 ast.figure_out_scope(mangle);
-                ast.compute_char_frequency(mangle);
+                ast.compute_char_frequency(mangle, format);
                 ast.mangle_names(mangle);
                 var fun;
                 walk(ast, node => {

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -261,7 +261,8 @@ function* minify_sync_or_async(files, options, _fs_module) {
     if (timings) timings.compress = Date.now();
     if (options.compress) {
         toplevel = new Compressor(options.compress, {
-            mangle_options: options.mangle
+            mangle_options: options.mangle,
+            format_options: options.format
         }).compress(toplevel);
     }
 
@@ -270,7 +271,7 @@ function* minify_sync_or_async(files, options, _fs_module) {
     if (options.mangle) toplevel.figure_out_scope(options.mangle);
     if (timings) timings.mangle = Date.now();
     if (options.mangle) {
-        toplevel.compute_char_frequency(options.mangle);
+        toplevel.compute_char_frequency(options.mangle, options.format);
         toplevel.mangle_names(options.mangle);
         toplevel = mangle_private_properties(toplevel, options.mangle);
     }

--- a/lib/output.js
+++ b/lib/output.js
@@ -259,9 +259,9 @@ class Rope {
     }
 }
 
-function OutputStream(options) {
+function OutputStream(options, readonly) {
 
-    var readonly = !options;
+    readonly = readonly != null ? readonly : !options;
     options = defaults(options, {
         ascii_only           : false,
         beautify             : false,
@@ -946,8 +946,8 @@ function OutputStream(options) {
     });
     AST_Node.DEFMETHOD("_print", AST_Node.prototype.print);
 
-    AST_Node.DEFMETHOD("print_to_string", function(options) {
-        var output = OutputStream(options);
+    AST_Node.DEFMETHOD("print_to_string", function(options, readonly) {
+        var output = OutputStream(options, readonly);
         this.print(output);
         return output.get();
     });
@@ -1208,7 +1208,7 @@ function OutputStream(options) {
         var p = output.parent();
         if (p instanceof AST_PropAccess && p.expression === this) {
             var value = this.getValue();
-            if (value < 0 || /^0/.test(make_num(value))) {
+            if (value < 0 || /^0/.test(make_num(output, value))) {
                 return true;
             }
         }
@@ -2162,7 +2162,7 @@ function OutputStream(options) {
                 output.print(key);
                 return false;
             }
-            output.print(make_num(key));
+            output.print(make_num(output, key));
             return false;
         }
         var print_string = ALL_RESERVED_WORDS.has(key)
@@ -2357,7 +2357,7 @@ function OutputStream(options) {
         if ((output.option("keep_numbers") || output.use_asm) && self.raw) {
             output.print(self.raw);
         } else {
-            output.print(make_num(self.getValue()));
+            output.print(make_num(output, self.getValue()));
         }
     });
     DEFPRINT(AST_BigInt, function(self, output) {
@@ -2419,7 +2419,9 @@ function OutputStream(options) {
         return best;
     }
 
-    function make_num(num) {
+    function make_num(output, num) {
+        if (output.option("keep_numbers")) return num;
+
         var str = num.toString(10).replace(/^0\./, ".").replace("e+", "e");
         var candidates = [ str ];
         if (Math.floor(num) === num) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -970,9 +970,9 @@ AST_Sequence.DEFMETHOD("tail_node", function() {
     return this.expressions[this.expressions.length - 1];
 });
 
-AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
-    options = format_mangler_options(options);
-    var nth_identifier = options.nth_identifier;
+AST_Toplevel.DEFMETHOD("compute_char_frequency", function(mangle_options, format_options) {
+    mangle_options = format_mangler_options(mangle_options);
+    var nth_identifier = mangle_options.nth_identifier;
     if (!nth_identifier.reset || !nth_identifier.consider || !nth_identifier.sort) {
         // If the identifier mangler is invariant, skip computing character frequency.
         return;
@@ -982,9 +982,9 @@ AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
     try {
         AST_Node.prototype.print = function(stream, force_parens) {
             this._print(stream, force_parens);
-            if (this instanceof AST_Symbol && !this.unmangleable(options)) {
+            if (this instanceof AST_Symbol && !this.unmangleable(mangle_options)) {
                 nth_identifier.consider(this.name, -1);
-            } else if (options.properties) {
+            } else if (mangle_options.properties) {
                 if (this instanceof AST_DotHash) {
                     nth_identifier.consider("#" + this.property, -1);
                 } else if (this instanceof AST_Dot) {
@@ -994,7 +994,11 @@ AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
                 }
             }
         };
-        nth_identifier.consider(this.print_to_string(), 1);
+        format_options = {...format_options};
+        delete format_options.ast;
+        delete format_options.code;
+        delete format_options.spidermonkey;
+        nth_identifier.consider(this.print_to_string(format_options, true), 1);
     } finally {
         AST_Node.prototype.print = AST_Node.prototype._print;
     }

--- a/test/compress.js
+++ b/test/compress.js
@@ -398,12 +398,13 @@ async function run_compress_tests(test_files, in_child_process) {
             }
             var cmp = new Compressor(options, {
                 false_by_default: options.defaults === undefined ? true : !options.defaults,
-                mangle_options: test.mangle
+                mangle_options: test.mangle,
+                format_options: output_options
             });
             var output = cmp.compress(input);
             output.figure_out_scope(test.mangle);
             if (test.mangle) {
-                output.compute_char_frequency(test.mangle);
+                output.compute_char_frequency(test.mangle, output_options);
                 (function(cache) {
                     if (!cache) return;
                     if (!("props" in cache)) {

--- a/test/compress/numbers.js
+++ b/test/compress/numbers.js
@@ -265,6 +265,35 @@ keep_numbers: {
     expect_exact: "const exp=1000000000000;const negativeExp=0.00000001;const huge=1000000000001;const big=100000000001;const fractional=100.2300200;const numeric_separators=1_000_000_000_000;"
 }
 
+compress_without_keeping_numbers: {
+    options = {
+        module: true,
+        defaults: true
+    }
+    input: {
+        var ONE_SECOND = 1000;
+        var ONE_MINUTE = ONE_SECOND * 60;
+        console.log(ONE_SECOND, ONE_MINUTE);
+    }
+    expect_exact: "console.log(1e3,6e4);"
+}
+
+compress_with_keeping_numbers: {
+    format = {
+        keep_numbers: true
+    }
+    options = {
+        module: true,
+        defaults: true
+    }
+    input: {
+        var ONE_SECOND = 1000;
+        var ONE_MINUTE = ONE_SECOND * 60;
+        console.log(ONE_SECOND, ONE_MINUTE);
+    }
+    expect_exact: "console.log(1000,60000);"
+}
+
 keep_numbers_in_properties_as_is: {
     beautify = {
         keep_numbers: true


### PR DESCRIPTION
To support `keep_nubmers` in cases like #1627