### PR TITLE
Support `using` and `await using` declarations

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1429,7 +1429,7 @@ var AST_Using = DEFNODE("Using", null, function AST_Using(props) {
 }, {
     $documentation: "A `using` statement",
     $propdoc: {
-        definitions: "[AST_UsingDef*] array of using variable definitions"
+        definitions: "[AST_VarDef*] array of using variable definitions"
     }
 }, AST_Definitions);
 
@@ -1444,7 +1444,7 @@ var AST_AwaitUsing = DEFNODE("AwaitUsing", null, function AST_AwaitUsing(props) 
 }, {
     $documentation: "An `await using` statement",
     $propdoc: {
-        definitions: "[AST_UsingDef*] array of using variable definitions"
+        definitions: "[AST_VarDef*] array of using variable definitions"
     }
 }, AST_Definitions);
 
@@ -1479,37 +1479,6 @@ var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
         } else {
             return this.name.all_symbols();
         }
-    }
-});
-
-var AST_UsingDef = DEFNODE("UsingDef", "name value", function AST_UsingDef(props) {
-    if (props) {
-        this.name = props.name;
-        this.value = props.value;
-        this.start = props.start;
-        this.end = props.end;
-    }
-
-    this.flags = 0;
-}, {
-    $documentation: "A using/await using declaration; only appears in a AST_Definitions node",
-    $propdoc: {
-        name: "[AST_SymbolUsing|AST_SymbolAwaitUsing] name of the variable",
-        value: "[AST_Node?] initializer, or null of there's no initializer"
-    },
-    _walk: function(visitor) {
-        return visitor._visit(this, function() {
-            this.name._walk(visitor);
-            if (this.value) this.value._walk(visitor);
-        });
-    },
-    _children_backwards(push) {
-        if (this.value) push(this.value);
-        push(this.name);
-    },
-    declarations_as_names() {
-        // using/await using does not allow destructuring
-        return [this];
     }
 });
 
@@ -3473,7 +3442,6 @@ export {
     AST_UnaryPrefix,
     AST_Undefined,
     AST_Using,
-    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1418,8 +1418,9 @@ var AST_Const = DEFNODE("Const", null, function AST_Const(props) {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
-var AST_Using = DEFNODE("Using", null, function AST_Using(props) {
+var AST_Using = DEFNODE("Using", "await", function AST_Using(props) {
     if (props) {
+        this.await = props.await;
         this.definitions = props.definitions;
         this.start = props.start;
         this.end = props.end;
@@ -1429,22 +1430,7 @@ var AST_Using = DEFNODE("Using", null, function AST_Using(props) {
 }, {
     $documentation: "A `using` statement",
     $propdoc: {
-        definitions: "[AST_VarDef*] array of using variable definitions"
-    }
-}, AST_Definitions);
-
-var AST_AwaitUsing = DEFNODE("AwaitUsing", null, function AST_AwaitUsing(props) {
-    if (props) {
-        this.definitions = props.definitions;
-        this.start = props.start;
-        this.end = props.end;
-    }
-
-    this.flags = 0;
-}, {
-    $documentation: "An `await using` statement",
-    $propdoc: {
-        definitions: "[AST_VarDef*] array of using variable definitions"
+        await: "[boolean] Whether it's `await using`"
     }
 }, AST_Definitions);
 
@@ -3320,7 +3306,6 @@ export {
     AST_Assign,
     AST_Atom,
     AST_Await,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1418,6 +1418,36 @@ var AST_Const = DEFNODE("Const", null, function AST_Const(props) {
     $documentation: "A `const` statement"
 }, AST_Definitions);
 
+var AST_Using = DEFNODE("Using", null, function AST_Using(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "A `using` statement",
+    $propdoc: {
+        definitions: "[AST_UsingDef*] array of using variable definitions"
+    }
+}, AST_Definitions);
+
+var AST_AwaitUsing = DEFNODE("AwaitUsing", null, function AST_AwaitUsing(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "An `await using` statement",
+    $propdoc: {
+        definitions: "[AST_UsingDef*] array of using variable definitions"
+    }
+}, AST_Definitions);
+
 var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
     if (props) {
         this.name = props.name;
@@ -1449,6 +1479,37 @@ var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
         } else {
             return this.name.all_symbols();
         }
+    }
+});
+
+var AST_UsingDef = DEFNODE("UsingDef", "name value", function AST_UsingDef(props) {
+    if (props) {
+        this.name = props.name;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "A using/await using declaration; only appears in a AST_Definitions node",
+    $propdoc: {
+        name: "[AST_SymbolUsing|AST_SymbolAwaitUsing] name of the variable",
+        value: "[AST_Node?] initializer, or null of there's no initializer"
+    },
+    _walk: function(visitor) {
+        return visitor._visit(this, function() {
+            this.name._walk(visitor);
+            if (this.value) this.value._walk(visitor);
+        });
+    },
+    _children_backwards(push) {
+        if (this.value) push(this.value);
+        push(this.name);
+    },
+    declarations_as_names() {
+        // using/await using does not allow destructuring
+        return [this];
     }
 });
 
@@ -2547,6 +2608,36 @@ var AST_SymbolConst = DEFNODE("SymbolConst", null, function AST_SymbolConst(prop
     $documentation: "A constant declaration"
 }, AST_SymbolBlockDeclaration);
 
+var AST_SymbolUsing = DEFNODE("SymbolUsing", null, function AST_SymbolUsing(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "A `using` declaration"
+}, AST_SymbolBlockDeclaration);
+
+var AST_SymbolAwaitUsing = DEFNODE("SymbolAwaitUsing", null, function AST_SymbolAwaitUsing(props) {
+    if (props) {
+        this.init = props.init;
+        this.scope = props.scope;
+        this.name = props.name;
+        this.thedef = props.thedef;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "An `await using` declaration"
+}, AST_SymbolBlockDeclaration);
+
 var AST_SymbolLet = DEFNODE("SymbolLet", null, function AST_SymbolLet(props) {
     if (props) {
         this.init = props.init;
@@ -3260,6 +3351,7 @@ export {
     AST_Assign,
     AST_Atom,
     AST_Await,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -3346,6 +3438,7 @@ export {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolBlockDeclaration,
     AST_SymbolCatch,
     AST_SymbolClass,
@@ -3363,6 +3456,7 @@ export {
     AST_SymbolLet,
     AST_SymbolMethod,
     AST_SymbolRef,
+    AST_SymbolUsing,
     AST_SymbolVar,
     AST_TemplateSegment,
     AST_TemplateString,
@@ -3378,6 +3472,8 @@ export {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Undefined,
+    AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1355,7 +1355,7 @@ var AST_Finally = DEFNODE("Finally", null, function AST_Finally(props) {
 
 /* -----[ VAR/CONST ]----- */
 
-var AST_Definitions = DEFNODE("Definitions", "definitions", function AST_Definitions(props) {
+var AST_DefinitionsLike = DEFNODE("DefinitionsLike", "definitions", function AST_DefinitionsLike(props) {
     if (props) {
         this.definitions = props.definitions;
         this.start = props.start;
@@ -1364,9 +1364,9 @@ var AST_Definitions = DEFNODE("Definitions", "definitions", function AST_Definit
 
     this.flags = 0;
 }, {
-    $documentation: "Base class for `var` or `const` nodes (variable declarations/initializations)",
+    $documentation: "Base class for variable definitions and `using`",
     $propdoc: {
-        definitions: "[AST_VarDef*] array of variable definitions"
+        definitions: "[AST_VarDef*|AST_UsingDef*] array of variable definitions"
     },
     _walk: function(visitor) {
         return visitor._visit(this, function() {
@@ -1381,6 +1381,18 @@ var AST_Definitions = DEFNODE("Definitions", "definitions", function AST_Definit
         while (i--) push(this.definitions[i]);
     },
 }, AST_Statement);
+
+var AST_Definitions = DEFNODE("Definitions", null, function AST_Definitions(props) {
+    if (props) {
+        this.definitions = props.definitions;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "Base class for `var` or `const` nodes (variable declarations/initializations)",
+}, AST_DefinitionsLike);
 
 var AST_Var = DEFNODE("Var", null, function AST_Var(props) {
     if (props) {
@@ -1431,10 +1443,10 @@ var AST_Using = DEFNODE("Using", "await", function AST_Using(props) {
     $documentation: "A `using` statement",
     $propdoc: {
         await: "[boolean] Whether it's `await using`"
-    }
-}, AST_Definitions);
+    },
+}, AST_DefinitionsLike);
 
-var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
+var AST_VarDefLike = DEFNODE("VarDefLike", "name value", function AST_VarDefLike(props) {
     if (props) {
         this.name = props.name;
         this.value = props.value;
@@ -1444,9 +1456,9 @@ var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
 
     this.flags = 0;
 }, {
-    $documentation: "A variable declaration; only appears in a AST_Definitions node",
+    $documentation: "A name=value pair in a variable definition statement or `using`",
     $propdoc: {
-        name: "[AST_Destructuring|AST_SymbolConst|AST_SymbolLet|AST_SymbolVar] name of the variable",
+        name: "[AST_Destructuring|AST_SymbolDeclaration] name of the variable",
         value: "[AST_Node?] initializer, or null of there's no initializer"
     },
     _walk: function(visitor) {
@@ -1461,12 +1473,38 @@ var AST_VarDef = DEFNODE("VarDef", "name value", function AST_VarDef(props) {
     },
     declarations_as_names() {
         if (this.name instanceof AST_SymbolDeclaration) {
-            return [this];
+            return [this.name];
         } else {
             return this.name.all_symbols();
         }
     }
 });
+
+var AST_VarDef = DEFNODE("VarDef", null, function AST_VarDef(props) {
+    if (props) {
+        this.name = props.name;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "A variable declaration; only appears in a AST_Definitions node",
+}, AST_VarDefLike);
+
+var AST_UsingDef = DEFNODE("UsingDef", null, function AST_UsingDef(props) {
+    if (props) {
+        this.name = props.name;
+        this.value = props.value;
+        this.start = props.start;
+        this.end = props.end;
+    }
+
+    this.flags = 0;
+}, {
+    $documentation: "Like VarDef but specific to AST_Using",
+}, AST_VarDefLike);
 
 var AST_NameMapping = DEFNODE("NameMapping", "foreign_name name", function AST_NameMapping(props) {
     if (props) {
@@ -3317,6 +3355,7 @@ export {
     AST_DefaultAssign,
     AST_DefClass,
     AST_Definitions,
+    AST_DefinitionsLike,
     AST_Defun,
     AST_Destructuring,
     AST_Directive,
@@ -3411,8 +3450,10 @@ export {
     AST_UnaryPrefix,
     AST_Undefined,
     AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield,

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2578,21 +2578,6 @@ var AST_SymbolUsing = DEFNODE("SymbolUsing", null, function AST_SymbolUsing(prop
     $documentation: "A `using` declaration"
 }, AST_SymbolBlockDeclaration);
 
-var AST_SymbolAwaitUsing = DEFNODE("SymbolAwaitUsing", null, function AST_SymbolAwaitUsing(props) {
-    if (props) {
-        this.init = props.init;
-        this.scope = props.scope;
-        this.name = props.name;
-        this.thedef = props.thedef;
-        this.start = props.start;
-        this.end = props.end;
-    }
-
-    this.flags = 0;
-}, {
-    $documentation: "An `await using` declaration"
-}, AST_SymbolBlockDeclaration);
-
 var AST_SymbolLet = DEFNODE("SymbolLet", null, function AST_SymbolLet(props) {
     if (props) {
         this.init = props.init;
@@ -3392,7 +3377,6 @@ export {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolBlockDeclaration,
     AST_SymbolCatch,
     AST_SymbolClass,

--- a/lib/compress/common.js
+++ b/lib/compress/common.js
@@ -44,7 +44,6 @@
 import {
     AST_Array,
     AST_Arrow,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_BlockStatement,
     AST_Call,
@@ -311,7 +310,6 @@ export function can_be_evicted_from_block(node) {
         node instanceof AST_Let ||
         node instanceof AST_Const ||
         node instanceof AST_Using ||
-        node instanceof AST_AwaitUsing ||
         node instanceof AST_Export ||
         node instanceof AST_Import
     );

--- a/lib/compress/common.js
+++ b/lib/compress/common.js
@@ -44,6 +44,7 @@
 import {
     AST_Array,
     AST_Arrow,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_BlockStatement,
     AST_Call,
@@ -80,6 +81,7 @@ import {
     AST_True,
     AST_UnaryPrefix,
     AST_Undefined,
+    AST_Using,
 
     TreeWalker,
     walk,
@@ -308,6 +310,8 @@ export function can_be_evicted_from_block(node) {
         node instanceof AST_Defun ||
         node instanceof AST_Let ||
         node instanceof AST_Const ||
+        node instanceof AST_Using ||
+        node instanceof AST_AwaitUsing ||
         node instanceof AST_Export ||
         node instanceof AST_Import
     );

--- a/lib/compress/drop-unused.js
+++ b/lib/compress/drop-unused.js
@@ -44,7 +44,6 @@
 import {
     AST_Accessor,
     AST_Assign,
-    AST_AwaitUsing,
     AST_BlockStatement,
     AST_Call,
     AST_Class,
@@ -179,7 +178,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
         if (node instanceof AST_SymbolFunarg && in_root_scope) {
             map_add(var_defs_by_id, node.definition().id, node);
         }
-        if (node instanceof AST_Definitions && !(node instanceof AST_Using || node instanceof AST_AwaitUsing) && in_root_scope) {
+        if (node instanceof AST_Definitions && !(node instanceof AST_Using) && in_root_scope) {
             const in_export = tw.parent() instanceof AST_Export;
             node.definitions.forEach(function(def) {
                 if (def.name instanceof AST_SymbolVar) {
@@ -311,7 +310,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
                     return in_list ? MAP.skip : make_node(AST_EmptyStatement, node);
                 }
             }
-            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node) && !(node instanceof AST_Using || node instanceof AST_AwaitUsing)) {
+            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node) && !(node instanceof AST_Using)) {
                 var drop_block = !(parent instanceof AST_Toplevel) && !(node instanceof AST_Var);
                 // place uninitialized names at the start
                 var body = [], head = [], tail = [];

--- a/lib/compress/drop-unused.js
+++ b/lib/compress/drop-unused.js
@@ -44,6 +44,7 @@
 import {
     AST_Accessor,
     AST_Assign,
+    AST_AwaitUsing,
     AST_BlockStatement,
     AST_Call,
     AST_Class,
@@ -74,6 +75,7 @@ import {
     AST_SymbolVar,
     AST_Toplevel,
     AST_Unary,
+    AST_Using,
     AST_Var,
 
     TreeTransformer,
@@ -177,7 +179,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
         if (node instanceof AST_SymbolFunarg && in_root_scope) {
             map_add(var_defs_by_id, node.definition().id, node);
         }
-        if (node instanceof AST_Definitions && in_root_scope) {
+        if (node instanceof AST_Definitions && !(node instanceof AST_Using || node instanceof AST_AwaitUsing) && in_root_scope) {
             const in_export = tw.parent() instanceof AST_Export;
             node.definitions.forEach(function(def) {
                 if (def.name instanceof AST_SymbolVar) {
@@ -309,7 +311,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
                     return in_list ? MAP.skip : make_node(AST_EmptyStatement, node);
                 }
             }
-            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node)) {
+            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node) && !(node instanceof AST_Using || node instanceof AST_AwaitUsing)) {
                 var drop_block = !(parent instanceof AST_Toplevel) && !(node instanceof AST_Var);
                 // place uninitialized names at the start
                 var body = [], head = [], tail = [];

--- a/lib/compress/drop-unused.js
+++ b/lib/compress/drop-unused.js
@@ -74,7 +74,6 @@ import {
     AST_SymbolVar,
     AST_Toplevel,
     AST_Unary,
-    AST_Using,
     AST_Var,
 
     TreeTransformer,
@@ -178,7 +177,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
         if (node instanceof AST_SymbolFunarg && in_root_scope) {
             map_add(var_defs_by_id, node.definition().id, node);
         }
-        if (node instanceof AST_Definitions && !(node instanceof AST_Using) && in_root_scope) {
+        if (node instanceof AST_Definitions && in_root_scope) {
             const in_export = tw.parent() instanceof AST_Export;
             node.definitions.forEach(function(def) {
                 if (def.name instanceof AST_SymbolVar) {
@@ -310,7 +309,7 @@ AST_Scope.DEFMETHOD("drop_unused", function(compressor) {
                     return in_list ? MAP.skip : make_node(AST_EmptyStatement, node);
                 }
             }
-            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node) && !(node instanceof AST_Using)) {
+            if (node instanceof AST_Definitions && !(parent instanceof AST_ForIn && parent.init === node)) {
                 var drop_block = !(parent instanceof AST_Toplevel) && !(node instanceof AST_Var);
                 // place uninitialized names at the start
                 var body = [], head = [], tail = [];

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -109,7 +109,6 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolClassProperty,
     AST_SymbolDeclaration,
     AST_SymbolDefun,
@@ -883,7 +882,7 @@ AST_Scope.DEFMETHOD("hoist_properties", function(compressor) {
             let def;
             let value;
             if (sym.scope === self
-                && !(sym instanceof AST_SymbolUsing || sym instanceof AST_SymbolAwaitUsing)
+                && !(sym instanceof AST_SymbolUsing)
                 && (def = sym.definition()).escaped != 1
                 && !def.assignments
                 && !def.direct_access

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -772,7 +772,6 @@ AST_Scope.DEFMETHOD("hoist_declarations", function(compressor) {
                     if (
                         hoist_vars
                         && node instanceof AST_Var
-                        && !(node instanceof AST_Using)
                         && !node.definitions.some(def => def.name instanceof AST_Destructuring)
                     ) {
                         node.definitions.forEach(function(def) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -110,6 +110,7 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolClassProperty,
     AST_SymbolDeclaration,
     AST_SymbolDefun,
@@ -119,6 +120,7 @@ import {
     AST_SymbolLet,
     AST_SymbolMethod,
     AST_SymbolRef,
+    AST_SymbolUsing,
     AST_TemplateString,
     AST_This,
     AST_Toplevel,
@@ -773,6 +775,7 @@ AST_Scope.DEFMETHOD("hoist_declarations", function(compressor) {
                     if (
                         hoist_vars
                         && node instanceof AST_Var
+                        && !(node instanceof AST_Using || node instanceof AST_AwaitUsing)
                         && !node.definitions.some(def => def.name instanceof AST_Destructuring)
                     ) {
                         node.definitions.forEach(function(def) {
@@ -882,6 +885,7 @@ AST_Scope.DEFMETHOD("hoist_properties", function(compressor) {
             let def;
             let value;
             if (sym.scope === self
+                && !(sym instanceof AST_SymbolUsing || sym instanceof AST_SymbolAwaitUsing)
                 && (def = sym.definition()).escaped != 1
                 && !def.assignments
                 && !def.direct_access

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -46,7 +46,6 @@ import {
     AST_Array,
     AST_Arrow,
     AST_Assign,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -705,7 +704,6 @@ function can_be_extracted_from_if_block(node) {
         node instanceof AST_Const
         || node instanceof AST_Let
         || node instanceof AST_Using
-        || node instanceof AST_AwaitUsing
         || node instanceof AST_Class
     );
 }
@@ -775,7 +773,7 @@ AST_Scope.DEFMETHOD("hoist_declarations", function(compressor) {
                     if (
                         hoist_vars
                         && node instanceof AST_Var
-                        && !(node instanceof AST_Using || node instanceof AST_AwaitUsing)
+                        && !(node instanceof AST_Using)
                         && !node.definitions.some(def => def.name instanceof AST_Destructuring)
                     ) {
                         node.definitions.forEach(function(def) {

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -46,6 +46,7 @@ import {
     AST_Array,
     AST_Arrow,
     AST_Assign,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -127,6 +128,7 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Undefined,
+    AST_Using,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -700,6 +702,8 @@ function can_be_extracted_from_if_block(node) {
     return !(
         node instanceof AST_Const
         || node instanceof AST_Let
+        || node instanceof AST_Using
+        || node instanceof AST_AwaitUsing
         || node instanceof AST_Class
     );
 }

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -45,6 +45,7 @@ import {
   AST_Array,
   AST_Arrow,
   AST_Assign,
+  AST_AwaitUsing,
   AST_BigInt,
   AST_Binary,
   AST_Block,
@@ -108,6 +109,7 @@ import {
   AST_UnaryPostfix,
   AST_UnaryPrefix,
   AST_Undefined,
+  AST_Using,
   AST_VarDef,
 
   walk,
@@ -501,6 +503,7 @@ export function is_nullish(node, compressor) {
     def_has_side_effects(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
+    def_has_side_effects([AST_Using, AST_AwaitUsing], return_true);
     def_has_side_effects(AST_VarDef, function() {
         return this.value != null;
     });
@@ -579,6 +582,7 @@ export function is_nullish(node, compressor) {
     def_may_throw(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
+    def_may_throw([AST_Using, AST_AwaitUsing], return_true);
     def_may_throw(AST_If, function(compressor) {
         return this.condition.may_throw(compressor)
             || this.body && this.body.may_throw(compressor)

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -45,7 +45,6 @@ import {
   AST_Array,
   AST_Arrow,
   AST_Assign,
-  AST_AwaitUsing,
   AST_BigInt,
   AST_Binary,
   AST_Block,
@@ -503,7 +502,7 @@ export function is_nullish(node, compressor) {
     def_has_side_effects(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
-    def_has_side_effects([AST_Using, AST_AwaitUsing], return_true);
+    def_has_side_effects(AST_Using, return_true);
     def_has_side_effects(AST_VarDef, function() {
         return this.value != null;
     });
@@ -582,7 +581,7 @@ export function is_nullish(node, compressor) {
     def_may_throw(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
-    def_may_throw([AST_Using, AST_AwaitUsing], return_true);
+    def_may_throw(AST_Using, return_true);
     def_may_throw(AST_If, function(compressor) {
         return this.condition.may_throw(compressor)
             || this.body && this.body.may_throw(compressor)

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -108,7 +108,6 @@ import {
   AST_UnaryPostfix,
   AST_UnaryPrefix,
   AST_Undefined,
-  AST_Using,
   AST_VarDef,
 
   walk,
@@ -502,7 +501,6 @@ export function is_nullish(node, compressor) {
     def_has_side_effects(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
-    def_has_side_effects(AST_Using, return_true);
     def_has_side_effects(AST_VarDef, function() {
         return this.value != null;
     });
@@ -581,7 +579,6 @@ export function is_nullish(node, compressor) {
     def_may_throw(AST_Definitions, function(compressor) {
         return any(this.definitions, compressor);
     });
-    def_may_throw(AST_Using, return_true);
     def_may_throw(AST_If, function(compressor) {
         return this.condition.may_throw(compressor)
             || this.body && this.body.may_throw(compressor)

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -82,14 +82,15 @@ import {
     AST_SymbolFunarg,
     AST_SymbolLambda,
     AST_SymbolRef,
-    AST_SymbolUsing,
     AST_This,
     AST_Toplevel,
     AST_Try,
     AST_Unary,
     AST_UnaryPrefix,
     AST_Undefined,
+    AST_UsingDef,
     AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_Yield,
 
@@ -236,7 +237,7 @@ function mark_escaped(tw, d, scope, node, value, level = 0, depth = 1) {
         parent instanceof AST_Assign && (parent.operator === "=" || parent.logical) && node === parent.right
         || parent instanceof AST_Call && (node !== parent.expression || parent instanceof AST_New)
         || parent instanceof AST_Exit && node === parent.value && node.scope !== d.scope
-        || parent instanceof AST_VarDef && node === parent.value
+        || parent instanceof AST_VarDefLike && node === parent.value
         || parent instanceof AST_Yield && node === parent.value && node.scope !== d.scope
     ) {
         if (depth > 1 && !(value && value.is_constant_expression(scope))) depth = 1;
@@ -827,10 +828,7 @@ def_reduce_vars(AST_Unary, function(tw) {
 
 def_reduce_vars(AST_VarDef, function(tw, descend) {
     var node = this;
-    if (
-        node.name instanceof AST_Destructuring
-        || node.name instanceof AST_SymbolUsing
-    ) {
+    if (node.name instanceof AST_Destructuring) {
         suppress(node.name);
         return;
     }
@@ -849,6 +847,10 @@ def_reduce_vars(AST_VarDef, function(tw, descend) {
             d.fixed = false;
         }
     }
+});
+
+def_reduce_vars(AST_UsingDef, function() {
+    suppress(this.name);
 });
 
 def_reduce_vars(AST_While, function(tw, descend, compressor) {

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -75,6 +75,7 @@ import {
     AST_Sequence,
     AST_SimpleStatement,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolConst,
     AST_SymbolDeclaration,
@@ -82,6 +83,7 @@ import {
     AST_SymbolFunarg,
     AST_SymbolLambda,
     AST_SymbolRef,
+    AST_SymbolUsing,
     AST_This,
     AST_Toplevel,
     AST_Try,
@@ -826,7 +828,11 @@ def_reduce_vars(AST_Unary, function(tw) {
 
 def_reduce_vars(AST_VarDef, function(tw, descend) {
     var node = this;
-    if (node.name instanceof AST_Destructuring) {
+    if (
+        node.name instanceof AST_Destructuring
+        || node.name instanceof AST_SymbolUsing
+        || node.name instanceof AST_SymbolAwaitUsing
+    ) {
         suppress(node.name);
         return;
     }

--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -75,7 +75,6 @@ import {
     AST_Sequence,
     AST_SimpleStatement,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolConst,
     AST_SymbolDeclaration,
@@ -831,7 +830,6 @@ def_reduce_vars(AST_VarDef, function(tw, descend) {
     if (
         node.name instanceof AST_Destructuring
         || node.name instanceof AST_SymbolUsing
-        || node.name instanceof AST_SymbolAwaitUsing
     ) {
         suppress(node.name);
         return;

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -46,6 +46,7 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
+    AST_AwaitUsing,
     AST_Binary,
     AST_Block,
     AST_BlockStatement,
@@ -90,6 +91,7 @@ import {
     AST_Sub,
     AST_Switch,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolConst,
     AST_SymbolDeclaration,
     AST_SymbolDefun,
@@ -97,6 +99,7 @@ import {
     AST_SymbolLambda,
     AST_SymbolLet,
     AST_SymbolRef,
+    AST_SymbolUsing,
     AST_SymbolVar,
     AST_This,
     AST_Try,
@@ -105,6 +108,7 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Undefined,
+    AST_Using,
     AST_Var,
     AST_VarDef,
     AST_With,
@@ -396,6 +400,8 @@ export function tighten_body(statements, compressor) {
                 && ((lvalues.has(node.name) && lvalues.get(node.name).modified) || side_effects && may_modify(node))
                 || node instanceof AST_VarDef && node.value
                 && (lvalues.has(node.name.name) || side_effects && may_modify(node.name))
+                || node instanceof AST_Using
+                || node instanceof AST_AwaitUsing
                 || (sym = is_lhs(node.left, node))
                 && (sym instanceof AST_PropAccess || lvalues.has(sym.name))
                 || may_throw
@@ -716,7 +722,12 @@ export function tighten_body(statements, compressor) {
                     candidates.push(hit_stack.slice());
                 }
             } else if (expr instanceof AST_VarDef) {
-                if (expr.value && !(expr.value instanceof AST_Chain)) {
+                if (
+                    expr.value
+                    && !(expr.value instanceof AST_Chain)
+                    && !(expr.name instanceof AST_SymbolUsing
+                        || expr.name instanceof AST_SymbolAwaitUsing)
+                ) {
                     candidates.push(hit_stack.slice());
                     extract_candidates(expr.value);
                 }
@@ -810,7 +821,10 @@ export function tighten_body(statements, compressor) {
                     ? expr.left
                     : expr.expression;
                 return !is_ref_of(lhs, AST_SymbolConst)
-                    && !is_ref_of(lhs, AST_SymbolLet) && lhs;
+                    && !is_ref_of(lhs, AST_SymbolLet)
+                    && !is_ref_of(lhs, AST_SymbolUsing)
+                    && !is_ref_of(lhs, AST_SymbolAwaitUsing)
+                    && lhs;
             }
         }
 

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -55,7 +55,6 @@ import {
     AST_Chain,
     AST_Class,
     AST_Conditional,
-    AST_Const,
     AST_Constant,
     AST_Continue,
     AST_Debugger,
@@ -76,7 +75,6 @@ import {
     AST_Import,
     AST_IterationStatement,
     AST_Lambda,
-    AST_Let,
     AST_LoopControl,
     AST_Node,
     AST_Number,
@@ -1147,7 +1145,7 @@ export function tighten_body(statements, compressor) {
                 return false;
             for (var j = i + 1, len = statements.length; j < len; j++) {
                 var stat = statements[j];
-                if (stat instanceof AST_Const || stat instanceof AST_Let)
+                if (stat instanceof AST_Definitions && !(stat instanceof AST_Var))
                     return false;
             }
             var lct = ab instanceof AST_LoopControl ? compressor.loopcontrol_target(ab) : null;
@@ -1287,7 +1285,7 @@ export function tighten_body(statements, compressor) {
             var line = block.body[i];
             if (line instanceof AST_Var && declarations_only(line)) {
                 decls.push(line);
-            } else if (stat || line instanceof AST_Const || line instanceof AST_Let) {
+            } else if (stat || line instanceof AST_Definitions && !(line instanceof AST_Var)) {
                 return false;
             } else {
                 stat = line;
@@ -1330,7 +1328,7 @@ export function tighten_body(statements, compressor) {
                         }
                     }
                 } else if (stat instanceof AST_ForIn) {
-                    if (!(stat.init instanceof AST_Const) && !(stat.init instanceof AST_Let)) {
+                    if (stat.init instanceof AST_Var) {
                         stat.object = cons_seq(stat.object);
                     }
                 } else if (stat instanceof AST_If) {

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -46,7 +46,6 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
-    AST_AwaitUsing,
     AST_Binary,
     AST_Block,
     AST_BlockStatement,
@@ -401,7 +400,6 @@ export function tighten_body(statements, compressor) {
                 || node instanceof AST_VarDef && node.value
                 && (lvalues.has(node.name.name) || side_effects && may_modify(node.name))
                 || node instanceof AST_Using
-                || node instanceof AST_AwaitUsing
                 || (sym = is_lhs(node.left, node))
                 && (sym instanceof AST_PropAccess || lvalues.has(sym.name))
                 || may_throw

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -90,7 +90,6 @@ import {
     AST_Sub,
     AST_Switch,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolConst,
     AST_SymbolDeclaration,
     AST_SymbolDefun,
@@ -723,8 +722,7 @@ export function tighten_body(statements, compressor) {
                 if (
                     expr.value
                     && !(expr.value instanceof AST_Chain)
-                    && !(expr.name instanceof AST_SymbolUsing
-                        || expr.name instanceof AST_SymbolAwaitUsing)
+                    && !(expr.name instanceof AST_SymbolUsing)
                 ) {
                     candidates.push(hit_stack.slice());
                     extract_candidates(expr.value);
@@ -821,7 +819,6 @@ export function tighten_body(statements, compressor) {
                 return !is_ref_of(lhs, AST_SymbolConst)
                     && !is_ref_of(lhs, AST_SymbolLet)
                     && !is_ref_of(lhs, AST_SymbolUsing)
-                    && !is_ref_of(lhs, AST_SymbolAwaitUsing)
                     && lhs;
             }
         }

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -60,6 +60,7 @@ import {
     AST_Debugger,
     AST_Default,
     AST_Definitions,
+    AST_DefinitionsLike,
     AST_Defun,
     AST_Destructuring,
     AST_Directive,
@@ -300,6 +301,7 @@ export function tighten_body(statements, compressor) {
             if (node instanceof AST_Assign
                     && (node.logical || node.operator != "=" && lhs.equivalent_to(node.left))
                 || node instanceof AST_Await
+                || node instanceof AST_Using
                 || node instanceof AST_Call && lhs instanceof AST_PropAccess && lhs.equivalent_to(node.expression)
                 ||
                     (node instanceof AST_Call || node instanceof AST_PropAccess)
@@ -719,11 +721,7 @@ export function tighten_body(statements, compressor) {
                     candidates.push(hit_stack.slice());
                 }
             } else if (expr instanceof AST_VarDef) {
-                if (
-                    expr.value
-                    && !(expr.value instanceof AST_Chain)
-                    && !(expr.name instanceof AST_SymbolUsing)
-                ) {
+                if (expr.value && !(expr.value instanceof AST_Chain)) {
                     candidates.push(hit_stack.slice());
                     extract_candidates(expr.value);
                 }
@@ -1154,7 +1152,7 @@ export function tighten_body(statements, compressor) {
                 return false;
             for (var j = i + 1, len = statements.length; j < len; j++) {
                 var stat = statements[j];
-                if (stat instanceof AST_Definitions && !(stat instanceof AST_Var))
+                if (stat instanceof AST_DefinitionsLike && !(stat instanceof AST_Var))
                     return false;
             }
             var lct = ab instanceof AST_LoopControl ? compressor.loopcontrol_target(ab) : null;
@@ -1294,7 +1292,7 @@ export function tighten_body(statements, compressor) {
             var line = block.body[i];
             if (line instanceof AST_Var && declarations_only(line)) {
                 decls.push(line);
-            } else if (stat || line instanceof AST_Definitions && !(line instanceof AST_Var)) {
+            } else if (stat || line instanceof AST_DefinitionsLike && !(line instanceof AST_Var)) {
                 return false;
             } else {
                 stat = line;
@@ -1317,7 +1315,7 @@ export function tighten_body(statements, compressor) {
                 if (stat instanceof AST_Exit) {
                     stat.value = cons_seq(stat.value || make_node(AST_Undefined, stat).transform(compressor));
                 } else if (stat instanceof AST_For) {
-                    if (!(stat.init instanceof AST_Definitions)) {
+                    if (!(stat.init instanceof AST_DefinitionsLike)) {
                         const abort = walk(prev.body, node => {
                             if (node instanceof AST_Scope)
                                 return true;
@@ -1337,7 +1335,7 @@ export function tighten_body(statements, compressor) {
                         }
                     }
                 } else if (stat instanceof AST_ForIn) {
-                    if (!(stat.init instanceof AST_Definitions) || stat.init instanceof AST_Var) {
+                    if (!(stat.init instanceof AST_DefinitionsLike) || stat.init instanceof AST_Var) {
                         stat.object = cons_seq(stat.object);
                     }
                 } else if (stat instanceof AST_If) {
@@ -1454,6 +1452,12 @@ export function tighten_body(statements, compressor) {
                     statements[++j] = stat;
                     defs = stat;
                 }
+            } else if (
+                stat instanceof AST_Using
+                && prev instanceof AST_Using
+                && prev.await === stat.await
+            ) {
+                prev.definitions = prev.definitions.concat(stat.definitions);
             } else if (stat instanceof AST_Exit) {
                 stat.value = extract_object_assignments(stat.value);
             } else if (stat instanceof AST_For) {

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -1328,7 +1328,7 @@ export function tighten_body(statements, compressor) {
                         }
                     }
                 } else if (stat instanceof AST_ForIn) {
-                    if (stat.init instanceof AST_Var) {
+                    if (!(stat.init instanceof AST_Definitions) || stat init instanceof AST_Var) {
                         stat.object = cons_seq(stat.object);
                     }
                 } else if (stat instanceof AST_If) {

--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -1328,7 +1328,7 @@ export function tighten_body(statements, compressor) {
                         }
                     }
                 } else if (stat instanceof AST_ForIn) {
-                    if (!(stat.init instanceof AST_Definitions) || stat init instanceof AST_Var) {
+                    if (!(stat.init instanceof AST_Definitions) || stat.init instanceof AST_Var) {
                         stat.object = cons_seq(stat.object);
                     }
                 } else if (stat instanceof AST_If) {

--- a/lib/equivalent-to.js
+++ b/lib/equivalent-to.js
@@ -14,7 +14,7 @@ import {
     AST_ConciseMethod,
     AST_Conditional,
     AST_Debugger,
-    AST_Definitions,
+    AST_DefinitionsLike,
     AST_Destructuring,
     AST_Directive,
     AST_Do,
@@ -61,7 +61,7 @@ import {
     AST_Toplevel,
     AST_Try,
     AST_Unary,
-    AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield
@@ -184,9 +184,9 @@ AST_Catch.prototype.shallow_cmp = function(other) {
 
 AST_Finally.prototype.shallow_cmp = pass_through;
 
-AST_Definitions.prototype.shallow_cmp = pass_through;
+AST_DefinitionsLike.prototype.shallow_cmp = pass_through;
 
-AST_VarDef.prototype.shallow_cmp = function(other) {
+AST_VarDefLike.prototype.shallow_cmp = function(other) {
     return this.value == null ? other.value == null : this.value === other.value;
 };
 

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -126,7 +126,6 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolClass,
     AST_SymbolClassProperty,
@@ -530,6 +529,7 @@ import { is_basic_identifier_string } from "./parse.js";
         VariableDeclaration: function(M) {
             let decl_type;
             let sym_type;
+            let await_using = false;
             if (M.kind === "const") {
                 decl_type = AST_Const;
                 sym_type = AST_SymbolConst;
@@ -541,7 +541,8 @@ import { is_basic_identifier_string } from "./parse.js";
                 sym_type = AST_SymbolUsing;
             } else if (M.kind === "await using") {
                 decl_type = AST_Using;
-                sym_type = AST_SymbolAwaitUsing;
+                sym_type = AST_SymbolUsing;
+                await_using = true;
             } else {
                 decl_type = AST_Var;
                 sym_type = AST_SymbolVar;
@@ -559,7 +560,7 @@ import { is_basic_identifier_string } from "./parse.js";
                     start       : my_start_token(M),
                     end         : my_end_token(M),
                     definitions : definitions,
-                    await       : sym_type === AST_SymbolAwaitUsing,
+                    await       : await_using,
                 });
             }
             return new decl_type({

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -159,7 +159,6 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Using,
-    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -532,7 +531,6 @@ import { is_basic_identifier_string } from "./parse.js";
         VariableDeclaration: function(M) {
             let decl_type;
             let sym_type;
-            let is_using = false;
             if (M.kind === "const") {
                 decl_type = AST_Const;
                 sym_type = AST_SymbolConst;
@@ -542,23 +540,14 @@ import { is_basic_identifier_string } from "./parse.js";
             } else if (M.kind === "using") {
                 decl_type = AST_Using;
                 sym_type = AST_SymbolUsing;
-                is_using = true;
             } else if (M.kind === "await using") {
                 decl_type = AST_AwaitUsing;
                 sym_type = AST_SymbolAwaitUsing;
-                is_using = true;
             } else {
                 decl_type = AST_Var;
                 sym_type = AST_SymbolVar;
             }
-            const definitions = is_using ? M.declarations.map(M => {
-                return new AST_UsingDef({
-                    start: my_start_token(M),
-                    end: my_end_token(M),
-                    name: from_moz_pattern(M.id, sym_type),
-                    value: from_moz(M.init),
-                });
-            }) : M.declarations.map(M => {
+            const definitions = M.declarations.map(M => {
                 return new AST_VarDef({
                     start: my_start_token(M),
                     end: my_end_token(M),
@@ -1170,13 +1159,6 @@ import { is_basic_identifier_string } from "./parse.js";
         };
     });
     def_to_moz(AST_VarDef, function To_Moz_VariableDeclarator(M) {
-        return {
-            type: "VariableDeclarator",
-            id: to_moz(M.name),
-            init: to_moz(M.value)
-        };
-    });
-    def_to_moz(AST_UsingDef, function To_Moz_VariableDeclarator(M) {
         return {
             type: "VariableDeclarator",
             id: to_moz(M.name),

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -49,7 +49,6 @@ import {
     AST_Assign,
     AST_Atom,
     AST_Await,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -541,7 +540,7 @@ import { is_basic_identifier_string } from "./parse.js";
                 decl_type = AST_Using;
                 sym_type = AST_SymbolUsing;
             } else if (M.kind === "await using") {
-                decl_type = AST_AwaitUsing;
+                decl_type = AST_Using;
                 sym_type = AST_SymbolAwaitUsing;
             } else {
                 decl_type = AST_Var;
@@ -555,6 +554,14 @@ import { is_basic_identifier_string } from "./parse.js";
                     value: from_moz(M.init),
                 });
             });
+            if (decl_type === AST_Using) {
+                return new AST_Using({
+                    start       : my_start_token(M),
+                    end         : my_end_token(M),
+                    definitions : definitions,
+                    await       : sym_type === AST_SymbolAwaitUsing,
+                });
+            }
             return new decl_type({
                 start       : my_start_token(M),
                 end         : my_end_token(M),
@@ -1379,9 +1386,8 @@ import { is_basic_identifier_string } from "./parse.js";
             type: "VariableDeclaration",
             kind:
                 M instanceof AST_Const ? "const" :
-                M instanceof AST_Let ? "let" : 
-                M instanceof AST_Using ? "using" : 
-                M instanceof AST_AwaitUsing ? "await using" : 
+                M instanceof AST_Let ? "let" :
+                M instanceof AST_Using ? (M.await ? "await using" : "using") :
                 "var",
             declarations: M.definitions.map(to_moz)
         };

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -73,7 +73,7 @@ import {
     AST_Default,
     AST_DefaultAssign,
     AST_DefClass,
-    AST_Definitions,
+    AST_DefinitionsLike,
     AST_Defun,
     AST_Destructuring,
     AST_Directive,
@@ -157,8 +157,10 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield,
@@ -528,6 +530,7 @@ import { is_basic_identifier_string } from "./parse.js";
 
         VariableDeclaration: function(M) {
             let decl_type;
+            let defs_type = AST_VarDef;
             let sym_type;
             let await_using = false;
             if (M.kind === "const") {
@@ -538,9 +541,11 @@ import { is_basic_identifier_string } from "./parse.js";
                 sym_type = AST_SymbolLet;
             } else if (M.kind === "using") {
                 decl_type = AST_Using;
+                defs_type = AST_UsingDef;
                 sym_type = AST_SymbolUsing;
             } else if (M.kind === "await using") {
                 decl_type = AST_Using;
+                defs_type = AST_UsingDef;
                 sym_type = AST_SymbolUsing;
                 await_using = true;
             } else {
@@ -548,25 +553,18 @@ import { is_basic_identifier_string } from "./parse.js";
                 sym_type = AST_SymbolVar;
             }
             const definitions = M.declarations.map(M => {
-                return new AST_VarDef({
+                return new defs_type({
                     start: my_start_token(M),
                     end: my_end_token(M),
                     name: from_moz_pattern(M.id, sym_type),
                     value: from_moz(M.init),
                 });
             });
-            if (decl_type === AST_Using) {
-                return new AST_Using({
-                    start       : my_start_token(M),
-                    end         : my_end_token(M),
-                    definitions : definitions,
-                    await       : await_using,
-                });
-            }
             return new decl_type({
                 start       : my_start_token(M),
                 end         : my_end_token(M),
                 definitions : definitions,
+                await       : await_using,
             });
         },
 
@@ -1166,7 +1164,7 @@ import { is_basic_identifier_string } from "./parse.js";
             type: "DebuggerStatement"
         };
     });
-    def_to_moz(AST_VarDef, function To_Moz_VariableDeclarator(M) {
+    def_to_moz(AST_VarDefLike, function To_Moz_VariableDeclarator(M) {
         return {
             type: "VariableDeclarator",
             id: to_moz(M.name),
@@ -1382,7 +1380,7 @@ import { is_basic_identifier_string } from "./parse.js";
         };
     });
 
-    def_to_moz(AST_Definitions, function To_Moz_VariableDeclaration(M) {
+    def_to_moz(AST_DefinitionsLike, function To_Moz_VariableDeclaration(M) {
         return {
             type: "VariableDeclaration",
             kind:

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -49,6 +49,7 @@ import {
     AST_Assign,
     AST_Atom,
     AST_Await,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -126,6 +127,7 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolClass,
     AST_SymbolClassProperty,
@@ -143,6 +145,7 @@ import {
     AST_SymbolMethod,
     AST_SymbolRef,
     AST_SymbolVar,
+    AST_SymbolUsing,
     AST_TemplateSegment,
     AST_TemplateString,
     AST_This,
@@ -155,6 +158,8 @@ import {
     AST_Unary,
     AST_UnaryPostfix,
     AST_UnaryPrefix,
+    AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -527,17 +532,33 @@ import { is_basic_identifier_string } from "./parse.js";
         VariableDeclaration: function(M) {
             let decl_type;
             let sym_type;
+            let is_using = false;
             if (M.kind === "const") {
                 decl_type = AST_Const;
                 sym_type = AST_SymbolConst;
             } else if (M.kind === "let") {
                 decl_type = AST_Let;
                 sym_type = AST_SymbolLet;
+            } else if (M.kind === "using") {
+                decl_type = AST_Using;
+                sym_type = AST_SymbolUsing;
+                is_using = true;
+            } else if (M.kind === "await using") {
+                decl_type = AST_AwaitUsing;
+                sym_type = AST_SymbolAwaitUsing;
+                is_using = true;
             } else {
                 decl_type = AST_Var;
                 sym_type = AST_SymbolVar;
             }
-            const definitions = M.declarations.map(M => {
+            const definitions = is_using ? M.declarations.map(M => {
+                return new AST_UsingDef({
+                    start: my_start_token(M),
+                    end: my_end_token(M),
+                    name: from_moz_pattern(M.id, sym_type),
+                    value: from_moz(M.init),
+                });
+            }) : M.declarations.map(M => {
                 return new AST_VarDef({
                     start: my_start_token(M),
                     end: my_end_token(M),
@@ -1155,6 +1176,13 @@ import { is_basic_identifier_string } from "./parse.js";
             init: to_moz(M.value)
         };
     });
+    def_to_moz(AST_UsingDef, function To_Moz_VariableDeclarator(M) {
+        return {
+            type: "VariableDeclarator",
+            id: to_moz(M.name),
+            init: to_moz(M.value)
+        };
+    });
 
     def_to_moz(AST_This, function To_Moz_ThisExpression() {
         return {
@@ -1369,7 +1397,10 @@ import { is_basic_identifier_string } from "./parse.js";
             type: "VariableDeclaration",
             kind:
                 M instanceof AST_Const ? "const" :
-                M instanceof AST_Let ? "let" : "var",
+                M instanceof AST_Let ? "let" : 
+                M instanceof AST_Using ? "using" : 
+                M instanceof AST_AwaitUsing ? "await using" : 
+                "var",
             declarations: M.definitions.map(to_moz)
         };
     });

--- a/lib/output.js
+++ b/lib/output.js
@@ -1765,9 +1765,7 @@ function OutputStream(options) {
         self._do_print(output, "using");
     });
     DEFPRINT(AST_AwaitUsing, function(self, output) {
-        output.print("await");
-        output.space();
-        self._do_print(output, "using");
+        self._do_print(output, "await using");
     });
     DEFPRINT(AST_Import, function(self, output) {
         output.print("import");

--- a/lib/output.js
+++ b/lib/output.js
@@ -85,6 +85,7 @@ import {
     AST_Default,
     AST_DefaultAssign,
     AST_Definitions,
+    AST_DefinitionsLike,
     AST_Defun,
     AST_Destructuring,
     AST_Directive,
@@ -149,7 +150,7 @@ import {
     AST_UnaryPrefix,
     AST_Using,
     AST_Var,
-    AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield,
@@ -1045,7 +1046,7 @@ function OutputStream(options) {
         return p instanceof AST_Call                          // (foo, bar)() or foo(1, (2, 3), 4)
             || p instanceof AST_Unary                         // !(foo, bar, baz)
             || p instanceof AST_Binary                        // 1 + (2, 3) + 4 ==> 8
-            || p instanceof AST_VarDef                        // var a = (1, 2), b = a + a; ==> b == 4
+            || p instanceof AST_VarDefLike                    // var a = (1, 2), b = a + a; ==> b == 4
             || p instanceof AST_PropAccess                    // (1, {foo:2}).foo or (1, {foo:2})["foo"] ==> 2
             || p instanceof AST_Array                         // [ 1, (2, 3), 4 ] ==> [ 1, 3, 4 ]
             || p instanceof AST_ObjectProperty                // { foo: (1, 2) }.foo ==> 2
@@ -1377,7 +1378,7 @@ function OutputStream(options) {
         output.space();
         output.with_parens(function() {
             if (self.init) {
-                if (self.init instanceof AST_Definitions) {
+                if (self.init instanceof AST_DefinitionsLike) {
                     self.init.print(output);
                 } else {
                     parenthesize_for_noin(self.init, output, true);
@@ -1737,7 +1738,7 @@ function OutputStream(options) {
     });
 
     /* -----[ var/const ]----- */
-    AST_Definitions.DEFMETHOD("_do_print", function(output, kind) {
+    AST_DefinitionsLike.DEFMETHOD("_do_print", function(output, kind) {
         output.print(kind);
         output.space();
         this.definitions.forEach(function(def, i) {
@@ -1929,7 +1930,7 @@ function OutputStream(options) {
         node.print(output, parens);
     }
 
-    DEFPRINT(AST_VarDef, function(self, output) {
+    DEFPRINT(AST_VarDefLike, function(self, output) {
         self.name.print(output);
         if (self.value) {
             output.space();
@@ -2405,7 +2406,7 @@ function OutputStream(options) {
         } else {
             if (!stat || stat instanceof AST_EmptyStatement)
                 output.force_semicolon();
-            else if ((stat instanceof AST_Definitions && !(stat instanceof AST_Var)) || stat instanceof AST_Class)
+            else if ((stat instanceof AST_DefinitionsLike && !(stat instanceof AST_Var)) || stat instanceof AST_Class)
                 make_block(stat, output);
             else
                 stat.print(output);
@@ -2485,7 +2486,7 @@ function OutputStream(options) {
         AST_Class,
         AST_Constant,
         AST_Debugger,
-        AST_Definitions,
+        AST_DefinitionsLike,
         AST_Directive,
         AST_Finally,
         AST_Jump,

--- a/lib/output.js
+++ b/lib/output.js
@@ -58,6 +58,7 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_BlockStatement,
@@ -147,6 +148,8 @@ import {
     AST_Unary,
     AST_UnaryPostfix,
     AST_UnaryPrefix,
+    AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -1758,6 +1761,14 @@ function OutputStream(options) {
     DEFPRINT(AST_Const, function(self, output) {
         self._do_print(output, "const");
     });
+    DEFPRINT(AST_Using, function(self, output) {
+        self._do_print(output, "using");
+    });
+    DEFPRINT(AST_AwaitUsing, function(self, output) {
+        output.print("await");
+        output.space();
+        self._do_print(output, "using");
+    });
     DEFPRINT(AST_Import, function(self, output) {
         output.print("import");
         output.space();
@@ -1926,6 +1937,18 @@ function OutputStream(options) {
     }
 
     DEFPRINT(AST_VarDef, function(self, output) {
+        self.name.print(output);
+        if (self.value) {
+            output.space();
+            output.print("=");
+            output.space();
+            var p = output.parent(1);
+            var noin = p instanceof AST_For || p instanceof AST_ForIn;
+            parenthesize_for_noin(self.value, output, noin);
+        }
+    });
+
+    DEFPRINT(AST_UsingDef, function(self, output) {
         self.name.print(output);
         if (self.value) {
             output.space();
@@ -2401,7 +2424,7 @@ function OutputStream(options) {
         } else {
             if (!stat || stat instanceof AST_EmptyStatement)
                 output.force_semicolon();
-            else if (stat instanceof AST_Let || stat instanceof AST_Const || stat instanceof AST_Class)
+            else if (stat instanceof AST_Let || stat instanceof AST_Const || stat instanceof AST_Using || stat instanceof AST_AwaitUsing || stat instanceof AST_Class)
                 make_block(stat, output);
             else
                 stat.print(output);

--- a/lib/output.js
+++ b/lib/output.js
@@ -2422,7 +2422,7 @@ function OutputStream(options) {
         } else {
             if (!stat || stat instanceof AST_EmptyStatement)
                 output.force_semicolon();
-            else if (stat instanceof AST_Let || stat instanceof AST_Const || stat instanceof AST_Using || stat instanceof AST_AwaitUsing || stat instanceof AST_Class)
+            else if ((stat instanceof AST_Definitions && !(stat instanceof AST_Var)) || stat instanceof AST_Class)
                 make_block(stat, output);
             else
                 stat.print(output);

--- a/lib/output.js
+++ b/lib/output.js
@@ -149,7 +149,6 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Using,
-    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -1935,18 +1934,6 @@ function OutputStream(options) {
     }
 
     DEFPRINT(AST_VarDef, function(self, output) {
-        self.name.print(output);
-        if (self.value) {
-            output.space();
-            output.print("=");
-            output.space();
-            var p = output.parent(1);
-            var noin = p instanceof AST_For || p instanceof AST_ForIn;
-            parenthesize_for_noin(self.value, output, noin);
-        }
-    });
-
-    DEFPRINT(AST_UsingDef, function(self, output) {
         self.name.print(output);
         if (self.value) {
             output.space();

--- a/lib/output.js
+++ b/lib/output.js
@@ -58,7 +58,6 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_BlockStatement,
@@ -1761,10 +1760,7 @@ function OutputStream(options) {
         self._do_print(output, "const");
     });
     DEFPRINT(AST_Using, function(self, output) {
-        self._do_print(output, "using");
-    });
-    DEFPRINT(AST_AwaitUsing, function(self, output) {
-        self._do_print(output, "await using");
+        self._do_print(output, self.await ? "await using" : "using");
     });
     DEFPRINT(AST_Import, function(self, output) {
         output.print("import");

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2202,7 +2202,9 @@ function parse($TEXT, options) {
             var sym_type =
                 kind === "var" ? AST_SymbolVar :
                 kind === "const" ? AST_SymbolConst :
-                kind === "let" ? AST_SymbolLet : null;
+                kind === "let" ? AST_SymbolLet :
+                kind === "using" ? AST_SymbolUsing :
+                kind === "await using" ? AST_SymbolAwaitUsing : null;
             // var { a } = b
             if (is("punc", "{") || is("punc", "[")) {
                 def = new AST_VarDef({
@@ -2217,8 +2219,8 @@ function parse($TEXT, options) {
                     name  : as_symbol(sym_type),
                     value : is("operator", "=")
                         ? (next(), expression(false, no_in))
-                        : !no_in && kind === "const"
-                            ? croak("Missing initializer in const declaration") : null,
+                        : !no_in && (kind === "const" || kind === "using" || kind === "await using")
+                            ? croak("Missing initializer in " + kind + " declaration") : null,
                     end   : prev()
                 });
                 if (def.name.name == "import") croak("Unexpected token: import");
@@ -2255,41 +2257,11 @@ function parse($TEXT, options) {
         });
     };
 
-    function usingdefs(no_in, kind) {
-        var using_defs = [];
-        var def;
-        for (;;) {
-            var sym_type =
-                kind === "using"
-                    ? AST_SymbolUsing
-                    : kind === "await using"
-                    ? AST_SymbolAwaitUsing
-                    : null;
-
-            def = new AST_VarDef({
-                start: S.token,
-                name: as_symbol(sym_type),
-                value: is("operator", "=")
-                    ? (next(), expression(false, no_in))
-                    : !no_in 
-                    ? croak("Missing initializer in " + kind + " declaration")
-                    : null,
-                end: prev(),
-            });
-            if (def.name.name == "import") croak("Unexpected token: import");
-            using_defs.push(def);
-            if (!is("punc", ","))
-                break;
-            next();
-        }
-        return using_defs;
-    }
-
     var using_ = function(no_in) {
         return new AST_Using({
             start       : prev(),
             await       : false,
-            definitions : usingdefs(no_in, "using"),
+            definitions : vardefs(no_in, "using"),
             end         : prev()
         });
     };
@@ -2299,7 +2271,7 @@ function parse($TEXT, options) {
         return new AST_Using({
             start       : prev(),
             await       : true,
-            definitions : (next(), usingdefs(no_in, "await using")),
+            definitions : (next(), vardefs(no_in, "await using")),
             end         : prev()
         });
     };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -817,7 +817,8 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             && (ch >= "a" && ch <= "z" || ch >= "A" && ch <= "Z")
         );
 
-        if (end > start + 1 && ch && ch !== "\\" && !is_identifier_char(ch)) {
+        if (end > start + 1 && ch && ch !== "\\" && !is_identifier_char(ch = S.text.codePointAt(end))) {
+            end += ch > 0xFFFF ? 1 : 0;
             S.pos += end - start;
             S.col += end - start;
             return S.text.slice(start, S.pos);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -195,6 +195,8 @@ var RE_BIN_NUMBER = /^0b[01]+$/i;
 var RE_DEC_NUMBER = /^\d*\.?\d*(?:e[+-]?\d*(?:\d\.?|\.?\d)\d*)?$/i;
 var RE_BIG_INT = /^(0[xob])?[0-9a-f]+n$/i;
 
+var RE_KEYWORD_RELATIONAL_OPERATORS = /in(?:stanceof)?/y;
+
 var OPERATORS = makePredicate([
     "in",
     "instanceof",
@@ -556,18 +558,12 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         if (ch == "\\") {
             return true;
         } else if (is_identifier_start(ch)) {
-            if (ch == "i") {
-                if (get_full_char(S.text, pos + 1) == "n") {
-                    var after_in = get_full_char(S.text, pos + 2);
-                    if (!is_identifier_char(after_in) && after_in != "\\") {
-                        return false; // "in" is a keyword, not a binding identifier
-                    }
-                    if (after_in == "s" && S.text.slice(pos + 3, pos + 10) == "tanceof") {
-                        var after_instanceof = get_full_char(S.text, pos + 10);
-                        if (!is_identifier_char(after_instanceof) && after_instanceof != "\\") {
-                            return false; // "instanceof" is a keyword, not a binding identifier
-                        }
-                    }
+            RE_KEYWORD_RELATIONAL_OPERATORS.lastIndex = pos;
+            if (RE_KEYWORD_RELATIONAL_OPERATORS.test(S.text)) {
+                var after = get_full_char(S.text, RE_KEYWORD_RELATIONAL_OPERATORS.lastIndex);
+                if (!is_identifier_char(after) && after != "\\") {
+                    // "in" or "instanceof" are keywords, not binding identifiers
+                    return false; 
                 }
             }
             return true;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -125,7 +125,6 @@ import {
     AST_Sub,
     AST_Super,
     AST_Switch,
-    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolClass,
     AST_SymbolClassProperty,
@@ -2204,7 +2203,7 @@ function parse($TEXT, options) {
                 kind === "const" ? AST_SymbolConst :
                 kind === "let" ? AST_SymbolLet :
                 kind === "using" ? AST_SymbolUsing :
-                kind === "await using" ? AST_SymbolAwaitUsing : null;
+                kind === "await using" ? AST_SymbolUsing : null;
             // var { a } = b
             if (is("punc", "{") || is("punc", "[")) {
                 def = new AST_VarDef({

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -56,6 +56,7 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_BlockStatement,
@@ -125,6 +126,7 @@ import {
     AST_Sub,
     AST_Super,
     AST_Switch,
+    AST_SymbolAwaitUsing,
     AST_SymbolCatch,
     AST_SymbolClass,
     AST_SymbolClassProperty,
@@ -142,6 +144,7 @@ import {
     AST_SymbolMethod,
     AST_SymbolRef,
     AST_SymbolVar,
+    AST_SymbolUsing,
     AST_TemplateSegment,
     AST_TemplateString,
     AST_This,
@@ -154,6 +157,8 @@ import {
     AST_TryBlock,
     AST_UnaryPostfix,
     AST_UnaryPrefix,
+    AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -512,6 +517,38 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     function skip_whitespace() {
         while (WHITESPACE_CHARS.has(peek()))
             next();
+    }
+
+    function peek_next_token_start_or_newline() {
+        var pos = S.pos;
+        for (var in_multiline_comment = false; pos < S.text.length; ) {
+            var ch = get_full_char(S.text, pos);
+            if (NEWLINE_CHARS.has(ch)) {
+                return ch;
+            } else if (in_multiline_comment) {
+                if (ch == "*" && get_full_char(S.text, pos + 1) == "/") {
+                    pos += 2;
+                    in_multiline_comment = false;
+                } else {
+                    pos++;
+                }
+            } else if (!WHITESPACE_CHARS.has(ch)) {
+                if (ch == "/") {
+                    var next_ch = get_full_char(S.text, pos + 1);
+                    if (next_ch == "/") {
+                        return get_full_char(S.text, find_eol());
+                    } else if (next_ch == "*") {
+                        in_multiline_comment = true;
+                        pos += 2;
+                        continue;
+                    }
+                }
+                return ch;
+            } else {
+                pos++;
+            }
+        }
+        return null;
     }
 
     function read_while(pred) {
@@ -1017,6 +1054,8 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         return S.directives[directive] > 0;
     };
 
+    next_token.peek_next_token_start_or_newline = peek_next_token_start_or_newline;
+
     return next_token;
 
 }
@@ -1252,6 +1291,22 @@ function parse($TEXT, options) {
                 semicolon();
                 return node;
             }
+            if (S.token.value == "using" && is_token(peek(), "name") && !has_newline_before(peek())) {
+                next();
+                var node = using_();
+                semicolon();
+                return node;
+            }
+            if (S.token.value == "await" && can_await() && is_token(peek(), "name", "using") && !has_newline_before(peek())) {
+                var next_next_char = S.input.peek_next_token_start_or_newline();
+                if (next_next_char == "\\" || is_identifier_start(next_next_char)) {
+                    next();
+                    // The "using" token will be consumed by the await_using_ function.
+                    var node = await_using_();
+                    semicolon();
+                    return node;
+                }
+            }
             return is_token(peek(), "punc", ":")
                 ? labeled_statement()
                 : simple_statement();
@@ -1485,6 +1540,8 @@ function parse($TEXT, options) {
                 is("keyword", "var") ? (next(), var_(true)) :
                 is("keyword", "let") ? (next(), let_(true)) :
                 is("keyword", "const") ? (next(), const_(true)) :
+                is("name", "using") && is_token(peek(), "name") && (peek().value != "of" || S.input.peek_next_token_start_or_newline() == "=") ? (next(), using_(true)) :
+                is("name", "await") && can_await() && is_token(peek(), "name", "using") ? (next(), await_using_(true)) :
                                        expression(true, true);
             var is_in = is("operator", "in");
             var is_of = is("name", "of");
@@ -2171,6 +2228,53 @@ function parse($TEXT, options) {
         return new AST_Const({
             start       : prev(),
             definitions : vardefs(no_in, "const"),
+            end         : prev()
+        });
+    };
+
+    function usingdefs(no_in, kind) {
+        var using_defs = [];
+        var def;
+        for (;;) {
+            var sym_type =
+                kind === "using"
+                    ? AST_SymbolUsing
+                    : kind === "await using"
+                    ? AST_SymbolAwaitUsing
+                    : null;
+
+            def = new AST_UsingDef({
+                start: S.token,
+                name: as_symbol(sym_type),
+                value: is("operator", "=")
+                    ? (next(), expression(false, no_in))
+                    : !no_in 
+                    ? croak("Missing initializer in " + kind + " declaration")
+                    : null,
+                end: prev(),
+            });
+            if (def.name.name == "import") croak("Unexpected token: import");
+            using_defs.push(def);
+            if (!is("punc", ","))
+                break;
+            next();
+        }
+        return using_defs;
+    }
+
+    var using_ = function(no_in) {
+        return new AST_Using({
+            start       : prev(),
+            definitions : usingdefs(no_in, "using"),
+            end         : prev()
+        });
+    };
+
+    var await_using_ = function(no_in) {
+        // Assumption: When await_using_ is called, only the `await` token has been consumed.
+        return new AST_AwaitUsing({
+            start       : prev(),
+            definitions : (next(), usingdefs(no_in, "await using")),
             end         : prev()
         });
     };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -56,7 +56,6 @@ import {
     AST_Arrow,
     AST_Assign,
     AST_Await,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_BlockStatement,
@@ -1573,7 +1572,7 @@ function parse($TEXT, options) {
                 if (init instanceof AST_Definitions) {
                     if (init.definitions.length > 1)
                         token_error(init.start, "Only one variable declaration allowed in for..in loop");
-                    if (is_in && (init instanceof AST_Using || init instanceof AST_AwaitUsing)) {
+                    if (is_in && init instanceof AST_Using) {
                         token_error(init.start, "Invalid using declaration in for..in loop");
                     }
                 } else if (!(is_assignable(init) || (init = to_destructuring(init)) instanceof AST_Destructuring)) {
@@ -2289,6 +2288,7 @@ function parse($TEXT, options) {
     var using_ = function(no_in) {
         return new AST_Using({
             start       : prev(),
+            await       : false,
             definitions : usingdefs(no_in, "using"),
             end         : prev()
         });
@@ -2296,8 +2296,9 @@ function parse($TEXT, options) {
 
     var await_using_ = function(no_in) {
         // Assumption: When await_using_ is called, only the `await` token has been consumed.
-        return new AST_AwaitUsing({
+        return new AST_Using({
             start       : prev(),
+            await       : true,
             definitions : (next(), usingdefs(no_in, "await using")),
             end         : prev()
         });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1574,6 +1574,9 @@ function parse($TEXT, options) {
                 if (init instanceof AST_Definitions) {
                     if (init.definitions.length > 1)
                         token_error(init.start, "Only one variable declaration allowed in for..in loop");
+                    if (is_in && init.definitions[0] instanceof AST_UsingDef) {
+                        token_error(init.start, "Invalid using declaration in for..in loop");
+                    }
                 } else if (!(is_assignable(init) || (init = to_destructuring(init)) instanceof AST_Destructuring)) {
                     token_error(init.start, "Invalid left-hand side in for..in loop");
                 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -158,7 +158,6 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Using,
-    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -1574,7 +1573,7 @@ function parse($TEXT, options) {
                 if (init instanceof AST_Definitions) {
                     if (init.definitions.length > 1)
                         token_error(init.start, "Only one variable declaration allowed in for..in loop");
-                    if (is_in && init.definitions[0] instanceof AST_UsingDef) {
+                    if (is_in && (init instanceof AST_Using || init instanceof AST_AwaitUsing)) {
                         token_error(init.start, "Invalid using declaration in for..in loop");
                     }
                 } else if (!(is_assignable(init) || (init = to_destructuring(init)) instanceof AST_Destructuring)) {
@@ -2268,7 +2267,7 @@ function parse($TEXT, options) {
                     ? AST_SymbolAwaitUsing
                     : null;
 
-            def = new AST_UsingDef({
+            def = new AST_VarDef({
                 start: S.token,
                 name: as_symbol(sym_type),
                 value: is("operator", "=")

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -524,7 +524,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         for (var in_multiline_comment = false; pos < S.text.length; ) {
             var ch = get_full_char(S.text, pos);
             if (NEWLINE_CHARS.has(ch)) {
-                return ch;
+                return { char: ch, pos: pos };
             } else if (in_multiline_comment) {
                 if (ch == "*" && get_full_char(S.text, pos + 1) == "/") {
                     pos += 2;
@@ -536,19 +536,43 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
                 if (ch == "/") {
                     var next_ch = get_full_char(S.text, pos + 1);
                     if (next_ch == "/") {
-                        return get_full_char(S.text, find_eol());
+                        pos = find_eol();
+                        return { char: get_full_char(S.text, pos), pos: pos };
                     } else if (next_ch == "*") {
                         in_multiline_comment = true;
                         pos += 2;
                         continue;
                     }
                 }
-                return ch;
+                return { char: ch, pos: pos };
             } else {
                 pos++;
             }
         }
-        return null;
+        return { char: null, pos: pos };
+    }
+
+    function ch_starts_binding_identifier(ch, pos) {
+        if (ch == "\\") {
+            return true;
+        } else if (is_identifier_start(ch)) {
+            if (ch == "i") {
+                if (get_full_char(S.text, pos + 1) == "n") {
+                    var after_in = get_full_char(S.text, pos + 2);
+                    if (!is_identifier_char(after_in) && after_in != "\\") {
+                        return false; // "in" is a keyword, not a binding identifier
+                    }
+                    if (after_in == "s" && S.text.slice(pos + 3, pos + 10) == "tanceof") {
+                        var after_instanceof = get_full_char(S.text, pos + 10);
+                        if (!is_identifier_char(after_instanceof) && after_instanceof != "\\") {
+                            return false; // "instanceof" is a keyword, not a binding identifier
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     function read_while(pred) {
@@ -1055,6 +1079,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     };
 
     next_token.peek_next_token_start_or_newline = peek_next_token_start_or_newline;
+    next_token.ch_starts_binding_identifier = ch_starts_binding_identifier;
 
     return next_token;
 
@@ -1298,8 +1323,8 @@ function parse($TEXT, options) {
                 return node;
             }
             if (S.token.value == "await" && can_await() && is_token(peek(), "name", "using") && !has_newline_before(peek())) {
-                var next_next_char = S.input.peek_next_token_start_or_newline();
-                if (next_next_char == "\\" || is_identifier_start(next_next_char)) {
+                var next_next = S.input.peek_next_token_start_or_newline();
+                if (S.input.ch_starts_binding_identifier(next_next.char, next_next.pos)) {
                     next();
                     // The "using" token will be consumed by the await_using_ function.
                     var node = await_using_();
@@ -1540,7 +1565,7 @@ function parse($TEXT, options) {
                 is("keyword", "var") ? (next(), var_(true)) :
                 is("keyword", "let") ? (next(), let_(true)) :
                 is("keyword", "const") ? (next(), const_(true)) :
-                is("name", "using") && is_token(peek(), "name") && (peek().value != "of" || S.input.peek_next_token_start_or_newline() == "=") ? (next(), using_(true)) :
+                is("name", "using") && is_token(peek(), "name") && (peek().value != "of" || S.input.peek_next_token_start_or_newline().char == "=") ? (next(), using_(true)) :
                 is("name", "await") && can_await() && is_token(peek(), "name", "using") ? (next(), await_using_(true)) :
                                        expression(true, true);
             var is_in = is("operator", "in");

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -817,8 +817,8 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
             && (ch >= "a" && ch <= "z" || ch >= "A" && ch <= "Z")
         );
 
-        if (end > start + 1 && ch && ch !== "\\" && !is_identifier_char(ch = S.text.codePointAt(end))) {
-            end += ch > 0xFFFF ? 1 : 0;
+        // 0x7F is very rare in actual code, so we compare it to "~" (0x7E)
+        if (end > start + 1 && ch && ch !== "\\" && !is_identifier_char(ch) && ch <= "~") {
             S.pos += end - start;
             S.col += end - start;
             return S.text.slice(start, S.pos);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1238,10 +1238,6 @@ function parse($TEXT, options) {
             return simple_statement();
 
           case "name":
-          case "privatename":
-            if(is("privatename") && !S.in_class)
-                croak("Private field must be used in an enclosing class");
-
             if (S.token.value == "async" && is_token(peek(), "keyword", "function")) {
                 next();
                 next();
@@ -1259,6 +1255,11 @@ function parse($TEXT, options) {
             return is_token(peek(), "punc", ":")
                 ? labeled_statement()
                 : simple_statement();
+
+          case "privatename":
+            if(!S.in_class)
+              croak("Private field must be used in an enclosing class");
+            return simple_statement();
 
           case "punc":
             switch (S.token.value) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -81,6 +81,7 @@ import {
     AST_DefaultAssign,
     AST_DefClass,
     AST_Definitions,
+    AST_DefinitionsLike,
     AST_Defun,
     AST_Destructuring,
     AST_Directive,
@@ -156,6 +157,7 @@ import {
     AST_UnaryPostfix,
     AST_UnaryPrefix,
     AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -1568,7 +1570,7 @@ function parse($TEXT, options) {
                 token_error(await_tok, for_await_error);
             }
             if (is_in || is_of) {
-                if (init instanceof AST_Definitions) {
+                if (init instanceof AST_DefinitionsLike) {
                     if (init.definitions.length > 1)
                         token_error(init.start, "Only one variable declaration allowed in for..in loop");
                     if (is_in && init instanceof AST_Using) {
@@ -1605,7 +1607,7 @@ function parse($TEXT, options) {
     }
 
     function for_of(init, is_await) {
-        var lhs = init instanceof AST_Definitions ? init.definitions[0].name : null;
+        var lhs = init instanceof AST_DefinitionsLike ? init.definitions[0].name : null;
         var obj = expression(true);
         expect(")");
         return new AST_ForOf({
@@ -2204,16 +2206,17 @@ function parse($TEXT, options) {
                 kind === "let" ? AST_SymbolLet :
                 kind === "using" ? AST_SymbolUsing :
                 kind === "await using" ? AST_SymbolUsing : null;
+            var def_type = kind === "using" || kind === "await using" ? AST_UsingDef : AST_VarDef;
             // var { a } = b
             if (is("punc", "{") || is("punc", "[")) {
-                def = new AST_VarDef({
+                def = new def_type({
                     start: S.token,
                     name: binding_element(undefined, sym_type),
                     value: is("operator", "=") ? (expect_token("operator", "="), expression(false, no_in)) : null,
                     end: prev()
                 });
             } else {
-                def = new AST_VarDef({
+                def = new def_type({
                     start : S.token,
                     name  : as_symbol(sym_type),
                     value : is("operator", "=")

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2722,13 +2722,13 @@ function parse($TEXT, options) {
             return name;
         };
 
+        var is_private = prev().type === "privatename";
         const is_not_method_start = () =>
-            !is("punc", "(") && !is("punc", ",") && !is("punc", "}") && !is("punc", ";") && !is("operator", "=");
+            !is("punc", "(") && !is("punc", ",") && !is("punc", "}") && !is("punc", ";") && !is("operator", "=") && !is_private;
 
         var is_async = false;
         var is_static = false;
         var is_generator = false;
-        var is_private = false;
         var accessor_type = null;
 
         if (is_class && name === "static" && is_not_method_start()) {
@@ -2751,7 +2751,7 @@ function parse($TEXT, options) {
             accessor_type = name;
             name = as_property_name();
         }
-        if (prev().type === "privatename") {
+        if (!is_private && prev().type === "privatename") {
             is_private = true;
         }
 

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -86,6 +86,7 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
+    AST_SymbolAwaitUsing,
     AST_SymbolBlockDeclaration,
     AST_SymbolCatch,
     AST_SymbolClass,
@@ -99,6 +100,7 @@ import {
     AST_SymbolLet,
     AST_SymbolMethod,
     AST_SymbolRef,
+    AST_SymbolUsing,
     AST_SymbolVar,
     AST_Toplevel,
     AST_VarDef,
@@ -322,6 +324,8 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
             node instanceof AST_SymbolVar
             || node instanceof AST_SymbolLet
             || node instanceof AST_SymbolConst
+            || node instanceof AST_SymbolUsing
+            || node instanceof AST_SymbolAwaitUsing
             || node instanceof AST_SymbolCatch
         ) {
             var def;
@@ -335,7 +339,7 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
                 if (node instanceof AST_SymbolBlockDeclaration) {
                     return sym instanceof AST_SymbolLambda;
                 }
-                return !(sym instanceof AST_SymbolLet || sym instanceof AST_SymbolConst);
+                return !(sym instanceof AST_SymbolLet || sym instanceof AST_SymbolConst || sym instanceof AST_SymbolUsing || sym instanceof AST_SymbolAwaitUsing);
             })) {
                 js_error(
                     `"${node.name}" is redeclared`,

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -86,7 +86,6 @@ import {
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
-    AST_SymbolAwaitUsing,
     AST_SymbolBlockDeclaration,
     AST_SymbolCatch,
     AST_SymbolClass,
@@ -325,7 +324,6 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
             || node instanceof AST_SymbolLet
             || node instanceof AST_SymbolConst
             || node instanceof AST_SymbolUsing
-            || node instanceof AST_SymbolAwaitUsing
             || node instanceof AST_SymbolCatch
         ) {
             var def;
@@ -339,7 +337,7 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
                 if (node instanceof AST_SymbolBlockDeclaration) {
                     return sym instanceof AST_SymbolLambda;
                 }
-                return !(sym instanceof AST_SymbolLet || sym instanceof AST_SymbolConst || sym instanceof AST_SymbolUsing || sym instanceof AST_SymbolAwaitUsing);
+                return !(sym instanceof AST_SymbolLet || sym instanceof AST_SymbolConst || sym instanceof AST_SymbolUsing);
             })) {
                 js_error(
                     `"${node.name}" is redeclared`,

--- a/lib/size.js
+++ b/lib/size.js
@@ -80,7 +80,7 @@ import {
     AST_Undefined,
     AST_Using,
     AST_Var,
-    AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield,
@@ -248,7 +248,7 @@ AST_Using.prototype._size = function () {
     return await_size + 6 + list_overhead(this.definitions);
 };
 
-AST_VarDef.prototype._size = function () {
+AST_VarDefLike.prototype._size = function () {
     return this.value ? 1 : 0;
 };
 

--- a/lib/size.js
+++ b/lib/size.js
@@ -3,6 +3,7 @@ import {
     AST_Array,
     AST_Arrow,
     AST_Await,
+    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -78,6 +79,8 @@ import {
     AST_Finally,
     AST_Unary,
     AST_Undefined,
+    AST_Using,
+    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -242,7 +245,19 @@ AST_Const.prototype._size = function () {
     return 6 + list_overhead(this.definitions);
 };
 
+AST_Using.prototype._size = function () {
+    return 6 + list_overhead(this.definitions);
+};
+
+AST_AwaitUsing.prototype._size = function () {
+    return 12 + list_overhead(this.definitions);
+};
+
 AST_VarDef.prototype._size = function () {
+    return this.value ? 1 : 0;
+};
+
+AST_UsingDef.prototype._size = function () {
     return this.value ? 1 : 0;
 };
 

--- a/lib/size.js
+++ b/lib/size.js
@@ -3,7 +3,6 @@ import {
     AST_Array,
     AST_Arrow,
     AST_Await,
-    AST_AwaitUsing,
     AST_BigInt,
     AST_Binary,
     AST_Block,
@@ -245,11 +244,8 @@ AST_Const.prototype._size = function () {
 };
 
 AST_Using.prototype._size = function () {
-    return 6 + list_overhead(this.definitions);
-};
-
-AST_AwaitUsing.prototype._size = function () {
-    return 12 + list_overhead(this.definitions);
+    const await_size = this.await ? 6 : 0;
+    return await_size + 6 + list_overhead(this.definitions);
 };
 
 AST_VarDef.prototype._size = function () {

--- a/lib/size.js
+++ b/lib/size.js
@@ -80,7 +80,6 @@ import {
     AST_Unary,
     AST_Undefined,
     AST_Using,
-    AST_UsingDef,
     AST_Var,
     AST_VarDef,
     AST_While,
@@ -254,10 +253,6 @@ AST_AwaitUsing.prototype._size = function () {
 };
 
 AST_VarDef.prototype._size = function () {
-    return this.value ? 1 : 0;
-};
-
-AST_UsingDef.prototype._size = function () {
     return this.value ? 1 : 0;
 };
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -56,7 +56,7 @@ import {
     AST_Class,
     AST_ClassStaticBlock,
     AST_Conditional,
-    AST_Definitions,
+    AST_DefinitionsLike,
     AST_Destructuring,
     AST_Do,
     AST_Exit,
@@ -83,7 +83,7 @@ import {
     AST_TemplateString,
     AST_Try,
     AST_Unary,
-    AST_VarDef,
+    AST_VarDefLike,
     AST_While,
     AST_With,
     AST_Yield,
@@ -189,11 +189,11 @@ def_transform(AST_Catch, function(self, tw) {
     self.body = do_list(self.body, tw);
 });
 
-def_transform(AST_Definitions, function(self, tw) {
+def_transform(AST_DefinitionsLike, function(self, tw) {
     self.definitions = do_list(self.definitions, tw);
 });
 
-def_transform(AST_VarDef, function(self, tw) {
+def_transform(AST_VarDefLike, function(self, tw) {
     self.name = self.name.transform(tw);
     if (self.value) self.value = self.value.transform(tw);
 });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -84,7 +84,6 @@ import {
     AST_Try,
     AST_Unary,
     AST_VarDef,
-    AST_UsingDef,
     AST_While,
     AST_With,
     AST_Yield,
@@ -195,11 +194,6 @@ def_transform(AST_Definitions, function(self, tw) {
 });
 
 def_transform(AST_VarDef, function(self, tw) {
-    self.name = self.name.transform(tw);
-    if (self.value) self.value = self.value.transform(tw);
-});
-
-def_transform(AST_UsingDef, function(self, tw) {
     self.name = self.name.transform(tw);
     if (self.value) self.value = self.value.transform(tw);
 });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -84,6 +84,7 @@ import {
     AST_Try,
     AST_Unary,
     AST_VarDef,
+    AST_UsingDef,
     AST_While,
     AST_With,
     AST_Yield,
@@ -194,6 +195,11 @@ def_transform(AST_Definitions, function(self, tw) {
 });
 
 def_transform(AST_VarDef, function(self, tw) {
+    self.name = self.name.transform(tw);
+    if (self.value) self.value = self.value.transform(tw);
+});
+
+def_transform(AST_UsingDef, function(self, tw) {
     self.name = self.name.transform(tw);
     if (self.value) self.value = self.value.transform(tw);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -267,9 +267,10 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2638,9 +2639,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
     },
     "acorn-jsx": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "@jridgewell/source-map": "^0.3.3",
-    "acorn": "^8.14.0",
+    "acorn": "^8.15.0",
     "commander": "^2.20.0",
     "source-map-support": "~0.5.20"
   },

--- a/test/compress/class-properties.js
+++ b/test/compress/class-properties.js
@@ -664,3 +664,27 @@ privatein_precedence_bad_2: {
         col: 38,
     })
 }
+
+private_async_function_method_bad: {
+    bad_input: `class C { #async function f() {} }`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected token: keyword (function)",
+    })
+}
+
+private_static_block_bad: {
+    bad_input: `class C { #static {} }`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected token: punc ({)",
+    })
+}
+
+private_async_function_statement_bad: {
+    bad_input: `class C { static { #async function f() {} } }`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected token keyword «function», expected operator «in»",
+    })
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -932,6 +932,24 @@ forin: {
     expect_stdout: "PASS"
 }
 
+forin_assignment: {
+    options = {
+        sequences: true,
+    }
+    input: {
+        var o = [], a = {};
+        o.push("PASS");
+        for (a.b in o)
+            console.log(o[a.b]);
+    }
+    expect: {
+        var o = [], a = {};
+        for (a.b in o.push("PASS"), o)
+            console.log(o[a.b]);
+    }
+    expect_stdout: "PASS"
+}
+
 call: {
     options = {
         sequences: true,

--- a/test/compress/unicode.js
+++ b/test/compress/unicode.js
@@ -112,6 +112,14 @@ ID_continue_with_non_bmp_character: {
     expect_exact: 'var in\\u{1d4d0},instanceof\\u{1d4d1};'
 }
 
+non_id_continue_non_bmp_character: {
+    bad_input: `var in𝅘𝅥`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Name expected"
+    })
+}
+
 escape_non_escaped_identifier: {
     beautify = {ascii_only: true, ecma: 2015}
     input: {

--- a/test/compress/unicode.js
+++ b/test/compress/unicode.js
@@ -104,6 +104,14 @@ ID_continue_with_surrogate_pair: {
     expect_exact: 'var \\u{2f800}\\u{2f800}\\u{2f800}\\u{2f800}="\\u{100000}\\u{100000}\\u{100000}\\u{100000}\\u{100000}";'
 }
 
+ID_continue_with_non_bmp_character: {
+    beautify = {ascii_only: true, ecma: 2015}
+    input: {
+        var in𝓐, instanceof𝓑;
+    }
+    expect_exact: 'var in\\u{1d4d0},instanceof\\u{1d4d1};'
+}
+
 escape_non_escaped_identifier: {
     beautify = {ascii_only: true, ecma: 2015}
     input: {

--- a/test/compress/using.js
+++ b/test/compress/using.js
@@ -1,0 +1,242 @@
+using_basic: {
+    options = {}
+    input: {
+        using x = null;
+    }
+    expect: {
+        using x=null;
+    }
+}
+
+using_multiple: {
+    options = {}
+    input: {
+        using x = f(), y = g(), z = null;
+    }
+    expect: {
+        using x=f(),y=g(),z=null;
+    }
+}
+
+using_for: {
+    options = {}
+    input: {
+        for (using x = y; ; ) { };
+    }
+    expect: {
+        for(using x = y;;);
+    }
+}
+
+using_for_of: {
+    options = {}
+    input: {
+        for (using x of y);
+    }
+    expect: {
+        for(using x of y);
+    }
+}
+
+using_of_equals_for: {
+    options = {}
+    input: {
+        for (using of = f();;);
+    }
+    expect: {
+        for(using of=f();;);
+    }
+}
+
+using_with_comments: {
+    format = {
+        comments: true
+    }
+    input: {
+        /* 1 */using /* 2 */x /* 3 */= /* 4 */f() /* 5 */;
+    }
+    expect: {
+        /* 1 */using/* 2 */x/* 3 */=/* 4 */f()/* 5 */;
+    }
+}
+
+using_as_name_asi: {
+    options = {}
+    input: {
+        using
+        x = f()
+    }
+    expect: {
+        using;x=f();
+    }
+}
+
+using_as_name_member_expr: {
+    options = {}
+    input: {
+        using [ obj ] = f();
+    }
+    expect: {
+        using[obj]=f();
+    }
+}
+
+using_as_name_for_of: {
+    options = {}
+    input: {
+        for (using of f());
+    }
+    expect: {
+        for(using of f());
+    }
+}
+
+using_as_name_for_of_of_member_expr: {
+    options = {}
+    input: {
+        for (using of of[property]);
+    }
+    expect: {
+        for(using of of[property]);
+    }
+}
+
+await_using_basic: {
+    options = {}
+    input: {
+        async () => { await using x = null; }
+    }
+    expect: {
+        async()=>{await using x=null;}
+    }
+}
+
+await_using_multiple: {
+    options = {}
+    input: {
+        async () => { await using x = f(), y = g(), z = null; }
+    }
+    expect: {
+        async()=>{await using x=f(),y=g(),z=null;}
+    }
+}
+
+await_using_escaped_identifier: {
+    options = {}
+    input: {
+        async () => { await using \u0061 = null; }
+    }
+    expect: {
+        async()=>{await using a=null;}
+    }
+}
+
+await_using_for: {
+    options = {}
+    input: {
+        async () => { for (await using x = y; ; ); }
+    }
+    expect: {
+        async()=>{for(await using x=y;;);}
+    }
+}
+
+await_using_for_of: {
+    options = {}
+    input: {
+        async () => { for (await using x of y); }
+    }
+    expect: {
+        async()=>{for(await using x of y);}
+    }
+}
+
+await_using_for_await_of: {
+    options = {}
+    input: {
+        async () => { for await (await using x of y); }
+    }
+    expect: {
+        async()=>{for await(await using x of y);}
+    }
+}
+
+await_using_with_comments: {
+    format = {
+        comments: true
+    }
+    input: {
+        async () => {/* 1 */await /* 2 */using /* 3 */x /* 4 */= /* 5 */f() /* 6 */}
+    }
+    expect: {
+        async()=>{/* 1 */await/* 2 */using/* 3 */x/* 4 */=/* 5 */f()/* 6 */};
+    }
+}
+
+await_using_as_name_asi: {
+    options = {}
+    input: {
+        async () => {
+            await using
+            x = f()
+        }
+    }
+    expect: {
+        async()=>{await using;x=f();}
+    }
+}
+
+await_using_as_name_asi_line_comment: {
+    options = {}
+    input: {
+        async () => {
+            await using // comment
+            x = f()
+        }
+    }
+    expect: {
+        async()=>{await using;x=f();}
+    }   
+}
+
+await_using_as_name_asi_multiline_comment: {
+    options = {}
+    input: {
+        async () => {
+            await using /* comment 
+            */ x = f()
+        }
+    }
+    expect: {
+        async()=>{await using;x=f();}
+    }   
+}
+
+await_using_as_name_member_expr: {
+    options = {}
+    input: {
+        async () => {
+            await using [ obj ];
+        }
+    }
+    expect: {
+        async()=>{await using[obj];}
+    }
+}
+
+await_using_and_using_in_same_scope: {
+    options = {}
+    input: {
+        async () => {
+            await
+            z;
+            using x
+                = f();
+            await using y
+                = g();
+        }
+    }
+    expect: {
+        async()=>{await z;using x=f();await using y=g();}
+    }
+}

--- a/test/compress/using.js
+++ b/test/compress/using.js
@@ -101,6 +101,16 @@ using_as_name_for_of_of_member_expr: {
     }
 }
 
+using_as_name_for_in: {
+    options = {}
+    input: {
+        for (using in f());
+    }
+    expect: {
+        for(using in f());
+    }
+}
+
 await_using_basic: {
     options = {}
     input: {

--- a/test/compress/using.js
+++ b/test/compress/using.js
@@ -71,13 +71,46 @@ using_as_name_asi: {
     }
 }
 
-using_as_name_member_expr: {
+using_as_name_subscript_expr: {
     options = {}
     input: {
-        using [ obj ] = f();
+        function f() {
+            using[x];
+            using.x + using(x) ? using?.x : using`x`;
+        }
     }
     expect: {
-        using[obj]=f();
+        function f(){using[x];using.x+using(x)?using?.x:using`x`};
+    }
+}
+
+using_as_name_in: {
+    options = {}
+    input: {
+        function f() {
+            using in foo;
+        }
+    }
+    expect: {
+        function f() {
+            using in foo;
+        }
+    }
+}
+
+using_as_name_instanceof: {
+    options = {}
+    input: {
+        function f() {
+            using instanceof foo;
+            using in using instanceof using;
+        }
+    }
+    expect: {
+        function f() {
+            using instanceof foo;
+            using in using instanceof using;
+        }
     }
 }
 
@@ -105,9 +138,12 @@ using_as_name_for_in: {
     options = {}
     input: {
         for (using in f());
+        for (using.foo in []);
+        for (using().foo in []);
+        for (using``.foo in []);
     }
     expect: {
-        for(using in f());
+        for(using in f());for(using.foo in []);for(using().foo in []);for(using``.foo in []);
     }
 }
 
@@ -138,6 +174,34 @@ await_using_escaped_identifier: {
     }
     expect: {
         async()=>{await using a=null;}
+    }
+}
+
+await_using_identifier_starts_with_in: {
+    options = {}
+    input: {
+        async () => {
+            await using ina = null;
+            await using in\u0062 = null;
+            await using in𝒞 = null;
+        }
+    }
+    expect: {
+        async()=>{await using ina=null;await using inb=null;await using in𝒞=null;}
+    }
+}
+
+await_using_identifier_starts_with_instanceof: {
+    options = {}
+    input: {
+        async () => {
+            await using instanceofa = null;
+            await using instanceof\u0062 = null;
+            await using instanceof𝒞 = null;
+        }
+    }
+    expect: {
+        async()=>{await using instanceofa=null;await using instanceofb=null;await using instanceof𝒞=null;}
     }
 }
 
@@ -222,15 +286,44 @@ await_using_as_name_asi_multiline_comment: {
     }   
 }
 
-await_using_as_name_member_expr: {
+await_using_as_name_in: {
     options = {}
     input: {
-        async () => {
-            await using [ obj ];
+        async function f() {
+            await using in foo;
         }
     }
     expect: {
-        async()=>{await using[obj];}
+        async function f() {
+            await using in foo;
+        }
+    }
+}
+
+await_using_as_name_instanceof: {
+    options = {}
+    input: {
+        async function f() {
+            await using instanceof foo;
+        }
+    }
+    expect: {
+        async function f() {
+            await using instanceof foo;
+        }
+    }
+}
+
+await_using_as_name_subscript_expr: {
+    options = {}
+    input: {
+        async () => {
+            await using[x];
+            await using.x + await using(x) ? await using?.x : await using`x`;
+        }
+    }
+    expect: {
+        async()=>{await using[x];await using.x+await using(x)?await using?.x:await using`x`};
     }
 }
 

--- a/test/compress/using.js
+++ b/test/compress/using.js
@@ -240,3 +240,27 @@ await_using_and_using_in_same_scope: {
         async()=>{await z;using x=f();await using y=g();}
     }
 }
+
+unused_using_should_be_kept: {
+    options = {
+        unused: true,
+    }
+    input: {
+        using x = f();
+    }
+    expect: {
+        using x=f();
+    }
+}
+
+unused_await_using_should_be_kept: {
+    options = {
+        unused: true,
+    }
+    input: {
+        (async () => { await using x = f(); })();
+    }
+    expect: {
+        (async()=>{await using x = f();})();
+    }
+}

--- a/test/compress/using.js
+++ b/test/compress/using.js
@@ -28,6 +28,15 @@ using_for: {
     }
 }
 
+using_for_in_bad: {
+    options = {}
+    bad_input: `for (using x in y);`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Invalid using declaration in for..in loop",
+    })
+}
+
 using_for_of: {
     options = {}
     input: {
@@ -58,6 +67,15 @@ using_with_comments: {
     expect: {
         /* 1 */using/* 2 */x/* 3 */=/* 4 */f()/* 5 */;
     }
+}
+
+using_object_pattern_bad: {
+    options = {}
+    bad_input: `using { x } = y;`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected token: punc ({)",
+    })
 }
 
 using_as_name_asi: {
@@ -205,6 +223,15 @@ await_using_identifier_starts_with_instanceof: {
     }
 }
 
+await_using_object_pattern_bad: {
+    options = {}
+    bad_input: `async () => { await using { x } = y; }`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Unexpected token: punc ({)",
+    })
+}
+
 await_using_for: {
     options = {}
     input: {
@@ -213,6 +240,15 @@ await_using_for: {
     expect: {
         async()=>{for(await using x=y;;);}
     }
+}
+
+await_using_for_in_bad: {
+    options = {}
+    bad_input: `async () => { for (await using x in y); }`
+    expect_error: ({
+        name: "SyntaxError",
+        message: "Invalid using declaration in for..in loop",
+    })
 }
 
 await_using_for_of: {

--- a/test/input/spidermonkey/input.js
+++ b/test/input/spidermonkey/input.js
@@ -299,3 +299,16 @@ function uses_asm() {
     0.0;
 }
 
+// using declarations
+function using() {
+    using x1 = resource(), y1 = resource();
+    for (using x1 = resource(), y1 = resource(); ; );
+    for (using x1 of iterable()) {}
+}
+
+// await using declarations
+async function await_using() {
+    await using x2 = resource(), y2 = resource();
+    for (await using x2 = resource(), y2 = resource(); ; );
+    for (await using x2 of iterable()) {}
+}

--- a/test/mocha/size.js
+++ b/test/mocha/size.js
@@ -9,4 +9,8 @@ describe("size", () => {
         assert.equal(parse("()=>{return 2}").size(), 5);
         assert.equal(parse("()=>2").size(), 5);
     });
+    it("approximates the size of variable declaration", () => {
+        assert.equal(parse("using x=null").size(), 12);
+        assert.equal(parse("async()=>{await using x=null}").size(), 30);
+    });
 });

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -134,7 +134,7 @@ describe("spidermonkey export/import sanity test", function() {
     it("should be capable of importing from acorn", async function() {
         var code = fs.readFileSync("test/input/spidermonkey/input.js", "utf-8");
         var terser_ast = parse(code);
-        var moz_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2025 });
+        var moz_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2026 });
         var from_moz_ast = AST.AST_Node.from_mozilla_ast(moz_ast);
         assert.strictEqual(
             from_moz_ast.print_to_string(),
@@ -149,7 +149,7 @@ describe("spidermonkey export/import sanity test", function() {
     it("(temp): should be capable of importing from acorn (astring incompatible bits)", async function() {
         var code = fs.readFileSync("test/input/spidermonkey/input-no-astring.js", "utf-8");
         var terser_ast = parse(code);
-        var moz_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2025 });
+        var moz_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2026 });
         var from_moz_ast = AST.AST_Node.from_mozilla_ast(moz_ast);
         assert.strictEqual(
             from_moz_ast.print_to_string(),
@@ -162,7 +162,7 @@ describe("spidermonkey export/import sanity test", function() {
     })
 
     it("should accept a spidermonkey AST w/ `parse.spidermonkey: true`", async function() {
-        var moz_ast = acornParse("var a = 1 + 2", { sourceType: "module", ecmaVersion: 2025 });
+        var moz_ast = acornParse("var a = 1 + 2", { sourceType: "module", ecmaVersion: 2026 });
         var result = await minify(moz_ast, {ecma: 2015, parse: {spidermonkey: true}});
         assert.deepStrictEqual(result.code, "var a=3;");
     });
@@ -204,7 +204,7 @@ describe("spidermonkey export/import sanity test", function() {
         var terser_ast = parse(code);
         var moz_ast = terser_ast.to_mozilla_ast();
         var generated = astringGenerate(moz_ast);
-        var parsed = acornParse(generated, { sourceType: "module", ecmaVersion: 2025 });
+        var parsed = acornParse(generated, { sourceType: "module", ecmaVersion: 2026 });
         assert.strictEqual(
             AST.AST_Node.from_mozilla_ast(parsed).print_to_string(),
             terser_ast.print_to_string()
@@ -218,7 +218,7 @@ describe("spidermonkey export/import sanity test", function() {
     it("should generate the same AST that acorn does", async function () {
         var code = fs.readFileSync("test/input/spidermonkey/input.js", "utf-8");
         var terser_ast = parse(code).to_mozilla_ast();
-        var acorn_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2025 });
+        var acorn_ast = acornParse(code, { sourceType: "module", ecmaVersion: 2026 });
         compare_estree_asts(terser_ast, acorn_ast)
     });
 });


### PR DESCRIPTION
Fixes https://github.com/terser/terser/issues/1625.

This PR is a very preliminary support for the using / await using declarations. The priority of this PR is to parse such declarations and ensure that we don't drop/inline such declarations in the optimizer: Because unlike const declarations, a `using` declaration itself, even unused, typically has side effects. Therefore this PR will surely miss quite a few optimization opportunity, which I think should be addressed in the future.

## AST
```ts
interface Using extends Definitions {
  definitions: UsingDef[]
}

interface AwaitUsing extends Definitions {
  definitions: UsingDef[]
}

interface UsingDef {
  name: AST_SymbolUsing|AST_SymbolAwaitUsing
  value: AST_Node?
}
```

Unlike `var`, `let` and `const`, we provided a new interface `UsingDef` for the definitions within `Using` and `AwaitUsing`. The `UsingDef` share the same interface with `VarDef`. The reason is that there are quite a few optimizers working on the `VarDef` AST, and so the separation here ensures that such optimizer will not handle the using/await using declarations, and thus we will not drop/inline them as we did for `const` or `let`. Of course in the future we can carefully review those `VarDef` optimizers and selectively apply some of them to the `UsingDef`. But in this PR the output correctness is prioritized over output size.