### PR TITLE
add "builtins" and "builtins_pure" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,10 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `ecma` (default: `5`) -- Pass `2015` or greater to enable `compress` options that
   will transform ES5 code into smaller ES6+ equivalent forms.
 
+- `builtins` (default: `[5]`) -- Tell Terser which well-known functions, constants, methods and classes are available in the global object. Pass in an array with an ES version number (like with `ecma`). In future, you'll be able to add more to this array. Does nothing by itself, but is used by `builtins_pure` and `unsafe`.
+
+- `builtins_pure` (default: `false`) -- Pass `true` to assume that functions matched by the `builtins` option (such as `Math.sin` or `unescape`) are pure and calls to them can be removed.
+
 - `evaluate` (default: `true`) -- attempt to evaluate constant expressions
 
 - `expression` (default: `false`) -- Pass `true` to preserve completion values

--- a/README.md
+++ b/README.md
@@ -740,9 +740,9 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `ecma` (default: `5`) -- Pass `2015` or greater to enable `compress` options that
   will transform ES5 code into smaller ES6+ equivalent forms.
 
-- `builtins` (default: `5`) -- Am EcmaScript version number (like `ecma`). Tells Terser which well-known functions, constants, methods and classes are available in the global object. Does nothing by itself, but is used by `builtins_pure` and `unsafe`.
+- `builtins_ecma` (default: `5`) -- An ES version number (like `ecma`). Tells Terser which well-known functions, constants, methods and classes are available in the global object. Does nothing by itself, but is used by `builtins_pure` and `unsafe`.
 
-- `builtins_pure` (default: `false`) -- Pass `true` to assume that functions matched by the `builtins` option (such as `Math.sin` or `unescape`) are pure and calls to them can be removed.
+- `builtins_pure` (default: `false`) -- Pass `true` to assume that functions matched by the `builtins_ecma` option (such as `Math.sin` or `unescape`) are pure and calls to them can be removed.
 
 - `evaluate` (default: `true`) -- attempt to evaluate constant expressions
 

--- a/README.md
+++ b/README.md
@@ -740,7 +740,7 @@ If you happen to need the source map as a raw object, set `sourceMap.asObject` t
 - `ecma` (default: `5`) -- Pass `2015` or greater to enable `compress` options that
   will transform ES5 code into smaller ES6+ equivalent forms.
 
-- `builtins` (default: `[5]`) -- Tell Terser which well-known functions, constants, methods and classes are available in the global object. Pass in an array with an ES version number (like with `ecma`). In future, you'll be able to add more to this array. Does nothing by itself, but is used by `builtins_pure` and `unsafe`.
+- `builtins` (default: `5`) -- Am EcmaScript version number (like `ecma`). Tells Terser which well-known functions, constants, methods and classes are available in the global object. Does nothing by itself, but is used by `builtins_pure` and `unsafe`.
 
 - `builtins_pure` (default: `false`) -- Pass `true` to assume that functions matched by the `builtins` option (such as `Math.sin` or `unescape`) are pure and calls to them can be removed.
 

--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -75,7 +75,6 @@ import {
     AST_With,
 } from "../ast.js";
 import { is_undeclared_ref} from "./inference.js";
-import { is_pure_native_value, is_pure_native_fn, is_pure_native_method } from "./native-objects.js";
 
 // methods to evaluate a constant expression
 
@@ -426,7 +425,7 @@ def_eval(AST_PropAccess, function (compressor, depth) {
             if (first_arg == null || first_arg.thedef && first_arg.thedef.undeclared) {
                 return this.clone();
             }
-            if (!is_pure_native_value(exp.name, key))
+            if (!compressor.is_pure_native_static_property(exp.name, key))
                 return this;
             obj = global_objs[exp.name];
         } else {
@@ -489,13 +488,13 @@ def_eval(AST_Call, function (compressor, depth) {
             if ((first_arg == null || first_arg.thedef && first_arg.thedef.undeclared)) {
                 return this.clone();
             }
-            if (!is_pure_native_fn(e.name, key)) return this;
+            if (!compressor.is_pure_native_static_fn(e.name, key)) return this;
             val = global_objs[e.name];
         } else {
             val = e._eval(compressor, depth + 1);
             if (val === e || !val)
                 return this;
-            if (!is_pure_native_method(val.constructor.name, key))
+            if (!compressor.is_pure_native_method(val.constructor.name, key))
                 return this;
         }
         var args = [];

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -214,6 +214,7 @@ import {
 import { tighten_body, extract_from_unreachable_code } from "./tighten-body.js";
 import { inline_into_symbolref, inline_into_call } from "./inline.js";
 import "./global-defs.js";
+import { is_pure_native_fn, is_pure_native_method, is_pure_native_static_fn, is_pure_native_static_property, pure_access_globals } from "./native-objects.js";
 
 class Compressor extends TreeWalker {
     constructor(options, { false_by_default = false, mangle_options = false }) {
@@ -234,6 +235,8 @@ class Compressor extends TreeWalker {
             drop_console  : false,
             drop_debugger : !false_by_default,
             ecma          : 5,
+            builtins      : [5],
+            builtins_pure : false,
             evaluate      : !false_by_default,
             expression    : false,
             global_defs   : false,
@@ -329,6 +332,12 @@ class Compressor extends TreeWalker {
         this._mangle_options = mangle_options
             ? format_mangler_options(mangle_options)
             : mangle_options;
+
+        this.pure_access_globals = pure_access_globals(this);
+        this.is_pure_native_fn = is_pure_native_fn(this);
+        this.is_pure_native_method = is_pure_native_method(this);
+        this.is_pure_native_static_fn = is_pure_native_static_fn(this);
+        this.is_pure_native_static_property = is_pure_native_static_property(this);
     }
 
     mangle_options() {
@@ -668,10 +677,9 @@ function find_variable(compressor, name) {
     return scope.find_variable(name);
 }
 
-var global_names = makePredicate("Array Boolean clearInterval clearTimeout console Date decodeURI decodeURIComponent encodeURI encodeURIComponent Error escape eval EvalError Function isFinite isNaN JSON Math Number parseFloat parseInt RangeError ReferenceError RegExp Object setInterval setTimeout String SyntaxError TypeError unescape URIError");
 AST_SymbolRef.DEFMETHOD("is_declared", function(compressor) {
     return !this.definition().undeclared
-        || compressor.option("unsafe") && global_names.has(this.name);
+        || compressor.option("unsafe") && compressor.pure_access_globals(this.name);
 });
 
 /* -----[ optimizers ]----- */

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -235,7 +235,7 @@ class Compressor extends TreeWalker {
             drop_console  : false,
             drop_debugger : !false_by_default,
             ecma          : 5,
-            builtins      : 5,
+            builtins_ecma : 5,
             builtins_pure : false,
             evaluate      : !false_by_default,
             expression    : false,
@@ -679,7 +679,7 @@ function find_variable(compressor, name) {
 
 AST_SymbolRef.DEFMETHOD("is_declared", function(compressor) {
     return !this.definition().undeclared
-        || compressor.option("unsafe") && compressor.pure_access_globals(this.name);
+        || (compressor.option("unsafe") || compressor.option("builtins_pure")) && compressor.pure_access_globals(this.name);
 });
 
 /* -----[ optimizers ]----- */

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -235,7 +235,7 @@ class Compressor extends TreeWalker {
             drop_console  : false,
             drop_debugger : !false_by_default,
             ecma          : 5,
-            builtins      : [5],
+            builtins      : 5,
             builtins_pure : false,
             evaluate      : !false_by_default,
             expression    : false,

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -128,7 +128,7 @@ import {
 import { make_sequence, best_of_expression, read_property, requires_sequence_to_maintain_binding } from "./common.js";
 
 import { INLINED, UNDEFINED, has_flag } from "./compressor-flags.js";
-import { pure_prop_access_globals, is_pure_native_fn, is_pure_native_method } from "./native-objects.js";
+import { pure_prop_access_globals } from "./native-objects.js";
 
 // Functions and methods to infer certain facts about expressions
 // It's not always possible to be 100% sure about something just by static analysis,
@@ -969,7 +969,7 @@ AST_Call.DEFMETHOD("is_callee_pure", function(compressor) {
         if (
             expr instanceof AST_Dot
             && is_undeclared_ref(expr.expression)
-            && is_pure_native_fn(expr.expression.name, expr.property)
+            && compressor.is_pure_native_static_fn(expr.expression.name, expr.property)
         ) {
             return true;
         }
@@ -1003,7 +1003,7 @@ AST_Dot.DEFMETHOD("is_call_pure", function(compressor) {
     } else if (!this.may_throw_on_access(compressor)) {
         native_obj = "Object";
     }
-    return native_obj != null && is_pure_native_method(native_obj, this.property);
+    return native_obj != null && compressor.is_pure_native_method(native_obj, this.property);
 });
 
 // tell me if a statement aborts

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -128,7 +128,7 @@ import {
 import { make_sequence, best_of_expression, read_property, requires_sequence_to_maintain_binding } from "./common.js";
 
 import { INLINED, UNDEFINED, has_flag } from "./compressor-flags.js";
-import { pure_prop_access_globals } from "./native-objects.js";
+import { is_pure_builtin_call, pure_prop_access_globals } from "./native-objects.js";
 
 // Functions and methods to infer certain facts about expressions
 // It's not always possible to be 100% sure about something just by static analysis,
@@ -956,8 +956,8 @@ export function is_lhs(node, parent) {
 // Is the callee of this function pure?
 var global_pure_fns = makePredicate("Boolean decodeURI decodeURIComponent Date encodeURI encodeURIComponent Error escape EvalError isFinite isNaN Number Object parseFloat parseInt RangeError ReferenceError String SyntaxError TypeError unescape URIError");
 AST_Call.DEFMETHOD("is_callee_pure", function(compressor) {
+    var expr = this.expression;
     if (compressor.option("unsafe")) {
-        var expr = this.expression;
         var first_arg = (this.args && this.args[0] && this.args[0].evaluate(compressor));
         if (
             expr.expression && expr.expression.name === "hasOwnProperty" &&
@@ -966,13 +966,9 @@ AST_Call.DEFMETHOD("is_callee_pure", function(compressor) {
             return false;
         }
         if (is_undeclared_ref(expr) && global_pure_fns.has(expr.name)) return true;
-        if (
-            expr instanceof AST_Dot
-            && is_undeclared_ref(expr.expression)
-            && compressor.is_pure_native_static_fn(expr.expression.name, expr.property)
-        ) {
-            return true;
-        }
+        if (is_pure_builtin_call(compressor, this)) return true;
+    } else if (compressor.option("builtins_pure")) {
+        if (is_pure_builtin_call(compressor, this)) return true;
     }
     if ((this instanceof AST_New) && compressor.option("pure_new")) {
         return true;

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -956,8 +956,8 @@ export function is_lhs(node, parent) {
 // Is the callee of this function pure?
 var global_pure_fns = makePredicate("Boolean decodeURI decodeURIComponent Date encodeURI encodeURIComponent Error escape EvalError isFinite isNaN Number Object parseFloat parseInt RangeError ReferenceError String SyntaxError TypeError unescape URIError");
 AST_Call.DEFMETHOD("is_callee_pure", function(compressor) {
-    var expr = this.expression;
     if (compressor.option("unsafe")) {
+        var expr = this.expression;
         var first_arg = (this.args && this.args[0] && this.args[0].evaluate(compressor));
         if (
             expr.expression && expr.expression.name === "hasOwnProperty" &&

--- a/lib/compress/native-objects.js
+++ b/lib/compress/native-objects.js
@@ -47,10 +47,14 @@ import { makePredicate } from "../utils/index.js";
 // Note: Lots of methods and functions are missing here, in case they aren't pure
 // or not available in all JS environments.
 
-function make_nested_lookup(obj) {
+const make_nested_lookup = (feature_callback) => (compressor) => {
+    const obj = feature_callback(feature_variables(compressor));
+
     const out = new Map();
     for (var key of Object.keys(obj)) {
-        out.set(key, makePredicate(obj[key]));
+        if (obj[key]) {
+            out.set(key, makePredicate(remove_false(obj[key])));
+        }
     }
 
     const does_have = (global_name, fname) => {
@@ -58,7 +62,78 @@ function make_nested_lookup(obj) {
         return inner_map != null && inner_map.has(fname);
     };
     return does_have;
+};
+
+const make_lookup = (feature_callback) => (compressor) => {
+    const obj = feature_callback(feature_variables(compressor));
+
+    const predicate = makePredicate(remove_false(obj));
+    const does_have = (global_name) => {
+        return predicate.has(global_name);
+    };
+    return does_have;
+};
+
+function remove_false(arr) {
+    for (let i = 0; i < arr.length; i++) {
+        if (arr[i] === false) {
+            arr.splice(i, 1);
+            i--;
+        }
+    }
+    return arr;
 }
+
+/** Generate the object with arguments seen below */
+function feature_variables(compressor) {
+    let sloppy = compressor.option("unsafe");
+    let es;
+    for (const lib of compressor.option("builtins") || []) {
+        if (typeof lib === "number") {
+            es = lib;
+        }
+    }
+
+    return { sloppy, es };
+}
+
+// eslint-disable-next-line no-unused-vars
+export const pure_access_globals = make_lookup(({ sloppy, es }) => [
+    "Array",
+    "Boolean",
+    "clearInterval",
+    "clearTimeout",
+    "console",
+    "Date",
+    "decodeURI",
+    "decodeURIComponent",
+    "encodeURI",
+    "encodeURIComponent",
+    "Error",
+    "escape",
+    "eval",
+    "EvalError",
+    "Function",
+    es >= 2020 && "globalThis",
+    "isFinite",
+    "isNaN",
+    "JSON",
+    "Math",
+    "Number",
+    "parseFloat",
+    "parseInt",
+    "RangeError",
+    "ReferenceError",
+    "RegExp",
+    "Object",
+    "setInterval",
+    "setTimeout",
+    "String",
+    "SyntaxError",
+    "TypeError",
+    "unescape",
+    "URIError",
+]);
 
 // Objects which are safe to access without throwing or causing a side effect.
 // Usually we'd check the `unsafe` option first but these are way too common for that
@@ -71,17 +146,67 @@ export const pure_prop_access_globals = new Set([
     "Promise",
 ]);
 
+// unused
+// eslint-disable-next-line no-unused-vars
+export const is_pure_native_fn = make_lookup(({ sloppy, es }) => [
+    sloppy && es >= 2021 && "AggregateError",
+    "Array",
+    sloppy && "ArrayBuffer",
+    es >= 2020 && "BigInt",
+    es >= 2020 && "BigInt64Array",
+    es >= 2020 && "BigUint64Array",
+    "Boolean",
+    "Date",
+    sloppy && "decodeURI",
+    sloppy && "decodeURIComponent",
+    sloppy && "encodeURI",
+    sloppy && "encodeURIComponent",
+    "Error",
+    "escape",
+    "EvalError",
+    es >= 2021 && "FinalizationRegistry",
+    es >= 2026 && "Float16Array",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "isFinite",
+    "isNaN",
+    es >= 2026 && "Iterator",
+    "Number",
+    "parseFloat",
+    "parseInt",
+    es >= 2015 && "Promise",
+    es >= 2015 && "Proxy",
+    "RangeError",
+    "ReferenceError",
+    sloppy && "RegExp",
+    "String",
+    es >= 2015 && "Symbol",
+    "SyntaxError",
+    "TypeError",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    sloppy && "unescape",
+    "URIError",
+    sloppy && es >= 2021 && "WeakRef",
+]);
+
 const object_methods = [
     "constructor",
     "toString",
     "valueOf",
 ];
 
-export const is_pure_native_method = make_nested_lookup({
+// eslint-disable-next-line no-unused-vars
+export const is_pure_native_method = make_nested_lookup(({ sloppy, es }) => ({
     Array: [
-        "at",
-        "flat",
-        "includes",
+        es >= 2022 && "at",
+        es >= 2019 && "flat",
+        es >= 2016 && "includes",
         "indexOf",
         "join",
         "lastIndexOf",
@@ -102,90 +227,165 @@ export const is_pure_native_method = make_nested_lookup({
         ...object_methods,
     ],
     String: [
-        "at",
+        es >= 2022 && "at",
         "charAt",
         "charCodeAt",
-        "charPointAt",
+        es >= 2015 && "charPointAt",
         "concat",
-        "endsWith",
-        "fromCharCode",
-        "fromCodePoint",
-        "includes",
+        es >= 2025 && "endsWith",
+        es >= 2015 && "includes",
         "indexOf",
         "italics",
         "lastIndexOf",
-        "localeCompare",
+        es >= 2020 && "localeCompare",
         "match",
-        "matchAll",
-        "normalize",
-        "padStart",
-        "padEnd",
-        "repeat",
+        es >= 2020 && "matchAll",
+        es >= 2015 && "normalize",
+        es >= 2017 && "padStart",
+        es >= 2017 && "padEnd",
+        es >= 2015 && "repeat",
         "replace",
-        "replaceAll",
+        es >= 2021 && "replaceAll",
         "search",
         "slice",
         "split",
-        "startsWith",
+        es >= 2015 && "startsWith",
         "substr",
         "substring",
-        "repeat",
+        es >= 2015 && "repeat",
         "toLocaleLowerCase",
         "toLocaleUpperCase",
         "toLowerCase",
         "toUpperCase",
         "trim",
-        "trimEnd",
-        "trimStart",
+        es >= 2019 && "trimEnd",
+        es >= 2019 && "trimStart",
+        es >= 2019 && "trimLeft",
+        es >= 2019 && "trimRight",
         ...object_methods,
     ],
-});
+}));
 
-export const is_pure_native_fn = make_nested_lookup({
+const typed_array_pure_statics = ["of"];
+
+// eslint-disable-next-line no-unused-vars
+export const is_pure_native_static_fn = make_nested_lookup(({ sloppy, es }) => ({
     Array: [
         "isArray",
+        es >= 2015 && "of",
     ],
+    ArrayBuffer: [
+        "isView",
+    ],
+    BigInt: es >= 2020 && [
+        sloppy && "asIntN",
+        sloppy && "asUintN",
+    ],
+    BigInt64Array: sloppy && es >= 2020 && typed_array_pure_statics,
+    BigUint64Array: sloppy && es >= 2020 && typed_array_pure_statics,
+    Date: [
+        "now",
+        "parse",
+        "UTC",
+    ],
+    Error: [
+        es >= 2026 && "isError",
+    ],
+    Float16Array: sloppy && es >= 2026 && typed_array_pure_statics,
+    Float32Array: sloppy && typed_array_pure_statics,
+    Float64Array: sloppy && typed_array_pure_statics,
+    Int16Array: sloppy && typed_array_pure_statics,
+    Int32Array: sloppy && typed_array_pure_statics,
+    Int8Array: sloppy && typed_array_pure_statics,
     Math: [
         "abs",
         "acos",
+        es >= 2015 && "acosh",
         "asin",
+        es >= 2015 && "asinh",
         "atan",
-        "ceil",
-        "cos",
-        "exp",
-        "floor",
-        "log",
-        "round",
-        "sin",
-        "sqrt",
-        "tan",
         "atan2",
-        "pow",
+        es >= 2015 && "atanh",
+        es >= 2015 && "cbrt",
+        "ceil",
+        es >= 2015 && "clz32",
+        "cos",
+        es >= 2015 && "cosh",
+        "exp",
+        es >= 2015 && "expm1",
+        "floor",
+        es >= 2026 && "f16round",
+        es >= 2015 && "fround",
+        es >= 2015 && "hypot",
+        es >= 2015 && "imul",
+        "log",
+        es >= 2015 && "log10",
+        es >= 2015 && "log1p",
+        es >= 2015 && "log2",
         "max",
         "min",
+        "pow",
+        "round",
+        es >= 2015 && "sign",
+        "sin",
+        es >= 2015 && "sinh",
+        "sqrt",
+        "tan",
+        es >= 2015 && "tanh",
+        es >= 2015 && "trunc",
     ],
     Number: [
-        "isFinite",
-        "isNaN",
+        es >= 2015 && "isFinite",
+        es >= 2015 && "isInteger",
+        es >= 2015 && "isSafeInteger",
+        es >= 2015 && "isNaN",
+        es >= 2015 && "parseFloat",
+        es >= 2015 && "parseInt",
     ],
     Object: [
         "create",
         "getOwnPropertyDescriptor",
+        es >= 2017 && "getOwnPropertyDescriptors",
         "getOwnPropertyNames",
+        es >= 2015 && "getOwnPropertySymbols",
         "getPrototypeOf",
+        es >= 2022 && "hasOwn",
+        es >= 2015 && "is",
         "isExtensible",
         "isFrozen",
         "isSealed",
-        "hasOwn",
-        "keys",
+        es >= 2022 && "hasOwn",
+        es >= 2015 && "keys",
+    ],
+    Promise: es >= 2015 && [
+        "reject",
+        "resolve",
+        es >= 2024 && "withResolvers",
+    ],
+    Proxy: es >= 2015 && [
+        "revocable",
+    ],
+    Reflect: es >= 2015 && [
+        "has",
+        "isExtensible",
+        "ownKeys",
+    ],
+    RegExp: [
+        es >= 2026 && "escape",
     ],
     String: [
         "fromCharCode",
+        sloppy && es >= 2025 && "fromCodePoint",
     ],
-});
+    Uint16Array: typed_array_pure_statics,
+    Uint32Array: typed_array_pure_statics,
+    Uint8Array: typed_array_pure_statics,
+    Uint8ClampedArray: typed_array_pure_statics,
+}));
 
 // Known numeric values which come with JS environments
-export const is_pure_native_value = make_nested_lookup({
+// eslint-disable-next-line no-unused-vars
+export const is_pure_native_static_property = make_nested_lookup(({ sloppy, es }) => ({
     Math: [
         "E",
         "LN10",
@@ -197,10 +397,31 @@ export const is_pure_native_value = make_nested_lookup({
         "SQRT2",
     ],
     Number: [
+        es >= 2015 && "EPSILON",
+        es >= 2015 && "MAX_SAFE_VALUE",
         "MAX_VALUE",
+        es >= 2015 && "MIN_SAFE_VALUE",
         "MIN_VALUE",
         "NaN",
         "NEGATIVE_INFINITY",
         "POSITIVE_INFINITY",
     ],
-});
+    RegExp: [
+        "$_",
+        "$0",
+        "$1",
+        "$2",
+        "$3",
+        "$4",
+        "$5",
+        "$6",
+        "$7",
+        "$8",
+        "$9",
+        "input",
+        "lastMatch",
+        "lastParen",
+        "leftContext",
+        "rightContext",
+    ],
+}));

--- a/lib/compress/native-objects.js
+++ b/lib/compress/native-objects.js
@@ -41,7 +41,9 @@
 
  ***********************************************************************/
 
+import { AST_Array, AST_Dot, AST_New, AST_Number, AST_SymbolRef } from "../ast.js";
 import { makePredicate } from "../utils/index.js";
+import { is_undeclared_ref } from "./inference.js";
 
 // Lists of native methods, useful for `unsafe` option which assumes they exist.
 // Note: Lots of methods and functions are missing here, in case they aren't pure
@@ -86,15 +88,10 @@ function remove_false(arr) {
 
 /** Generate the object with arguments seen below */
 function feature_variables(compressor) {
-    let sloppy = compressor.option("unsafe");
-    let es;
-    for (const lib of compressor.option("builtins") || []) {
-        if (typeof lib === "number") {
-            es = lib;
-        }
-    }
-
-    return { sloppy, es };
+    return {
+        sloppy: false,
+        es: compressor.option("builtins"),
+    };
 }
 
 // eslint-disable-next-line no-unused-vars
@@ -146,12 +143,11 @@ export const pure_prop_access_globals = new Set([
     "Promise",
 ]);
 
-// unused
 // eslint-disable-next-line no-unused-vars
 export const is_pure_native_fn = make_lookup(({ sloppy, es }) => [
     sloppy && es >= 2021 && "AggregateError",
     "Array",
-    sloppy && "ArrayBuffer",
+    "ArrayBuffer",
     es >= 2020 && "BigInt",
     es >= 2020 && "BigInt64Array",
     es >= 2020 && "BigUint64Array",
@@ -174,6 +170,7 @@ export const is_pure_native_fn = make_lookup(({ sloppy, es }) => [
     "isFinite",
     "isNaN",
     es >= 2026 && "Iterator",
+    es >= 2015 && "Map",
     "Number",
     "parseFloat",
     "parseInt",
@@ -182,6 +179,7 @@ export const is_pure_native_fn = make_lookup(({ sloppy, es }) => [
     "RangeError",
     "ReferenceError",
     sloppy && "RegExp",
+    es >= 2015 && "Set",
     "String",
     es >= 2015 && "Symbol",
     "SyntaxError",
@@ -192,8 +190,30 @@ export const is_pure_native_fn = make_lookup(({ sloppy, es }) => [
     "Uint8ClampedArray",
     sloppy && "unescape",
     "URIError",
+    sloppy && es >= 2015 && "WeakMap",
     sloppy && es >= 2021 && "WeakRef",
+    sloppy && es >= 2015 && "WeakSet",
 ]);
+
+const arg1_is_iterable = new Set([
+    "Map",
+    "Set",
+    "WeakMap",
+    "WeakSet",
+]);
+const arg1_is_range_or_iterable = new Set([
+    "ArrayBuffer",
+    "Float32Array",
+    "Float64Array",
+    "Int16Array",
+    "Int32Array",
+    "Int8Array",
+    "Uint16Array",
+    "Uint32Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+]);
+const lone_arg_is_range = new Set(["Array"]);
 
 const object_methods = [
     "constructor",
@@ -425,3 +445,99 @@ export const is_pure_native_static_property = make_nested_lookup(({ sloppy, es }
         "rightContext",
     ],
 }));
+
+const re_uppercase_first_letter = /^[A-Z]/;
+export function is_pure_builtin_call(compressor, call) {
+    let builtin = '';
+    let method = '';
+
+    let exp = call.expression;
+    if (is_undeclared_ref(exp)) {
+        builtin = exp.name;
+    } else if (exp instanceof AST_Dot) {
+        method = exp.property;
+
+        exp = exp.expression;
+        if (is_undeclared_ref(exp)) {
+            if (
+                // globalThis.pureFunc()
+                exp.name === "globalThis"
+                && compressor.option("builtins") >= 2020
+            ) {
+                builtin = method;
+                method = '';
+            } else {
+                // SomeBuiltin.pureFunc()
+                builtin = exp.name;
+            }
+        } else if (exp instanceof AST_Dot) {
+            if (
+                is_undeclared_ref(exp.expression)
+                && exp.expression.name === "globalThis"
+                && compressor.option("builtins") >= 2020
+            ) {
+                // globalThis.SomeBuiltin.pureFunc()
+                builtin = exp.property;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    if (!method) {
+        if (compressor.is_pure_native_fn(builtin)) {
+            // some require `new`, others throw if you use it
+            const is_new = call instanceof AST_New;
+            const should_be_new = re_uppercase_first_letter.test(builtin); // true of all `is_pure_native_fn`
+            if (is_new !== should_be_new) return false;
+
+            if (!is_builtin_pure_with_these_args(builtin, call.args)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        return false;
+    } else {
+        return compressor.is_pure_native_static_fn(builtin, method);
+    }
+}
+
+/** Some builtins are listed above but their purity is subject to some conditions */
+function is_builtin_pure_with_these_args(builtin, args) {
+    // all the builtins we deal with here are ok with getting 0 args
+    if (args.length === 0) return true;
+
+    let arg1 = args[0];
+    if (arg1 instanceof AST_SymbolRef) {
+        arg1 = arg1.fixed_value();
+    }
+
+    if (lone_arg_is_range.has(builtin)) { // new Array(number)
+        const arg_valid = args.length > 1
+            || arg1 instanceof AST_Number
+                && arg1.value >= 0 && arg1.value <= 0xffffffff
+            // TODO: or, we are asked to ignore TypeError
+        if (!arg_valid) return false;
+    }
+
+    if (arg1_is_range_or_iterable.has(builtin)) { // new Float32Array(number | Array)
+        const arg_valid = args.length === 0
+            || arg1 instanceof AST_Array
+            || arg1 instanceof AST_Number
+                && arg1.value >= 0 && arg1.value <= 0xffffffff
+        if (!arg_valid) return false;
+    }
+
+    if (arg1_is_iterable.has(builtin)) { // new Set(iterable)
+        const arg_valid = args.length === 0 || arg1 instanceof AST_Array;
+        if (!arg_valid) return false;
+    }
+
+    return true;
+}

--- a/lib/compress/native-objects.js
+++ b/lib/compress/native-objects.js
@@ -90,7 +90,7 @@ function remove_false(arr) {
 function feature_variables(compressor) {
     return {
         sloppy: false,
-        es: compressor.option("builtins"),
+        es: compressor.option("builtins_ecma"),
     };
 }
 
@@ -448,8 +448,8 @@ export const is_pure_native_static_property = make_nested_lookup(({ sloppy, es }
 
 const re_uppercase_first_letter = /^[A-Z]/;
 export function is_pure_builtin_call(compressor, call) {
-    let builtin = '';
-    let method = '';
+    let builtin = "";
+    let method = "";
 
     let exp = call.expression;
     if (is_undeclared_ref(exp)) {
@@ -462,10 +462,10 @@ export function is_pure_builtin_call(compressor, call) {
             if (
                 // globalThis.pureFunc()
                 exp.name === "globalThis"
-                && compressor.option("builtins") >= 2020
+                && compressor.option("builtins_ecma") >= 2020
             ) {
                 builtin = method;
-                method = '';
+                method = "";
             } else {
                 // SomeBuiltin.pureFunc()
                 builtin = exp.name;
@@ -474,7 +474,7 @@ export function is_pure_builtin_call(compressor, call) {
             if (
                 is_undeclared_ref(exp.expression)
                 && exp.expression.name === "globalThis"
-                && compressor.option("builtins") >= 2020
+                && compressor.option("builtins_ecma") >= 2020
             ) {
                 // globalThis.SomeBuiltin.pureFunc()
                 builtin = exp.property;
@@ -521,7 +521,7 @@ function is_builtin_pure_with_these_args(builtin, args) {
     if (lone_arg_is_range.has(builtin)) { // new Array(number)
         const arg_valid = args.length > 1
             || arg1 instanceof AST_Number
-                && arg1.value >= 0 && arg1.value <= 0xffffffff
+                && arg1.value >= 0 && arg1.value <= 0xffffffff;
             // TODO: or, we are asked to ignore TypeError
         if (!arg_valid) return false;
     }
@@ -530,7 +530,7 @@ function is_builtin_pure_with_these_args(builtin, args) {
         const arg_valid = args.length === 0
             || arg1 instanceof AST_Array
             || arg1 instanceof AST_Number
-                && arg1.value >= 0 && arg1.value <= 0xffffffff
+                && arg1.value >= 0 && arg1.value <= 0xffffffff;
         if (!arg_valid) return false;
     }
 

--- a/lib/compress/native-objects.js
+++ b/lib/compress/native-objects.js
@@ -89,7 +89,7 @@ function remove_false(arr) {
 /** Generate the object with arguments seen below */
 function feature_variables(compressor) {
     return {
-        sloppy: false,
+        sloppy: compressor.option("unsafe"),
         es: compressor.option("builtins_ecma"),
     };
 }
@@ -250,7 +250,7 @@ export const is_pure_native_method = make_nested_lookup(({ sloppy, es }) => ({
         es >= 2022 && "at",
         "charAt",
         "charCodeAt",
-        es >= 2015 && "charPointAt",
+        es >= 2015 && "codePointAt",
         "concat",
         es >= 2025 && "endsWith",
         es >= 2015 && "includes",
@@ -263,7 +263,7 @@ export const is_pure_native_method = make_nested_lookup(({ sloppy, es }) => ({
         es >= 2015 && "normalize",
         es >= 2017 && "padStart",
         es >= 2017 && "padEnd",
-        es >= 2015 && "repeat",
+        es >= 2015 && sloppy && "repeat",
         "replace",
         es >= 2021 && "replaceAll",
         "search",
@@ -286,8 +286,6 @@ export const is_pure_native_method = make_nested_lookup(({ sloppy, es }) => ({
     ],
 }));
 
-const typed_array_pure_statics = ["of"];
-
 // eslint-disable-next-line no-unused-vars
 export const is_pure_native_static_fn = make_nested_lookup(({ sloppy, es }) => ({
     Array: [
@@ -301,8 +299,8 @@ export const is_pure_native_static_fn = make_nested_lookup(({ sloppy, es }) => (
         sloppy && "asIntN",
         sloppy && "asUintN",
     ],
-    BigInt64Array: sloppy && es >= 2020 && typed_array_pure_statics,
-    BigUint64Array: sloppy && es >= 2020 && typed_array_pure_statics,
+    BigInt64Array: sloppy && es >= 2020 && ["of"],
+    BigUint64Array: sloppy && es >= 2020 && ["of"],
     Date: [
         "now",
         "parse",
@@ -311,12 +309,12 @@ export const is_pure_native_static_fn = make_nested_lookup(({ sloppy, es }) => (
     Error: [
         es >= 2026 && "isError",
     ],
-    Float16Array: sloppy && es >= 2026 && typed_array_pure_statics,
-    Float32Array: sloppy && typed_array_pure_statics,
-    Float64Array: sloppy && typed_array_pure_statics,
-    Int16Array: sloppy && typed_array_pure_statics,
-    Int32Array: sloppy && typed_array_pure_statics,
-    Int8Array: sloppy && typed_array_pure_statics,
+    Float16Array: sloppy && es >= 2026 && ["of"],
+    Float32Array: sloppy && ["of"],
+    Float64Array: sloppy && ["of"],
+    Int16Array: sloppy && ["of"],
+    Int32Array: sloppy && ["of"],
+    Int8Array: sloppy && ["of"],
     Math: [
         "abs",
         "acos",
@@ -363,44 +361,41 @@ export const is_pure_native_static_fn = make_nested_lookup(({ sloppy, es }) => (
         es >= 2015 && "parseInt",
     ],
     Object: [
-        "create",
-        "getOwnPropertyDescriptor",
-        es >= 2017 && "getOwnPropertyDescriptors",
-        "getOwnPropertyNames",
-        es >= 2015 && "getOwnPropertySymbols",
-        "getPrototypeOf",
-        es >= 2022 && "hasOwn",
+        sloppy && "create",
+        sloppy && "getOwnPropertyDescriptor",
+        es >= 2017 && sloppy && "getOwnPropertyDescriptors",
+        sloppy && "getOwnPropertyNames",
+        es >= 2015 && sloppy && "getOwnPropertySymbols",
+        sloppy && "getPrototypeOf",
+        es >= 2022 && sloppy && "hasOwn",
         es >= 2015 && "is",
         "isExtensible",
         "isFrozen",
         "isSealed",
-        es >= 2022 && "hasOwn",
-        es >= 2015 && "keys",
+        es >= 2015 && sloppy && "keys",
     ],
     Promise: es >= 2015 && [
-        "reject",
-        "resolve",
         es >= 2024 && "withResolvers",
     ],
     Proxy: es >= 2015 && [
-        "revocable",
+        sloppy && "revocable",
     ],
     Reflect: es >= 2015 && [
-        "has",
-        "isExtensible",
-        "ownKeys",
+        sloppy && "has",
+        sloppy && "isExtensible",
+        sloppy && "ownKeys",
     ],
     RegExp: [
-        es >= 2026 && "escape",
+        es >= 2026 && sloppy && "escape",
     ],
     String: [
         "fromCharCode",
         sloppy && es >= 2025 && "fromCodePoint",
     ],
-    Uint16Array: typed_array_pure_statics,
-    Uint32Array: typed_array_pure_statics,
-    Uint8Array: typed_array_pure_statics,
-    Uint8ClampedArray: typed_array_pure_statics,
+    Uint16Array: ["of"],
+    Uint32Array: ["of"],
+    Uint8Array: ["of"],
+    Uint8ClampedArray: ["of"],
 }));
 
 // Known numeric values which come with JS environments

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -90,12 +90,8 @@ function defaults(args, defs, croak) {
             ret[i] = defs[i];
         } else if (i === "ecma") {
             ret[i] = parse_ecma(args[i]);
-        } else if (i === "builtins") {
-            if (!Array.isArray(args[i])) args[i] = [args[i]];
-            ret[i] = args[i].map(btns => {
-                if (typeof btns === "number") return parse_ecma(btns);
-                else return btns;
-            });
+        } else if (i === "builtins" && typeof args[i] === 'number') {
+            ret[i] = parse_ecma(args[i]);
         } else {
             ret[i] = (args && HOP(args, i)) ? args[i] : defs[i];
         }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -63,15 +63,6 @@ class DefaultsError extends Error {
     }
 }
 
-function parse_ecma(ecma) {
-    ecma = ecma | 0;
-    if (ecma > 5 && ecma < 2015) {
-        return ecma + 2009;
-    } else {
-        return ecma;
-    }
-}
-
 function defaults(args, defs, croak) {
     if (args === true) {
         args = {};
@@ -88,10 +79,10 @@ function defaults(args, defs, croak) {
     for (const i in defs) if (HOP(defs, i)) {
         if (!args || !HOP(args, i)) {
             ret[i] = defs[i];
-        } else if (i === "ecma") {
-            ret[i] = parse_ecma(args[i]);
-        } else if (i === "builtins" && typeof args[i] === 'number') {
-            ret[i] = parse_ecma(args[i]);
+        } else if (i === "ecma" || i === "builtins_ecma") {
+            let ecma = args[i] | 0;
+            if (ecma > 5 && ecma < 2015) ecma += 2009;
+            ret[i] = ecma;
         } else {
             ret[i] = (args && HOP(args, i)) ? args[i] : defs[i];
         }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -63,6 +63,15 @@ class DefaultsError extends Error {
     }
 }
 
+function parse_ecma(ecma) {
+    ecma = ecma | 0;
+    if (ecma > 5 && ecma < 2015) {
+        return ecma + 2009;
+    } else {
+        return ecma;
+    }
+}
+
 function defaults(args, defs, croak) {
     if (args === true) {
         args = {};
@@ -80,9 +89,13 @@ function defaults(args, defs, croak) {
         if (!args || !HOP(args, i)) {
             ret[i] = defs[i];
         } else if (i === "ecma") {
-            let ecma = args[i] | 0;
-            if (ecma > 5 && ecma < 2015) ecma += 2009;
-            ret[i] = ecma;
+            ret[i] = parse_ecma(args[i]);
+        } else if (i === "builtins") {
+            if (!Array.isArray(args[i])) args[i] = [args[i]];
+            ret[i] = args[i].map(btns => {
+                if (typeof btns === "number") return parse_ecma(btns);
+                else return btns;
+            });
         } else {
             ret[i] = (args && HOP(args, i)) ? args[i] : defs[i];
         }

--- a/test/compress/builtins_ecma.js
+++ b/test/compress/builtins_ecma.js
@@ -1,0 +1,51 @@
+issue_1443_pure_builtins: {
+    options = {
+        unused: true,
+        builtins_ecma: 2015,
+        builtins_pure: true,
+        toplevel: true,
+        passes: 2,
+    }
+    input: {
+        // kept
+        const keep1 = new Map(side_effect_iterable);
+        const keep2 = new Array(maybe_nan);
+        const keep3 = encodeURI("might throw URIError");
+        class keep4 extends UnknownGlobal { }
+        const keep5 = Math.f16round(); // ES2026
+        const keep6 = Promise.resolve()
+        // dropped
+        const drop1 = isFinite(1234);
+        const drop2 = new Array();
+        const drop3 = new Map();
+        const drop4 = new Set();
+        const drop5 = Math.acos();
+    }
+    expect: {
+        new Map(side_effect_iterable);
+        new Array(maybe_nan);
+        encodeURI("might throw URIError");
+        UnknownGlobal;
+        Math.f16round();
+        Promise.resolve()
+    }
+}
+
+pure_builtins_globalthis: {
+    options = {
+        unused: true,
+        builtins_ecma: 2020,
+        builtins_pure: true,
+        toplevel: true,
+        passes: 2,
+    }
+    input: {
+        const drop1 = globalThis.isFinite(1234);
+        const drop2 = new globalThis.Array();
+        const drop3 = new globalThis.Map();
+        const drop4 = new globalThis.Set();
+        const drop5 = globalThis.Math.acosh();
+    }
+    expect: {
+    }
+}

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1570,7 +1570,7 @@ issue_2231_3: {
     options = {
         evaluate: true,
         unsafe: true,
-        builtins: [2015],
+        builtins: 2015,
     }
     input: {
         console.log(Object.keys({ foo: "bar" })[0]);

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1570,6 +1570,7 @@ issue_2231_3: {
     options = {
         evaluate: true,
         unsafe: true,
+        builtins: [2015],
     }
     input: {
         console.log(Object.keys({ foo: "bar" })[0]);

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1570,7 +1570,7 @@ issue_2231_3: {
     options = {
         evaluate: true,
         unsafe: true,
-        builtins: 2015,
+        builtins_ecma: 2015,
     }
     input: {
         console.log(Object.keys({ foo: "bar" })[0]);

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -2,7 +2,7 @@
 
 import { SectionedSourceMapInput, EncodedSourceMap, DecodedSourceMap } from '@jridgewell/source-map';
 
-export type ECMA = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020;
+export type ECMA = 5 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021 | 2022 | 2023 | 2024 | 2025;
 
 export type ConsoleProperty = keyof typeof console;
 type DropConsoleOption = boolean | ConsoleProperty[];
@@ -30,6 +30,7 @@ export interface CompressOptions {
     drop_console?: DropConsoleOption;
     drop_debugger?: boolean;
     ecma?: ECMA;
+    builtins?: Array<ECMA>;
     evaluate?: boolean;
     expression?: boolean;
     global_defs?: object;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -30,7 +30,8 @@ export interface CompressOptions {
     drop_console?: DropConsoleOption;
     drop_debugger?: boolean;
     ecma?: ECMA;
-    builtins?: Array<ECMA>;
+    builtins?: ECMA;
+    builtins_pure?: boolean;
     evaluate?: boolean;
     expression?: boolean;
     global_defs?: object;

--- a/tools/terser.d.ts
+++ b/tools/terser.d.ts
@@ -30,7 +30,7 @@ export interface CompressOptions {
     drop_console?: DropConsoleOption;
     drop_debugger?: boolean;
     ecma?: ECMA;
-    builtins?: ECMA;
+    builtins_ecma?: ECMA;
     builtins_pure?: boolean;
     evaluate?: boolean;
     expression?: boolean;


### PR DESCRIPTION
Closes: #1443 

I've turned the list of pure functions into a little index that we can refer to. Ideally if a small-enough NPM package exists with information like this, I would like to use it.

To do:

- [x] implement `builtins_pure`: a less-unsafe subset of `unsafe` just for pure builtins