### PR TITLE
add "observedAttributes" to domprops list

### DIFF
--- a/tools/domprops.js
+++ b/tools/domprops.js
@@ -6424,6 +6424,7 @@ export var domprops = [
     "objectStoreNames",
     "objectType",
     "observe",
+    "observedAttributes",
     "occlusionQuerySet",
     "of",
     "off",


### PR DESCRIPTION
### Now
Among other custom element-related DOM properties, like `connectedCallback`,  `disconnectedCallback`, `adoptedCallback`, `attributeChangedCallback`, etc. there's also a static property called [observedAttributes](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#responding_to_attribute_changes).

I realized this property is missing when mangling a Lit web component app. I added it to save anyone doing the same thing some trouble.

### Additional
There are some other missing properties. Some of these released in stable Chrome on Feb 4, 2025, so it may be time to add them here as well. 

1. [moveBefore](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore) (Chrome 133, Firefox 144, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=281223))
1. [connectedMoveCallback](https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore#moving_custom_elements_while_preserving_state) (Chrome 133, Firefox 144, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=281223))
1. [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.Duration](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.Instant](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Instant) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.Now](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Now) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.PlainDate](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.PlainDateTime](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.PlainMonthDay](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.PlainTime](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.PlainYearMonth](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))
1. [Temporal.ZonedDateTime](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime) (Chrome [144](https://chromestatus.com/feature/5668291307634688), Firefox 139, Safari [soon?](https://bugs.webkit.org/show_bug.cgi?id=223166))