### PR TITLE
refactor: swallowed errors in infer_options hide real failures

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ async function infer_options(options) {
     try {
         await minify("", options);
     } catch (error) {
-        return error.defs;
+        if (error.defs) return error.defs;
+        throw error;
     }
 }


### PR DESCRIPTION
## Description

infer_options catches *all* errors from minify() and returns error.defs (or undefined if the thrown error lacks a defs property). Real errors during option inference or minification are silently turned into undefined, preventing proper error propagation and hiding failures from callers.

## Changes

- `main.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #1667