### PR TITLE
refactor: async infer_options called without await in _default_options

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,13 +8,14 @@ export { run_cli as _run_cli } from "./lib/cli.js";
 export async function _default_options() {
     const defs = {};
 
-    Object.keys(infer_options({ 0: 0 })).forEach((component) => {
-        const options = infer_options({
+    const base = await infer_options({ 0: 0 });
+    for (const component of Object.keys(base)) {
+        const options = await infer_options({
             [component]: {0: 0}
         });
 
         if (options) defs[component] = options;
-    });
+    }
     return defs;
 }
 


### PR DESCRIPTION
## Description

Object.keys(infer_options({ 0: 0 })) and the inner infer_options call treat the returned Promise as a plain object. This results in an empty defs object (or incorrect promise assignment) instead of the intended option definitions, breaking any code relying on _default_options().

## Changes

- `main.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #1669