### PR TITLE
Quality: Broad exception swallowing in option inference may mask real failures

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ async function infer_options(options) {
     try {
         await minify("", options);
     } catch (error) {
-        return error.defs;
+        if (error && error.defs) return error.defs;
+        throw error;
     }
 }


### PR DESCRIPTION
## Problem

`infer_options` catches any error from `minify` and returns `error.defs` without validating error type. Unexpected runtime errors (not intended option-probing failures) can be silently converted into undefined behavior.

**Severity**: `high`
**File**: `main.js`

## Solution

Narrow the catch to expected error shapes (e.g., check `error && error.defs`) and rethrow unknown errors to avoid hiding genuine regressions.

## Changes

- `main.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
