### PR TITLE
UI/UX: Production bundle disables source maps, harming debugging UX

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default () => {
                 "@jridgewell/source-map": "sourceMap",
             },
             name: "Terser",
-            sourcemap: false,
+            sourcemap: true,
             sourcemapExcludeSources: true,
             esModule: false,
             indent: false


### PR DESCRIPTION
## Problem

The Rollup output sets `sourcemap: false`, which makes downstream debugging of minified builds significantly harder for integrators.

**Severity**: `medium`
**File**: `rollup.config.js`

## Solution

Enable source maps for distributable builds (or provide a separate debug build with source maps) to improve developer troubleshooting.

## Changes

- `rollup.config.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
