### PR TITLE
fix: preserve impure optional property access

### DIFF
--- a/lib/compress/drop-side-effect-free.js
+++ b/lib/compress/drop-side-effect-free.js
@@ -104,6 +104,15 @@ function def_drop_side_effect_free(node_or_nodes, func) {
     }
 }
 
+function optional_access_may_call_impure_getter(node, compressor) {
+    if (!node.optional || compressor.option("pure_getters")) return false;
+    if (node.expression._dot_throw(compressor)) return false;
+    return !(
+        node.expression instanceof AST_PropAccess
+        && node.expression.expression._dot_throw(compressor)
+    );
+}
+
 // Drop side-effect-free elements from an array of expressions.
 // Returns an array of expressions with side-effects or null
 // if all elements were dropped. Note: original array may be
@@ -340,6 +349,9 @@ def_drop_side_effect_free(AST_Dot, function (compressor, first_in_statement) {
     if (is_nullish_shortcircuited(this, compressor)) {
         return this.expression.drop_side_effect_free(compressor, first_in_statement);
     }
+    if (optional_access_may_call_impure_getter(this, compressor)) {
+        return this;
+    }
     if (!this.optional && this.expression.may_throw_on_access(compressor)) {
         return this;
     }
@@ -356,6 +368,9 @@ def_drop_side_effect_free(AST_Sub, function (compressor, first_in_statement) {
     }
 
     var property = this.property.drop_side_effect_free(compressor);
+    if (optional_access_may_call_impure_getter(this, compressor)) {
+        return this;
+    }
     if (property && this.optional) return this;
 
     var expression = this.expression.drop_side_effect_free(compressor, first_in_statement);

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -356,6 +356,15 @@ export function is_nullish(node, compressor) {
     return is_nullish_shortcircuited(node, compressor);
 }
 
+function optional_access_may_call_impure_getter(node, compressor) {
+    if (!node.optional || compressor.option("pure_getters")) return false;
+    if (node.expression._dot_throw(compressor)) return false;
+    return !(
+        node.expression instanceof AST_PropAccess
+        && node.expression.expression._dot_throw(compressor)
+    );
+}
+
 // Determine if expression might cause side effects
 // If there's a possibility that a node may change something when it's executed, this returns true
 (function(def_has_side_effects) {
@@ -478,6 +487,9 @@ export function is_nullish(node, compressor) {
         if (is_nullish(this, compressor)) {
             return this.expression.has_side_effects(compressor);
         }
+        if (optional_access_may_call_impure_getter(this, compressor)) {
+            return true;
+        }
         if (!this.optional && this.expression.may_throw_on_access(compressor)) {
             return true;
         }
@@ -493,6 +505,9 @@ export function is_nullish(node, compressor) {
         }
 
         var property = this.property.has_side_effects(compressor);
+        if (optional_access_may_call_impure_getter(this, compressor)) {
+            return true;
+        }
         if (property && this.optional) return true; // "?." is a condition
 
         return property || this.expression.has_side_effects(compressor);

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -183,6 +183,23 @@ impure_getter_2: {
     expect: {}
 }
 
+optional_chain_impure_getter: {
+    options = {
+        pure_getters: false,
+        side_effects: true,
+    }
+    input: {
+        var key = "bar";
+        this.foo?.bar;
+        this.foo?.[key];
+    }
+    expect: {
+        var key = "bar";
+        this.foo?.bar;
+        this.foo?.[key];
+    }
+}
+
 issue_2110_1: {
     options = {
         collapse_vars: true,


### PR DESCRIPTION
Fixes #1632.

This keeps unused optional property access expressions when `pure_getters: false`, so `this.foo?.bar` and `this.foo?.[key]` are not reduced to only `this.foo`. That preserves the possibility that the optional access reaches an impure getter while still allowing existing nullish/throwing receiver reductions to run.

Verification:

- `node test/compress.js pure_getters.js optional-chains.js drop-unused.js evaluate.js`
- `npm run lint`
- `npm test`
- `npm run build`