### PR TITLE
fix: parameter defaults must not resolve to body declarations

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -446,6 +446,27 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
     });
     this.walk(tw);
 
+    // pass 2.5: parameter default expressions are evaluated in a scope that only
+    // contains the parameters, not the declarations from the function body. When a
+    // body declaration shadows an outer name used by a default, the reference must
+    // resolve to the outer binding, otherwise mangling would merge the two and
+    // produce a reference to the not-yet-initialized body variable at runtime.
+    walk(this, node => {
+        if (!(node instanceof AST_Lambda)) return;
+        for (const argname of node.argnames) {
+            walk(argname, ref => {
+                if (!(ref instanceof AST_SymbolRef)) return;
+                const def = ref.thedef;
+                if (def && def.scope === node && !(def.orig[0] instanceof AST_SymbolFunarg)) {
+                    def.references = def.references.filter(r => r !== ref);
+                    ref.thedef = node.parent_scope && node.parent_scope.find_variable(ref.name)
+                        || toplevel.def_global(ref);
+                    ref.reference();
+                }
+            });
+        }
+    });
+
     // pass 3: work around IE8 and Safari catch scope bugs
     if (options.ie8 || options.safari10) {
         walk(this, node => {

--- a/test/compress/parameters.js
+++ b/test/compress/parameters.js
@@ -242,3 +242,148 @@ accept_destructuring_async_word_with_default: {
     }
     expect_stdout: "PASS"
 }
+
+issue_1698: {
+    mangle = {}
+    input: {
+        const value = "outer";
+        function example(ref = { value }) {
+            const { value } = ref;
+            console.log("local value =", value);
+        }
+        example();
+    }
+    expect: {
+        const value = "outer";
+        function example(e = { value: value }) {
+            const { value: l } = e;
+            console.log("local value =", l);
+        }
+        example();
+    }
+    expect_stdout: "local value = outer"
+}
+
+default_value_shadowed_by_const: {
+    mangle = {}
+    input: {
+        const x = "X";
+        function f(a = x) {
+            const x = "inner";
+            return a + "/" + x;
+        }
+        console.log(f());
+    }
+    expect: {
+        const x = "X";
+        function f(n = x) {
+            const o = "inner";
+            return n + "/" + o;
+        }
+        console.log(f());
+    }
+    expect_stdout: "X/inner"
+}
+
+default_value_shadowed_by_let: {
+    mangle = {}
+    input: {
+        let x = "X";
+        function f(a = x) {
+            let x = "inner";
+            return a + "/" + x;
+        }
+        console.log(f());
+    }
+    expect: {
+        let x = "X";
+        function f(n = x) {
+            let e = "inner";
+            return n + "/" + e;
+        }
+        console.log(f());
+    }
+    expect_stdout: "X/inner"
+}
+
+default_value_shadowed_by_var: {
+    mangle = {}
+    input: {
+        var x = "X";
+        function f(a = x) {
+            var x = "inner";
+            return a + "/" + x;
+        }
+        console.log(f());
+    }
+    expect: {
+        var x = "X";
+        function f(n = x) {
+            var r = "inner";
+            return n + "/" + r;
+        }
+        console.log(f());
+    }
+    expect_stdout: "X/inner"
+}
+
+default_value_closure_shadowed_by_const: {
+    mangle = {}
+    input: {
+        const x = "outer";
+        function f(get = () => x) {
+            const x = "inner";
+            return get() + "/" + x;
+        }
+        console.log(f());
+    }
+    expect: {
+        const x = "outer";
+        function f(n = () => x) {
+            const o = "inner";
+            return n() + "/" + o;
+        }
+        console.log(f());
+    }
+    expect_stdout: "outer/inner"
+}
+
+default_value_shadowed_by_class: {
+    mangle = {}
+    input: {
+        class C { static tag = "outer"; }
+        function f(a = C) {
+            class C { static tag = "inner"; }
+            return a.tag + "/" + C.tag;
+        }
+        console.log(f());
+    }
+    expect: {
+        class C { static tag = "outer"; }
+        function f(t = C) {
+            class a { static tag = "inner"; }
+            return t.tag + "/" + a.tag;
+        }
+        console.log(f());
+    }
+    expect_stdout: "outer/inner"
+}
+
+default_value_references_earlier_param: {
+    mangle = {}
+    input: {
+        function f(a, b = a) {
+            const a2 = "x";
+            return b;
+        }
+        console.log(f("P"));
+    }
+    expect: {
+        function f(n, o = n) {
+            const c = "x";
+            return o;
+        }
+        console.log(f("P"));
+    }
+    expect_stdout: "P"
+}


### PR DESCRIPTION
Fixes #1698.

A function's parameter default expressions are evaluated in a scope that only contains the parameters, not the declarations in the function body. terser resolved a default's reference to a same-named body `let`/`const`/`class`/`var` declaration, so the mangler merged the two and emitted a reference to the not-yet-initialized body binding:

```js
const value = "outer";
function example(ref = { value }) {
  const { value } = ref;
  console.log(value);
}
// mangled to: function example(e = { value: l }) { const { value: l } = e; ... }
// ReferenceError: l is not defined
```

After `figure_out_scope`, any reference inside a parameter that resolved to a non-parameter binding in the same function scope is re-pointed to the enclosing binding, so the two are mangled apart. Added regression tests covering `const`/`let`/`var`/`class` shadowing, a closure in the default, and a guard that earlier-parameter references are unaffected.
