### PR TITLE
fix join_vars merging an assignment into the wrong copy of a duplicate object key

### DIFF
--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -1418,7 +1418,15 @@ export function tighten_body(statements, compressor) {
                 };
             if (!def.value.properties.every(diff))
                 break;
-            var p = def.value.properties.filter(function (p) { return p.key === prop; })[0];
+            var matching = def.value.properties.filter(function (p) { return p.key === prop; });
+            // If the literal itself already declares the same plain key more than
+            // once, the *last* one wins when the object is created (duplicate keys
+            // are legal since ES2015). Merging into any of them other than the
+            // last would silently discard the assignment's effect, so bail out
+            // rather than guess.
+            if (matching.length > 1)
+                break;
+            var p = matching[0];
             if (!p) {
                 def.value.properties.push(make_node(AST_ObjectKeyVal, node, {
                     key: prop,

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1598,6 +1598,47 @@ join_object_assignments_4: {
     ]
 }
 
+// The object literal already contains a duplicate key before any
+// assignment is merged into it. Per spec, the last duplicate "wins"
+// when the literal is evaluated, so a subsequent assignment to that
+// key must be observable. join_object_assignments() must either leave
+// the assignment alone or merge it into the *winning* (last) property,
+// never into a property that gets shadowed away.
+join_object_assignments_duplicate_key: {
+    options = {
+        join_vars: true,
+    }
+    input: {
+        var obj = {
+            x: 1,
+            x: 2,
+        };
+        obj.x = 3;
+        console.log(obj.x, JSON.stringify(obj));
+    }
+    expect_stdout: [
+        "3 {\"x\":3}",
+    ]
+}
+
+join_object_assignments_duplicate_key_triple: {
+    options = {
+        join_vars: true,
+    }
+    input: {
+        var obj = {
+            x: 1,
+            x: 2,
+            x: 5,
+        };
+        obj.x = 9;
+        console.log(obj.x, JSON.stringify(obj));
+    }
+    expect_stdout: [
+        "9 {\"x\":9}",
+    ]
+}
+
 join_object_assignments_return_1: {
     options = {
         join_vars: true,


### PR DESCRIPTION
Found this while poking at join_vars: `var obj={x:1,x:2}; obj.x=3;` minifies to `var obj={x:(1,3),x:2};`, which makes `obj.x` read `2` instead of `3`. The duplicate key in the literal is legal ES2015+ and the second one wins at runtime, but join_object_assignments picks the *first* matching property to merge the assignment into, so the assignment gets buried in a dead comma expression on the wrong copy.

The fix just bails out of the merge when more than one property in the literal matches the key, instead of trying to guess which copy is the live one. Added two regression tests that assert on actual stdout (not just AST shape) since this is a runtime-behavior bug, not a style one.

Ran the full suite (compress + mocha) before and after - all green, and confirmed the new tests actually fail without the fix.