### PR TITLE
skip folding BigInt `**` with a huge or negative exponent

### DIFF
--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -300,6 +300,21 @@ def_eval(AST_Binary, function (compressor, depth) {
         return this;
     }
 
+    // `**` on a BigInt can be pathological: a negative exponent throws at
+    // runtime, and a large exponent produces an astronomically large result
+    // whose evaluation and decimal serialization can take seconds for a tiny
+    // input. Skip folding these — the folded value could never be smaller
+    // than the source expression anyway.
+    if (typeof left === "bigint" && this.operator === "**") {
+        var abs_left = left < 0n ? -left : left;
+        // Approximate bit length of the result: right * log2(abs_left).
+        var result_bits = abs_left > 1n
+            ? Number(right) * Math.log2(Number(abs_left))
+            : 0;
+        if (right < 0n || result_bits > 0x10000)
+            return this;
+    }
+
     var result;
     switch (this.operator) {
         case "&&": result = left && right; break;

--- a/test/compress/big_int.js
+++ b/test/compress/big_int.js
@@ -93,3 +93,16 @@ big_int_math_counter_examples: {
     expect_exact: "console.log({mixing_types:1*10n,bad_shift:1n>>>0n,bad_div:1n/0n});"
     expect_stdout: true
 }
+
+big_int_pow_guarded: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        // `2n ** 3n` has a small result and is still folded, but `2n ** -3n`
+        // throws at runtime (negative BigInt exponent) so it is left as-is
+        // instead of crashing the compressor.
+        console.log(2n ** 3n, 2n ** -3n);
+    }
+    expect_exact: "console.log(8n,2n**-3n);"
+}

--- a/test/mocha/big-int.js
+++ b/test/mocha/big-int.js
@@ -1,0 +1,31 @@
+import assert from "assert";
+import { minify } from "../../main.js";
+
+describe("BigInt", function() {
+    it("Should not spend excessive time folding a large BigInt exponentiation", async function() {
+        // A tiny input must not make minify() compute and serialize an
+        // astronomically large BigInt. See issue #1703 (before the guard this
+        // took ~10s; the expression is left unfolded, so it is a no-op too).
+        var start = Date.now();
+        var result = await minify("if (999999937n ** 3999999n) console.log(1);", {
+            compress: true,
+            mangle: false,
+        });
+        var elapsed = Date.now() - start;
+        assert.strictEqual(/\*\*/.test(result.code), true, result.code);
+        assert.strictEqual(elapsed < 5000, true, "minify took " + elapsed + "ms");
+    });
+
+    it("Should not throw folding a BigInt with a negative exponent", async function() {
+        // `x ** <negative>` throws a RangeError at runtime, so it must be left
+        // untouched instead of being evaluated and crashing the compressor.
+        for (var input of [
+            "x = 2n ** -3n;",
+            "x = 0n ** -1n;",
+            "x = (5n) ** (-2n);",
+        ]) {
+            var result = await minify(input, { compress: true, mangle: false });
+            assert.strictEqual(/\*\*/.test(result.code), true, result.code);
+        }
+    });
+});


### PR DESCRIPTION
Fixes #1703.

`minify("if (999999937n ** 3999999n) console.log(1);")` takes ~10s here for that tiny input. The `evaluate` pass constant-folds the BigInt `**`, so it actually computes `999999937n ** 3999999n` (a ~36-million-digit number) and stringifies it — only for `best_of` to throw the folded value away afterwards because it's larger than the source.

While in that path I also hit a crash on a negative exponent: `minify("x = 2n ** -3n;")` throws `RangeError: undefined must be positive`, because the folding evaluates `2n ** -3n` at compile time and BigInt exponentiation rejects a negative exponent.

I added a guard in `AST_Binary._eval`, next to the existing `/ 0n` and `>>>` BigInt guards, that skips folding `**` when the exponent is negative or the result would be huge (estimated cheaply from `right * log2(abs(left))`). In both cases the expression is left untouched, which is the outcome anyway once `best_of` compares sizes / when it runs. Small results like `2n ** 3n` → `8n` still fold.

Tested with a new compress case (`big_int_pow_guarded`) and a mocha test for the timing and negative-exponent cases; `npm test`, `npm run lint`, and `node test/ufuzz.js 1000 --seed 1234` all pass.
