### PR TITLE
fix preserve_annotations keeping comments that merely mention an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1052,7 +1052,7 @@ as "output options".
   - `2` -- always use double quotes
   - `3` -- always use the original quotes
 
-- `preserve_annotations` -- (default `false`) -- Preserve [Terser annotations](#annotations) in the output.
+- `preserve_annotations` -- (default `false`) -- Preserve [Terser annotations](#annotations) in the output. Only comments whose entire contents are annotations are kept; a comment that merely mentions an annotation in prose is treated as a regular comment.
 
 - `safari10` (default `false`) -- set this option to `true` to work around
   the [Safari 10/11 await bug](https://bugs.webkit.org/show_bug.cgi?id=176685).

--- a/lib/output.js
+++ b/lib/output.js
@@ -178,6 +178,10 @@ const CODE_LINE_BREAK = 10;
 const CODE_SPACE = 32;
 
 const r_annotation = /[@#]__(PURE|INLINE|NOINLINE)__/;
+// `preserve_annotations` only keeps comments that *are* an annotation, as opposed to
+// prose that merely mentions one. Leading `*` and whitespace allow for the `/** @__PURE__ */`
+// style, and several annotations may share a single comment.
+const r_annotation_only = /^[\s*]*(?:[@#]__(?:PURE|INLINE|NOINLINE)__[\s*]*)+$/;
 
 function is_some_comments(comment) {
     // multiline comment
@@ -332,7 +336,7 @@ function OutputStream(options) {
     if (options.preserve_annotations) {
         let prev_comment_filter = comment_filter;
         comment_filter = function (comment) {
-            return r_annotation.test(comment.value) || prev_comment_filter.apply(this, arguments);
+            return r_annotation_only.test(comment.value) || prev_comment_filter.apply(this, arguments);
         };
     }
 
@@ -735,6 +739,8 @@ function OutputStream(options) {
 
     function filter_comment(comment) {
         if (!options.preserve_annotations) {
+            // Deliberately the broad match: when annotations are being dropped, any comment
+            // that could still be *read* as one downstream has to be neutralized.
             comment = comment.replace(r_annotation, " ");
         }
         if (/^\s*$/.test(comment)) {

--- a/test/mocha/comments.js
+++ b/test/mocha/comments.js
@@ -364,6 +364,63 @@ describe("comments", function() {
         });
     });
 
+    describe("preserve_annotations", function() {
+        var options = {
+            compress: false,
+            mangle: false,
+            format: { comments: false, preserve_annotations: true }
+        };
+
+        it("Should preserve comments that are an annotation", async function() {
+            await for_each_async([
+                ["/*#__PURE__*/ f();", "/*#__PURE__*/f();"],
+                ["/*@__PURE__*/ f();", "/*@__PURE__*/f();"],
+                ["/* @__PURE__ */ f();", "/* @__PURE__ */f();"],
+                ["/**@__PURE__*/ f();", "/**@__PURE__*/f();"],
+                ["//#__PURE__\nf();", "//#__PURE__\nf();"],
+                ["// @__PURE__\nf();", "// @__PURE__\nf();"],
+                ["var v = /*#__NOINLINE__*/ g();", "var v=/*#__NOINLINE__*/g();"],
+                ["var v = /*#__INLINE__*/ g();", "var v=/*#__INLINE__*/g();"],
+                ["/*@__PURE__*/ /*@__NOINLINE__*/ f();", "/*@__PURE__*/ /*@__NOINLINE__*/f();"],
+                ["/*@__PURE__ @__NOINLINE__*/ f();", "/*@__PURE__ @__NOINLINE__*/f();"],
+                // positions terser does not annotate itself, but other tools read
+                ["(/*@__PURE__*/ c)();", "/*@__PURE__*/c();"],
+                ["var C = /*#__PURE__*/ class extends B {};", "var C=/*#__PURE__*/class extends B{};"],
+                ["/*#__PURE__*/ var a = f();", "/*#__PURE__*/var a=f();"],
+                ["var y = /*#__PURE__*/ tag`x`;", "var y=/*#__PURE__*/tag`x`;"],
+            ], async function(test) {
+                var result = await minify(test[0], options);
+                assert.strictEqual(result.code, test[1], test[0]);
+            });
+        });
+
+        it("Should drop comments that merely mention an annotation", async function() {
+            await for_each_async([
+                // https://github.com/terser/terser/issues/1690
+                [
+                    "function f() {\n"
+                        + "  // keep g() out of line, see the #__NOINLINE__ note\n"
+                        + "  var value = /*#__NOINLINE__*/ g();\n"
+                        + "  return value;\n"
+                        + "}",
+                    "function f(){var value=/*#__NOINLINE__*/g();return value}"
+                ],
+                ["// this comment mentions @__PURE__ for docs\nf();", "f();"],
+                ["/**\n * see @__PURE__ docs\n */\nf();", "f();"],
+                ["// legacy: was /*#__PURE__*/ annotated\nf();", "f();"],
+                ["// docs about @__PURE__ annotations\nvar x = 1;", "var x=1;"],
+                ["f(); // trailing mentions @__PURE__", "f();"],
+                ["var o = { /* see docs about @__PURE__ */ key: 1 };", "var o={key:1};"],
+                ["f(/* mentions @__PURE__ here */ \"abc\");", 'f("abc");'],
+                // only the real annotation survives
+                ["// note about #__PURE__\n/*#__PURE__*/ f();", "/*#__PURE__*/f();"],
+            ], async function(test) {
+                var result = await minify(test[0], options);
+                assert.strictEqual(result.code, test[1], test[0]);
+            });
+        });
+    });
+
     describe("Huge number of comments.", function() {
         it("Should parse and compress code with thousands of consecutive comments", async function() {
             var js = "function lots_of_comments(x) { return 7 -";


### PR DESCRIPTION
Fixes #1690.

Under `preserve_annotations: true` the printer keeps any comment whose text *contains* `/[@#]__(PURE|INLINE|NOINLINE)__/`, so prose that merely mentions an annotation survives alongside the real ones:

```js
function f() {
  // keep g() out of line, see the #__NOINLINE__ note
  const value = /*#__NOINLINE__*/ g()
  return value ? value : 0
}
```

The `//` comment ends up in the output. Terser's own output is still valid, but a `//` comment in minified code is a latent hazard: any later step that joins lines turns it into one that swallows the code after it.

My first attempt was to mark, in the parser, the comments `annotate()` actually consumes and preserve only those. That's wrong in enough ways that it seems worth recording so the next person skips the detour: comment objects are `AST_Token`s and `Object.seal`ed, so the flag can't just be assigned; it breaks 8 `expect_exact` cases in `test/compress/pure_funcs.js`; it drops annotations terser doesn't model but other tools read (`/*#__PURE__*/ var a = f()`, `/*#__PURE__*/ class ...`, tagged templates, `(/*@__PURE__*/ c)()`); it would start leaking `__KEY__`/`__MANGLE_PROP__` into output, bypassing the `clear_annotation` calls in `propmangle.js`; and it doesn't reliably fix the reported case anyway, since a prose comment sitting directly above a call *is* in annotation position - `test/compress/issue-1261.js` asserts such comments must keep annotating.

So the criterion here is the shape of the text rather than the position: preserve a comment whose entire contents are annotations, instead of one that mentions an annotation somewhere. No parser changes, and the position-blind pass-through that `pure_funcs.js` encodes as the contract stays intact.

That keeps every annotation form I could find in the wild - `/*#__PURE__*/`, `/*@__PURE__*/`, `/* @__PURE__ */`, `/**@__PURE__*/`, `//#__PURE__`, `// @__PURE__`, the multi-line JSDoc form, and several annotations sharing one comment - while dropping prose in any position.

Two things I deliberately left out, since both felt like separate changes: `filter_comment`'s scrub path still uses the broad regex, on the theory that when annotations are being dropped anything that could still be *read* as one downstream ought to be neutralized; and `__KEY__`/`__MANGLE_PROP__` are still not preserved, since terser consumes those itself and emitting them would defeat the `clear_annotation` calls in `propmangle.js`.

Added 23 cases in `test/mocha/comments.js` covering both directions, and confirmed they fail without the fix. `npm test` is green on Node 24: 2628/2628 compress cases and 265 mocha tests.

Also updated the README, since this narrows what the option documents.
