### PR TITLE
docs: clarify default CLI behavior without compress/mangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ instance:
 
 If no input file is specified, Terser will read from STDIN.
 
+By default (with no `--compress`/`-c` or `--mangle`/`-m`), Terser parses the
+input and prints it using the default format options. That removes unnecessary
+whitespace but does not run the compressor or mangler. Pass `--compress` and/or
+`--mangle` to enable those transforms.
+
 If you wish to pass your options before the input files, separate the two with
 a double dash to prevent input files being used as option arguments:
 


### PR DESCRIPTION
## Summary
- Documents what `terser input.js` does when `--compress`/`-c` and `--mangle`/`-m` are omitted.
- Default behavior parses input and prints with default format options (whitespace cleanup only), without compressing or mangling.

Fixes #614

## Test plan
- [x] Confirmed locally: `terser script.js` removes unnecessary whitespace but does not mangle names
- [x] Confirmed with `--compress --mangle` that mangling still requires those flags
- [ ] README wording looks clear to maintainers