### PR TITLE
fix: keep declaration and reference in sync when a catch shadows a name

### DIFF
--- a/lib/compress/reduce-vars.js
+++ b/lib/compress/reduce-vars.js
@@ -205,6 +205,10 @@ function safe_to_assign(tw, def, scope, value) {
 function ref_once(tw, compressor, def) {
     return compressor.option("unused")
         && !def.scope.pinned()
+        // A catch parameter of the same name keeps this definition in use, so its
+        // declaration is not dropped. Replacing the single reference with the value would
+        // then leave the same node in both the declaration and the reference.
+        && !def.redefined_by_catch
         && def.references.length - def.recursive_refs == 1
         && tw.loop_ids.get(def.id) === tw.in_loop;
 }

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -146,6 +146,7 @@ class SymbolDef {
         this.should_replace = undefined;
         this.single_use = false;
         this.fixed = false;
+        this.redefined_by_catch = false;
         Object.seal(this);
     }
     fixed_value() {
@@ -436,6 +437,10 @@ AST_Scope.DEFMETHOD("figure_out_scope", function(options, { parent_scope = undef
         // ensure mangling works if catch reuses a scope variable
         var def;
         if (node instanceof AST_SymbolCatch && (def = redefined_catch_def(node.definition()))) {
+            // `drop_unused` keeps this definition alive for as long as the catch symbol is
+            // referenced, so its declaration survives even when every reference to it has
+            // been replaced by its value.
+            def.redefined_by_catch = true;
             var s = node.scope;
             while (s) {
                 push_uniq(s.enclosed, def);

--- a/test/compress/issue-1712.js
+++ b/test/compress/issue-1712.js
@@ -1,0 +1,102 @@
+inline_function_shadowed_by_catch: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function foo(i, j) {
+            const a = function(i, j) {
+                return i(j);
+            };
+            const b = function(i, j) {
+                return i === j;
+            };
+            let r;
+            try {
+                r = a(i, j);
+            } catch (b) {
+                throw b;
+            }
+            return b(r, 4);
+        }
+        console.log(foo(function(i) {
+            return 2 * i;
+        }, 2));
+    }
+    expect_stdout: "true"
+}
+
+inline_function_shadowed_by_catch_minimal: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function foo(i, j) {
+            const b = function(i, j) {
+                return i === j;
+            };
+            let r;
+            try {
+                r = i(j);
+            } catch (b) {
+                throw b;
+            }
+            return b(r, 4);
+        }
+        console.log(foo(function(i) {
+            return 2 * i;
+        }, 2));
+    }
+    expect_stdout: "true"
+}
+
+inline_var_shadowed_by_catch: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function foo(i, j) {
+            var b = function(i, j) {
+                return i === j;
+            };
+            var r;
+            try {
+                r = i(j);
+            } catch (b) {
+                throw b;
+            }
+            return b(r, 4);
+        }
+        console.log(foo(function(i) {
+            return 2 * i;
+        }, 2));
+    }
+    expect_stdout: "true"
+}
+
+inline_function_not_shadowed_by_catch: {
+    options = {
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function foo(i, j) {
+            const b = function(i, j) {
+                return i === j;
+            };
+            let r;
+            try {
+                r = i(j);
+            } catch (e) {
+                throw e;
+            }
+            return b(r, 4);
+        }
+        console.log(foo(function(i) {
+            return 2 * i;
+        }, 2));
+    }
+    expect_stdout: "true"
+}


### PR DESCRIPTION
Fixes #1712.

## Problem

When a `catch` parameter has the same name as a variable in the enclosing function scope, a function stored in that variable can be replaced by an empty function, so calling it returns `undefined`:

```js
function foo(i, j) {
    const b = function(i, j) { return i === j };
    let r;
    try { r = i(j) } catch (b) { throw b; }
    return b(r, 4);
}
console.log(foo(i => 2 * i, 2));   // true unminified, undefined minified
```

Minified output on `master`:

```js
function foo(i,j){var r,b=function(i,j){return i===j};try{r=i(j)}catch(b){throw b}return function(){}(r,4)}
```

`b(r, 4)` became `function(){}(r, 4)`. Two conditions are needed together: the `catch` parameter must shadow the variable, and the stored function's parameters must shadow the enclosing function's parameters. Changing either one produces correct output. It reproduces with `var` as well as `const`, and does not depend on mangling.

## Root cause

`drop_unused` keeps a definition alive while a `catch` parameter of the same name is referenced, so that the mangler can still resolve it through `redefined_catch_def`:

```js
// lib/compress/drop-unused.js
if (node_def.orig[0] instanceof AST_SymbolCatch) {
    const redef = node_def.scope.is_block_scope()
        && node_def.scope.get_defun_scope().variables.get(node_def.name);
    if (redef) in_use_ids.set(redef.id, redef);
}
```

`reduce_vars` independently decided the same definition was used once and replaced its only reference with the value. `single_use` normally implies the declaration is dropped, so the value ends up in exactly one place, and `AST_SymbolRef.optimize` only clones the value when `fixed.parent_scope !== nearest_scope`. Here the declaration and the reference are in the same scope, so no clone is made and the declaration survives — leaving the same function node in both positions. Compressing that shared node then emptied it.

## Change

Do not treat a definition as used once when a `catch` parameter redefines it, since its declaration will be kept:

- `lib/scope.js` — record `redefined_by_catch` on the definition, where `figure_out_scope` already detects this exact relationship.
- `lib/compress/reduce-vars.js` — `ref_once()` returns `false` for such definitions.

This only disables the single-use substitution for a name that a `catch` parameter shadows. Everything else is unchanged, which is why no existing test output moved.

I first confirmed the cause by disabling the `drop_unused` branch above, which also fixes every case — but that branch is what keeps the mangler's `redefined_catch_def` lookup working, so the fix belongs on the `reduce_vars` side.

## Validation

| command | result |
| --- | --- |
| `node test/compress.js issue-1712.js` | 4 passed (3 of the 4 fail on `master`) |
| `node test/compress.js` | **2633 passed** (2629 before this change, + 4 new) |
| `npx mocha test/mocha` | 263 passing, 1 pending — same as `master` |
| `npm run lint` | clean |
| `npm run build` | clean |

`test/compress/issue-1712.js` adds four cases using `expect_stdout`, so they check the behaviour of the minified code rather than its text:

- the reported case
- a reduced case without the second function
- the same shape with `var` instead of `const`
- a `catch` parameter that does *not* shadow, which passes before and after and guards against fixing this by simply disabling the optimisation

Only validated locally on Windows with Node 24; I have not run CI on other platforms.

## Compatibility

- No public API change, no option change, no new dependency, lockfile untouched.
- Output is unchanged except where a `catch` parameter shadows a single-use variable; that variable is no longer inlined, which can cost a few bytes in this narrow case.
