### PR TITLE
experimental type stripping

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2967,6 +2967,13 @@ function parse($TEXT, options) {
             }
         }
 
+        if (
+            is("name", "type")
+            && typescript_import_type_statement()
+        ) {
+            return new AST_EmptyStatement({ start, end: prev() });
+        }
+
         var imported_name;
         var imported_names;
         if (is("name")) {
@@ -2982,7 +2989,7 @@ function parse($TEXT, options) {
         if (imported_names || imported_name) {
             expect_token("name", "from");
         }
-        var mod_str = S.token;
+        var mod_str = S.token; // expect_token("string");
         if (mod_str.type !== "string") {
             unexpected();
         }
@@ -3129,7 +3136,15 @@ function parse($TEXT, options) {
             next();
             names = [];
             while (!is("punc", "}")) {
-                names.push(map_name(is_import));
+                if (
+                    is("name", "type")
+                    && !(is_token(peek(), "name", "as") || is_token(peek(), "punc", ",") || is_token(peek(), "punc", "}"))
+                    && typescript_import_named_type()
+                ) {
+                    // nothing to import
+                } else {
+                    names.push(map_name(is_import));
+                }
                 if (is("punc", ",")) {
                     next();
                 }
@@ -3151,6 +3166,11 @@ function parse($TEXT, options) {
         var start = S.token;
         var is_default;
         var exported_names;
+
+        if ((is("name", "type") || is("name", "interface"))) {
+            typescript_export_type_statement();
+            return new AST_EmptyStatement({ start, end: prev() });
+        }
 
         if (is("keyword", "default")) {
             is_default = true;
@@ -3776,6 +3796,70 @@ function parse($TEXT, options) {
         }
         _ts_object_body();
     }
+    function typescript_import_type_statement() {
+        if (!options.experimental_typescript) return;
+
+        if (
+            is_token(peek(), "name", "from")
+            || is_token(peek(), "punc", ",")
+        ) {
+            // not TS: `import type from ...`, `import type, { ...`
+            return false;
+        }
+
+        expect_token("name", "type");
+
+        if (!is("punc", "{")) {
+            next(); // star or name
+            if (is("name", "as")) {
+                next();
+                _ts_type_name(); // import type 'string' as NotString
+            }
+
+            if (is("punc", ",")) {
+                next();
+                _ts_import_export_name_mapping();
+            }
+        } else if (is("punc", "{")) {
+            _ts_import_export_name_mapping();
+        }
+
+        expect_token("name", "from");
+        expect_token("string");
+
+        return true;
+    }
+    function typescript_export_type_statement() {
+        if (!options.experimental_typescript) return;
+
+        if (is("name", "type") && is_token(peek(), "name")) {
+            typescript_type_statement();
+            return;
+        }
+        if (is("name", "interface")) {
+            typescript_interface_statement();
+            return;
+        }
+
+        expect_token("name", "type");
+
+        if (is("operator", "*")) {
+            next();
+            if (is("name", "as")) {
+                next();
+                next();
+            }
+        }
+
+        if (is("punc", "{")) {
+            _ts_import_export_name_mapping();
+        }
+
+        if (is("name", "from")) {
+            expect_token("name", "from");
+            expect_token("string");
+        }
+    }
     function typescript_maybe_annotation() {
         if (!options.experimental_typescript) return;
 
@@ -3787,6 +3871,19 @@ function parse($TEXT, options) {
             return true;
         }
         return false;
+    }
+    function typescript_import_named_type() {
+        if (!options.experimental_typescript) return false;
+
+        expect_token("name", "type");
+        next(); // name or string
+        if (is("name", "as")) {
+            next();
+            if (is("keyword", "default")) next();
+            else _ts_type();
+        }
+
+        return true;
     }
     function typescript_type_annotation() {
         if (!options.experimental_typescript) return;
@@ -4022,6 +4119,18 @@ function parse($TEXT, options) {
             _ts_type();
         });
         expect(")");
+    }
+    function _ts_import_export_name_mapping() {
+        expect("{");
+        _ts_commatized("punc", "}", () => {
+            next();
+            if (is("name", "as")) {
+                next();
+                if (is("string") || is("keyword")) next();
+                else _ts_type_name();
+            }
+        });
+        expect("}");
     }
     function _ts_commatized(till_type, till, cb) {
         while (!(is(till_type, till))) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3145,8 +3145,8 @@ function parse($TEXT, options) {
                 } else {
                     names.push(map_name(is_import));
                 }
-                if (is("punc", ",")) {
-                    next();
+                if (!is("punc", "}")) {
+                    expect_token("punc", ",");
                 }
             }
             next();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -992,6 +992,73 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
 
     next_token.peek_next_token_start_or_newline = peek_next_token_start_or_newline;
     next_token.ch_starts_binding_identifier = ch_starts_binding_identifier;
+    next_token.typescript_is_type_parameters_before_call = () => {
+        const stack = [">"]; // We start at the opening "<"
+        const peek = () => get_full_char(S.text, i + 1);
+        const next = () => get_full_char(S.text, ++i);
+        let i = S.pos;
+        for (; stack.length; i++) {
+            let ch = get_full_char(S.text, i);
+
+            if (!ch) return false;
+
+            if (ch === stack[stack.length - 1]) {
+                stack.pop();
+                continue;
+            }
+
+            // Skip comments
+            if (ch === "/") {
+                ch = next();
+                if (ch === "/") {
+                    while ((ch = next()) && ch !== "\n");
+                } else if (ch === "*") {
+                    while ((ch = next()) && !(ch === "*" && peek() === "/"));
+                }
+            }
+
+            // Skip strings
+            if (ch === "'" || ch === '"') {
+                const start = ch;
+                do {
+                    ch = next();
+                    if (ch === "\\") ++i; // skip over \"
+                } while (ch && ch !== start && ch !== "\n");
+            }
+
+            // Skip template strings
+            if (
+                ch === "`"
+                || ch === "}" && stack[stack.length - 1] === "${" && stack.pop()
+            ) {
+                do {
+                    ch = next();
+
+                    if (ch === "$" && peek() === "{") {
+                        next();
+                        stack.push("${");
+                        break;
+                    }
+                } while (ch && ch !== "`");
+            }
+
+            // for each opener, push the closer
+            if (ch === "<") { stack.push(">"); continue; }
+            if (ch === "[") { stack.push("]"); continue; }
+            if (ch === "(") { stack.push(")"); continue; }
+            if (ch === "{") { stack.push("}"); continue; }
+
+            // When we see a closer, see if it's the same as the opener
+            if (ch === ">" || ch === "]" || ch === ")" || ch === "}") {
+                if (stack.pop() !== ch) return false;
+                continue;
+            }
+        }
+
+        while (WHITESPACE_CHARS.has(get_full_char(S.text, i))) i++;
+
+        return S.text[i] === "(" || S.text.slice(i, i + 2) === "?.";
+    };
 
     return next_token;
 
@@ -1064,6 +1131,7 @@ function parse($TEXT, options) {
         shebang        : true,
         strict         : false,
         toplevel       : null,
+        experimental_typescript: false,
     }, true);
 
     var S = {
@@ -1220,7 +1288,9 @@ function parse($TEXT, options) {
                 if (is_for_body) {
                     croak("functions are not allowed as the body of a loop");
                 }
-                return function_(AST_Defun, false, true, is_export_default);
+                const func = function_(AST_Defun, false, true, is_export_default);
+                if (func == typescript_ellide) return new AST_EmptyStatement();
+                return func;
             }
             if (S.token.value == "import" && !is_token(peek(), "punc", "(") && !is_token(peek(), "punc", ".")) {
                 next();
@@ -1332,7 +1402,9 @@ function parse($TEXT, options) {
                 if (is_for_body) {
                     croak("functions are not allowed as the body of a loop");
                 }
-                return function_(AST_Defun, false, false, is_export_default);
+                const func = function_(AST_Defun, false, false, is_export_default);
+                if (func == typescript_ellide) return new AST_EmptyStatement();
+                return func;
 
               case "if":
                 next();
@@ -1558,9 +1630,12 @@ function parse($TEXT, options) {
             croak("Unexpected newline before arrow (=>)");
         }
 
+        if (is("punc", ":")) typescript_type_annotation();
+
         expect_token("arrow", "=>");
 
         var body = _function_body(is("punc", "{"), false, is_async);
+        // (should never return typescript_ellide)
 
         return new AST_Arrow({
             start    : start,
@@ -1595,15 +1670,17 @@ function parse($TEXT, options) {
         }
 
         var args = [];
+        const start = S.token;
         var body = _function_body(true, is_generator, is_async, name, args);
+        if (body == typescript_ellide) return body;
         return new ctor({
-            start : args.start,
-            end   : body.end,
+            start,
             is_generator: is_generator,
             async : is_async,
             name  : name,
             argnames: args,
-            body  : body
+            body  : body,
+            end   : prev(),
         });
     };
 
@@ -1671,6 +1748,10 @@ function parse($TEXT, options) {
         expect("(");
 
         while (!is("punc", ")")) {
+            if (is("name", "this") && typescript_skip_this_type()) {
+                continue;
+            }
+
             var param = parameter(used_parameters);
             params.push(param);
 
@@ -1697,7 +1778,12 @@ function parse($TEXT, options) {
             used_parameters.mark_spread(S.token);
             next();
         }
+
         param = binding_element(used_parameters, symbol_type);
+
+        if (is("punc", ":") || is("operator", "?")) {
+            typescript_parameter_after_name();
+        }
 
         if (is("operator", "=") && expand === false) {
             used_parameters.mark_default_assignment(S.token);
@@ -1919,6 +2005,11 @@ function parse($TEXT, options) {
             } else {
                 a.push(expression());
             }
+
+            if (is("punc", ":") || is("operator", "?")) {
+                typescript_parameter_after_name();
+            }
+
             if (!is("punc", ")")) {
                 expect(",");
                 if (is("punc", ")")) {
@@ -1928,6 +2019,9 @@ function parse($TEXT, options) {
             }
         }
         expect(")");
+        if (allow_arrows && is("punc", ":")) {
+            typescript_type_annotation();
+        }
         if (allow_arrows && is("arrow", "=>")) {
             if (spread_token && trailing_comma) unexpected(trailing_comma);
         } else if (invalid_sequence) {
@@ -1946,7 +2040,13 @@ function parse($TEXT, options) {
             S.in_generator = S.in_function;
         if (is_async)
             S.in_async = S.in_function;
-        if (args) parameters(args);
+        if (args) {
+            parameters(args);
+            if (is("punc", ":")) typescript_type_annotation();
+            if (block && !is("punc", "{") && typescript_is_function_no_body()) {
+                return typescript_ellide;
+            }
+        }
         if (block)
             S.in_directives = true;
         S.in_loop = 0;
@@ -2142,8 +2242,7 @@ function parse($TEXT, options) {
             if (name.name == "import") croak("Unexpected token: import");
 
             if (is("punc", ":")) {
-                next();
-                typescript_type();
+                typescript_type_annotation();
             }
 
             var value = is("operator", "=")
@@ -2354,6 +2453,9 @@ function parse($TEXT, options) {
     }
 
     var expr_atom = function(allow_calls, allow_arrows) {
+        if (is("operator", "<")) {
+            typescript_skip_type_parameters_before_call();
+        }
         if (is("operator", "new")) {
             return new_(allow_calls);
         }
@@ -2366,11 +2468,18 @@ function parse($TEXT, options) {
             && (peeked = peek()).value != "["
             && peeked.type != "arrow"
             && as_atom_node();
+        if (async && is("operator", "<")) {
+            // async <T>() => null
+            typescript_skip_type_parameters_before_call();
+        }
         if (is("punc")) {
             switch (S.token.value) {
               case "(":
                 if (async && !allow_calls) break;
                 var exprs = params_or_seq_(allow_arrows, !async);
+                if (allow_arrows && is("punc", ":")) {
+                    typescript_type_annotation();
+                }
                 if (allow_arrows && is("arrow", "=>")) {
                     return arrow_function(start, exprs.map(e => to_fun_args(e)), !!async);
                 }
@@ -2421,6 +2530,7 @@ function parse($TEXT, options) {
         if (is("keyword", "function")) {
             next();
             var func = function_(AST_Function, false, !!async);
+            if (func == typescript_ellide) typescript_croak();
             func.start = start;
             func.end = prev();
             return subscripts(func, allow_calls);
@@ -2498,9 +2608,9 @@ function parse($TEXT, options) {
         });
     });
 
-    var create_accessor = embed_tokens((is_generator, is_async) => {
+    var create_accessor = (is_generator, is_async) => {
         return function_(AST_Accessor, is_generator, is_async);
-    });
+    };
 
     var object_or_destructuring_ = embed_tokens(function object_or_destructuring_() {
         var start = S.token, first = true, a = [];
@@ -2530,6 +2640,9 @@ function parse($TEXT, options) {
             // Check property and fetch value
             if (!is("punc", ":")) {
                 var concise = object_or_class_property(name, start);
+                if (concise === typescript_ellide) {
+                    continue;
+                }
                 if (concise) {
                     a.push(concise);
                     continue;
@@ -2592,9 +2705,17 @@ function parse($TEXT, options) {
             }
         }
 
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
+
         if (S.token.value == "extends") {
             next();
             extends_ = expression(true);
+        }
+
+        if (is("name", "implements")) {
+            typescript_extends_implements();
         }
 
         expect("{");
@@ -2604,9 +2725,12 @@ function parse($TEXT, options) {
         while (is("punc", ";")) { next(); }  // Leading semicolons are okay in class bodies.
         while (!is("punc", "}")) {
             start = S.token;
-            method = object_or_class_property(as_property_name(), start, true);
+            method = object_or_class_property(as_property_name(true), start, true);
             if (!method) { unexpected(); }
-            properties.push(method);
+            if (method !== typescript_ellide) {
+                properties.push(method);
+            }
+
             while (is("punc", ";")) { next(); }
         }
         // mark in class feild,
@@ -2644,14 +2768,26 @@ function parse($TEXT, options) {
         var is_generator = false;
         var accessor_type = null;
 
+        if (name === typescript_ellide) return name;
+
+        if (is_class && (name === "public" || name === "private" || name === "protected") && is_not_method_start()) {
+            const did_eat = typescript_is_accessibility_modifier();
+            if (did_eat) name = as_property_name(true);
+        }
+        if (name === typescript_ellide) return name;
         if (is_class && name === "static" && is_not_method_start()) {
             const static_block = class_static_block();
             if (static_block != null) {
                 return static_block;
             }
             is_static = true;
-            name = as_property_name();
+            name = as_property_name(true);
         }
+        if (name === typescript_ellide) return name;
+        if (name === "readonly" && typescript_is_readonly() && is_not_method_start()) {
+            name = as_property_name(true);
+        }
+        if (name === typescript_ellide) return name;
         if (name === "async" && is_not_method_start()) {
             is_async = true;
             name = as_property_name();
@@ -2670,6 +2806,10 @@ function parse($TEXT, options) {
 
         const property_token = prev();
 
+        if (is("punc", ":")) {
+            typescript_type_annotation();
+        }
+
         if (accessor_type != null) {
             if (!is_private) {
                 const AccessorClass = accessor_type === "get"
@@ -2677,12 +2817,16 @@ function parse($TEXT, options) {
                     : AST_ObjectSetter;
 
                 name = get_symbol_ast(name, AST_SymbolMethod);
+
+                const accessor = create_accessor();
+                if (accessor == typescript_ellide) return accessor;
+
                 return annotate(new AccessorClass({
                     start,
                     static: is_static,
                     key: name,
                     quote: name instanceof AST_SymbolMethod ? property_token.quote : undefined,
-                    value: create_accessor(),
+                    value: accessor,
                     end: prev()
                 }));
             } else {
@@ -2690,28 +2834,42 @@ function parse($TEXT, options) {
                     ? AST_PrivateGetter
                     : AST_PrivateSetter;
 
+                name = get_symbol_ast(name, AST_SymbolMethod);
+
+                const accessor = create_accessor();
+                if (accessor == typescript_ellide) return accessor;
+
                 return annotate(new AccessorClass({
                     start,
                     static: is_static,
-                    key: get_symbol_ast(name, AST_SymbolMethod),
-                    value: create_accessor(),
+                    key: name,
+                    value: accessor,
                     end: prev(),
                 }));
             }
         }
 
+        if (is_class && is("operator", "<")) {
+            typescript_type_parameters();
+        }
+
         if (is("punc", "(")) {
             name = get_symbol_ast(name, AST_SymbolMethod);
+
             const AST_MethodVariant = is_private
                 ? AST_PrivateMethod
                 : AST_ConciseMethod;
+
+            const accessor = create_accessor(is_generator, is_async);
+            if (accessor == typescript_ellide) return accessor;
+
             var node = new AST_MethodVariant({
                 start       : start,
                 static      : is_static,
                 key         : name,
                 quote       : name instanceof AST_SymbolMethod ?
                               property_token.quote : undefined,
-                value       : create_accessor(is_generator, is_async),
+                value       : accessor,
                 end         : prev()
             });
             return annotate(node);
@@ -3059,13 +3217,19 @@ function parse($TEXT, options) {
         });
     }
 
-    function as_property_name() {
+    function as_property_name(typescript_class_index_notation = false) {
         var tmp = S.token;
         switch (tmp.type) {
           case "punc":
             if (tmp.value === "[") {
                 next();
                 var ex = expression(false);
+                if (typescript_class_index_notation && is("punc", ":")) {
+                    typescript_type_annotation();
+                    expect("]");
+                    if (is("punc", ":")) typescript_type_annotation();
+                    return typescript_ellide;
+                }
                 expect("]");
                 return ex;
             } else unexpected(tmp);
@@ -3219,6 +3383,7 @@ function parse($TEXT, options) {
                 end        : prev()
             }), allow_calls, is_chain));
         }
+        if (allow_calls && is("operator", "<")) typescript_skip_type_parameters_before_call();
         if (allow_calls && is("punc", "(")) {
             next();
             var call = new AST_Call({
@@ -3237,6 +3402,8 @@ function parse($TEXT, options) {
             next();
 
             let chain_contents;
+
+            if (allow_calls && is("operator", "<")) typescript_type_parameters();
 
             if (allow_calls && is("punc", "(")) {
                 next();
@@ -3345,11 +3512,8 @@ function parse($TEXT, options) {
             val.end = S.token;
             next();
         }
-        if (is("name", "as")) {
-            typescript_as();
-        }
-        if (is("name", "satisfies")) {
-            typescript_satisfies();
+        if (is("name", "as") || is("name", "satisfies")) {
+            typescript_as_satisfies();
         }
         return val;
     };
@@ -3427,6 +3591,9 @@ function parse($TEXT, options) {
         var expr = expr_ops(no_in, 0, true, true);
         if (is("operator", "?")) {
             next();
+            if (is("punc", ":") && typescript_parameter_after_name()) {
+                return expr;
+            }
             var yes = expression(false);
             expect(":");
             return new AST_Conditional({
@@ -3555,7 +3722,10 @@ function parse($TEXT, options) {
     // These functions are called when we know S.token begins some TS fluff
     // Just call next() and friends, skipping TypeScript information
 
+    // Typescript entrypoints, from the rest of the parser
     function typescript_type_parameters() {
+        if (!options.experimental_typescript) return;
+
         expect_token("operator", "<");
         for (;;) {
             typescript_type_parameter();
@@ -3573,6 +3743,103 @@ function parse($TEXT, options) {
         }
     }
 
+    const typescript_ellide = Symbol("typescript_ellide");
+    function typescript_as_satisfies() {
+        if (!options.experimental_typescript) return;
+
+        while (is("name", "as") || is("name", "satisfies")) {
+            next();
+            typescript_type();
+        }
+    }
+    function typescript_type_statement() {
+        if (!options.experimental_typescript) return;
+
+        expect_token("name", "type");
+        expect_token("name");
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
+        expect_token("operator", "=");
+        typescript_type();
+    }
+    function typescript_interface_statement() {
+        if (!options.experimental_typescript) return;
+
+        expect_token("name", "interface");
+        expect_token("name");
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
+        if (is("keyword", "extends") || is("keyword", "implements")) {
+            typescript_extends_implements();
+        }
+        typescript_type_body();
+    }
+    function typescript_parameter_after_name() {
+        if (!options.experimental_typescript) return;
+
+        if (is("operator", "?") && is_token(peek(), "punc", ":")) {
+            next();
+            typescript_type_annotation();
+            return true;
+        } else if (is("punc", ":")) {
+            typescript_type_annotation();
+            return true;
+        }
+    }
+    function typescript_type_annotation() {
+        if (!options.experimental_typescript) return;
+
+        expect_token("punc", ":");
+        typescript_type();
+    }
+    function typescript_skip_this_type() {
+        if (!options.experimental_typescript) return;
+
+        if (is("name", "this")) {
+            next();
+            typescript_type_annotation();
+            if (is("punc", ",")) next();
+            return true;
+        }
+    }
+    function typescript_extends_implements() {
+        if (!options.experimental_typescript) return;
+
+        next(); // "extends" / "implements"
+        typescript_commatized_while("name", typescript_type);
+    }
+    function typescript_is_accessibility_modifier() {
+        if (!options.experimental_typescript) return;
+
+        // Known to be 'private', 'public' or 'protected'
+        return true;
+    }
+    function typescript_is_readonly() {
+        if (!options.experimental_typescript) return;
+
+        // Known to be 'readonly'
+        return true;
+    }
+    function typescript_is_function_no_body() {
+        if (!options.experimental_typescript) return;
+
+        // There's no body. Is this okay?
+        return true;
+    }
+    function typescript_skip_type_parameters_before_call() {
+        if (!options.experimental_typescript) return;
+
+        // Skip type parameters without parsing ahead. Differentiates between comparisons and type parameters: varname < T > (1)
+        // Go until "?." or "("
+        const matches = S.input.typescript_is_type_parameters_before_call();
+        if (matches) typescript_type_parameters();
+    }
+
+
+    // Internal stuff
+
     function typescript_pop_gt_operator() {
         // HACK: JS has >, >>, >>>. TS only knows >
         if (S.token.type === "operator" && S.token.value.startsWith(">")) {
@@ -3584,19 +3851,21 @@ function parse($TEXT, options) {
             }
         }
     }
-
     function typescript_type_parameter() {
         typescript_type();
         typescript_constraint();
     }
-
     function typescript_constraint() {
         if (is("keyword", "extends")) {
             expect_token("keyword", "extends");
             typescript_type();
+
+            if (is("operator", "=")) {
+                expect_token("operator", "=");
+                typescript_type();
+            }
         }
     }
-
     function typescript_type() {
         if (is("operator", "new")) {
             // new(...args) => Type
@@ -3618,15 +3887,18 @@ function parse($TEXT, options) {
             } while (is("operator", "|") || is("operator", "&"));
         }
     }
-
     var TS_PREDEFINED_TYPES = makePredicate(["any", "number", "boolean", "string", "symbol", "void"]);
     function typescript_primary_type() {
+        if (is("name", "readonly")) next();
+
         if (is("punc", "(")) {
             next();
             typescript_type();
             expect(")");
         } else if (is("name") && TS_PREDEFINED_TYPES.has(S.token.value)) {
             next();
+        } else if (is("template_head")) {
+            typescript_template_string();
         } else if (is("string") || is("num") || is("big_int") || is("atom")) {
             next();
         } else if (is("name")) {
@@ -3651,31 +3923,44 @@ function parse($TEXT, options) {
             next();
         }
     }
-
+    // Also used as `typeof`'s argument
     function typescript_type_name() {
         expect_token("name");
-        while (is("punc", ".")) {
-            next();
-            expect_token("name");
+        for (;;) {
+            if (is("punc", ".")) {
+                next();
+                expect_token("name");
+                continue;
+            }
+            if (is("punc", "[") && !is_token(peek(), "punc", "]")) {
+                expect_token("punc", "[");
+                typescript_type();
+                expect_token("punc", "]");
+                continue;
+            }
+            break;
         }
     }
-
     function typescript_type_body() {
+        const is_method_key = (token) =>
+            is_token(token, "name")
+            || is_token(token, "string")
+            || is_token(token, "operator", "new")
+            || is_token(token, "template_head");
         expect_token("punc", "{");
         typescript_commas_or_semicolons("punc", "}", () => {
-            // IS A FUNCTION OR CONSTRUCTOR
+            // SKIP `readonly` WHEN IT'S A KEYWORD
             if (
-                (is("operator", "new") && next())
-                || is("punc", "(")
+                is("name", "readonly")
+                && (is_method_key(peek())
+                    || is_token(peek(), "punc", "["))
             ) {
-                typescript_parenthesized_parameter_list();
-                expect(":");
-                typescript_type();
-                return;
+                next();
             }
 
             // KEY
-            if (is("name") || is("string")) {
+            if (is_method_key(S.token)) {
+                if (is("template_head")) typescript_template_string();
                 next();
             } else if (is("punc", "[")) {
                 next();
@@ -3684,12 +3969,23 @@ function parse($TEXT, options) {
                 typescript_type();
                 expect("]");
             } else {
-                typescript_croak();
+                // naked call signature
+            }
+
+            // OPTIONAL
+            if (is("operator", "?")) next();
+
+            // TYPE PARAMETERS
+            if (is("operator", "<")) {
+                typescript_type_parameters();
             }
 
             // VALUE (method or thing)
             if (is("punc", "(")) {
                 typescript_parenthesized_parameter_list();
+                if (is("punc", ":")) {
+                    typescript_type_annotation();
+                }
             } else if (is("punc", ":")) {
                 next();
                 typescript_type();
@@ -3699,7 +3995,6 @@ function parse($TEXT, options) {
         });
         expect_token("punc", "}");
     }
-
     function typescript_tuple_types() {
         typescript_commatized("punc", "]", () => {
             if (is("expand", "...")) {
@@ -3720,88 +4015,59 @@ function parse($TEXT, options) {
             }
         });
     }
-
     function typescript_parenthesized_parameter_list() {
         expect("(");
         typescript_commatized("punc", ")", typescript_parameter);
         expect(")");
     }
-
     function typescript_parameter() {
         if (is("expand", "...")) next();
 
         expect_token("name");
+        if (is("operator", "?")) next();
         expect(":");
         typescript_type();
     }
-
     function typescript_commatized(till_type, till, cb) {
-        if (is(till_type, till)) return;
-
-        for (;;) {
+        while (!(is(till_type, till))) {
             cb();
-
-            if (is("punc", ",")) {
-                next();
-                if (!is(till_type, till)) {
-                    continue;
-                }
+            if (!is(till_type, till)) {
+                expect(",");
+            } else {
+                break;
             }
-
-            break;
         }
     }
-
-    function typescript_commas_or_semicolons(till_type, till, cb) {
-        if (is(till_type, till)) return;
-
-        for (;;) {
+    function typescript_commatized_while(while_type, cb) {
+        while (is(while_type)) {
             cb();
-
-            if ((is("punc", ",") && next()) || (is("punc", ";") && next()) || S.token.nlb) {
-                if (!is(till_type, till)) {
-                    continue;
-                }
-            }
-
-            break;
-        }
-    }
-
-    function typescript_as() {
-        while (is("name", "as")) {
-            expect_token("name", "as");
-            typescript_type();
-        }
-    }
-
-    function typescript_satisfies() {
-        expect_token("name", "satisfies");
-        typescript_type();
-    }
-
-    function typescript_type_statement() {
-        expect_token("name", "type");
-        expect_token("name");
-        if (is("operator", "<")) {
-            typescript_type_parameters();
-        }
-        expect_token("operator", "=");
-        typescript_type();
-    }
-    function typescript_interface_statement() {
-        expect_token("name", "interface");
-        expect_token("name");
-        if (is("operator", "<")) {
-            typescript_type_parameters();
-        }
-        if (is("keyword", "extends")) {
+            if (!is("punc", ",")) break;
             next();
-            typescript_type();
         }
-        typescript_type_body();
     }
+    function typescript_commas_or_semicolons(till_type, till, cb) {
+        while (!is(till_type, till)) {
+            cb();
+            if (!is(till_type, till)) {
+                if (is("punc", ",") || is("punc", ";")) next();
+                else if (S.token.nlb) ; // ASI
+                else typescript_croak();
+            } else {
+                break;
+            }
+        }
+    }
+    function typescript_template_string() {
+        while (!S.token.template_end) {
+            next(); // consume a template string
 
+            typescript_type();
+            if (!is("template_cont")) {
+                typescript_croak();
+            }
+        }
+        next();
+    }
     function typescript_croak() {
         croak("invalid or unsupported TypeScript syntax");
     }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1782,7 +1782,7 @@ function parse($TEXT, options) {
         param = binding_element(used_parameters, symbol_type);
 
         if (is("punc", ":") || is("operator", "?")) {
-            typescript_parameter_after_name();
+            typescript_maybe_annotation();
         }
 
         if (is("operator", "=") && expand === false) {
@@ -2007,7 +2007,7 @@ function parse($TEXT, options) {
             }
 
             if (is("punc", ":") || is("operator", "?")) {
-                typescript_parameter_after_name();
+                typescript_maybe_annotation();
             }
 
             if (!is("punc", ")")) {
@@ -3591,7 +3591,7 @@ function parse($TEXT, options) {
         var expr = expr_ops(no_in, 0, true, true);
         if (is("operator", "?")) {
             next();
-            if (is("punc", ":") && typescript_parameter_after_name()) {
+            if (is("punc", ":") && typescript_maybe_annotation()) {
                 return expr;
             }
             var yes = expression(false);
@@ -3727,29 +3727,18 @@ function parse($TEXT, options) {
         if (!options.experimental_typescript) return;
 
         expect_token("operator", "<");
-        for (;;) {
-            typescript_type_parameter();
-            if (is("punc", ",")) {
-                next();
-                if (!typescript_pop_gt_operator()) {
-                    continue;
-                }
-            }
-            break;
-        }
-
-        if (!typescript_pop_gt_operator()) {
-            typescript_croak();
-        }
+        do {
+            _ts_type_parameter();
+        } while (is("punc", ",") && next());
+        if (!_ts_gt_operator()) typescript_croak();
     }
-
     const typescript_ellide = Symbol("typescript_ellide");
     function typescript_as_satisfies() {
         if (!options.experimental_typescript) return;
 
         while (is("name", "as") || is("name", "satisfies")) {
             next();
-            typescript_type();
+            _ts_type();
         }
     }
     function typescript_type_statement() {
@@ -3761,7 +3750,7 @@ function parse($TEXT, options) {
             typescript_type_parameters();
         }
         expect_token("operator", "=");
-        typescript_type();
+        _ts_type();
     }
     function typescript_interface_statement() {
         if (!options.experimental_typescript) return;
@@ -3774,25 +3763,25 @@ function parse($TEXT, options) {
         if (is("keyword", "extends") || is("keyword", "implements")) {
             typescript_extends_implements();
         }
-        typescript_type_body();
+        _ts_object_body();
     }
-    function typescript_parameter_after_name() {
+    function typescript_maybe_annotation() {
         if (!options.experimental_typescript) return;
 
-        if (is("operator", "?") && is_token(peek(), "punc", ":")) {
-            next();
-            typescript_type_annotation();
-            return true;
-        } else if (is("punc", ":")) {
+        if (
+            is("operator", "?") && is_token(peek(), "punc", ":") && next()
+            || is("punc", ":")
+        ) {
             typescript_type_annotation();
             return true;
         }
+        return false;
     }
     function typescript_type_annotation() {
         if (!options.experimental_typescript) return;
 
         expect_token("punc", ":");
-        typescript_type();
+        _ts_type();
     }
     function typescript_skip_this_type() {
         if (!options.experimental_typescript) return;
@@ -3808,7 +3797,7 @@ function parse($TEXT, options) {
         if (!options.experimental_typescript) return;
 
         next(); // "extends" / "implements"
-        typescript_commatized_while("name", typescript_type);
+        _ts_commatized_while("name", _ts_type);
     }
     function typescript_is_accessibility_modifier() {
         if (!options.experimental_typescript) return;
@@ -3836,11 +3825,13 @@ function parse($TEXT, options) {
         const matches = S.input.typescript_is_type_parameters_before_call();
         if (matches) typescript_type_parameters();
     }
-
+    function typescript_croak() {
+        croak("invalid or unsupported TypeScript syntax");
+    }
 
     // Internal stuff
 
-    function typescript_pop_gt_operator() {
+    function _ts_gt_operator() {
         // HACK: JS has >, >>, >>>. TS only knows >
         if (S.token.type === "operator" && S.token.value.startsWith(">")) {
             if (S.token.value === ">") {
@@ -3851,108 +3842,107 @@ function parse($TEXT, options) {
             }
         }
     }
-    function typescript_type_parameter() {
-        typescript_type();
-        typescript_constraint();
+    function _ts_type_parameter() {
+        _ts_type();
+        _ts_constraint();
     }
-    function typescript_constraint() {
+    function _ts_constraint() {
         if (is("keyword", "extends")) {
             expect_token("keyword", "extends");
-            typescript_type();
+            _ts_type();
 
             if (is("operator", "=")) {
                 expect_token("operator", "=");
-                typescript_type();
+                _ts_type();
             }
         }
     }
-    function typescript_type() {
+    function _ts_type() {
         if (is("operator", "new")) {
             // new(...args) => Type
             next();
             if (is("operator", "<")) typescript_type_parameters();
-            typescript_parenthesized_parameter_list();
+            _ts_parenthesized_params();
             expect_token("arrow", "=>");
-            typescript_type();
+            _ts_type();
         } else if (is("punc", "(")) {
             // (...args) => Type
-            typescript_parenthesized_parameter_list();
+            _ts_parenthesized_params();
             expect_token("arrow", "=>");
-            typescript_type();
+            _ts_type();
             expect_token("punc", ")");
         } else {
             do {
                 if (is("operator", "|") || is("operator", "&")) next();
-                typescript_primary_type();
+                _ts_primary_type();
             } while (is("operator", "|") || is("operator", "&"));
         }
     }
-    var TS_PREDEFINED_TYPES = makePredicate(["any", "number", "boolean", "string", "symbol", "void"]);
-    function typescript_primary_type() {
+    var _TS_PREDEFINED_TYPES = makePredicate(["any", "unknown", "const", "number", "boolean", "string", "symbol", "void"]);
+    function _ts_primary_type() {
         if (is("name", "readonly")) next();
 
         if (is("punc", "(")) {
             next();
-            typescript_type();
+            _ts_type();
             expect(")");
-        } else if (is("name") && TS_PREDEFINED_TYPES.has(S.token.value)) {
+        } else if (is("name") && _TS_PREDEFINED_TYPES.has(S.token.value)) {
             next();
         } else if (is("template_head")) {
-            typescript_template_string();
+            _ts_template_string();
         } else if (is("string") || is("num") || is("big_int") || is("atom")) {
             next();
         } else if (is("name")) {
-            typescript_type_name();
+            _ts_type_name();
             if (is("operator", "<")) typescript_type_parameters();
         } else if (is("punc", "{")) {
-            typescript_type_body();
+            _ts_object_body();
         } else if (is("punc", "[")) {
             next();
-            typescript_tuple_types();
+            _ts_tuple_types();
             expect_token("punc", "]");
         } else if (is("operator", "typeof")) {
             next();
-            typescript_type_name();
+            _ts_type_name();
         } else {
             typescript_croak();
         }
 
-        // ArrayType
+        // NestedArraySuffixes[][][][]
         while (is("punc", "[") && is_token(peek(), "punc", "]")) {
             next();
             next();
         }
     }
     // Also used as `typeof`'s argument
-    function typescript_type_name() {
+    function _ts_type_name() {
         expect_token("name");
         for (;;) {
             if (is("punc", ".")) {
                 next();
                 expect_token("name");
-                continue;
-            }
-            if (is("punc", "[") && !is_token(peek(), "punc", "]")) {
+            } else if (is("punc", "[") && !is_token(peek(), "punc", "]")) {
                 expect_token("punc", "[");
-                typescript_type();
+                _ts_type();
                 expect_token("punc", "]");
-                continue;
+            } else {
+                break;
             }
-            break;
         }
     }
-    function typescript_type_body() {
+    function _ts_object_body() {
         const is_method_key = (token) =>
             is_token(token, "name")
+            || is_token(token, "num")
             || is_token(token, "string")
-            || is_token(token, "operator", "new")
-            || is_token(token, "template_head");
+            || is_token(token, "operator", "new");
         expect_token("punc", "{");
-        typescript_commas_or_semicolons("punc", "}", () => {
+        _ts_commas_or_semicolons("punc", "}", () => {
             // SKIP `readonly` WHEN IT'S A KEYWORD
             if (
                 is("name", "readonly")
                 && (is_method_key(peek())
+                    || is_token(peek(), "template_head")
                     || is_token(peek(), "punc", "["))
             ) {
                 next();
@@ -3960,13 +3950,13 @@ function parse($TEXT, options) {
 
             // KEY
             if (is_method_key(S.token)) {
-                if (is("template_head")) typescript_template_string();
                 next();
+            } else if (is("template_head")) {
+                _ts_template_string();
             } else if (is("punc", "[")) {
                 next();
-                expect_token("name");
-                expect(":");
-                typescript_type();
+                if (is_method_key(S.token)) next();
+                typescript_maybe_annotation();
                 expect("]");
             } else {
                 // naked call signature
@@ -3982,94 +3972,68 @@ function parse($TEXT, options) {
 
             // VALUE (method or thing)
             if (is("punc", "(")) {
-                typescript_parenthesized_parameter_list();
-                if (is("punc", ":")) {
-                    typescript_type_annotation();
-                }
+                _ts_parenthesized_params();
+                typescript_maybe_annotation();
             } else if (is("punc", ":")) {
                 next();
-                typescript_type();
+                _ts_type();
             } else {
                 typescript_croak();
             }
         });
         expect_token("punc", "}");
     }
-    function typescript_tuple_types() {
-        typescript_commatized("punc", "]", () => {
-            if (is("expand", "...")) {
-                next();
+    function _ts_tuple_types() {
+        _ts_commatized("punc", "]", () => {
+            if (is("expand", "...")) next(); // [...T]
+            _ts_type();
+            if (is("punc", ":") || is("operator", "?")) {
+                typescript_maybe_annotation(); // [name?: T]
             }
-
-            if (is("name")) {
-                typescript_type();
-                if (is("punc", ":")) {
-                    typescript_type();
-                }
-            } else {
-                typescript_type();
-            }
-
-            if (is("operator", "?")) {
-                next();
-            }
+            if (is("operator", "?")) next(); // ["value"?]
         });
     }
-    function typescript_parenthesized_parameter_list() {
+    function _ts_parenthesized_params() {
         expect("(");
-        typescript_commatized("punc", ")", typescript_parameter);
+        _ts_commatized("punc", ")", () => {
+            if (is("expand", "...")) next();
+            expect_token("name");
+            if (is("operator", "?")) next();
+            expect(":");
+            _ts_type();
+        });
         expect(")");
     }
-    function typescript_parameter() {
-        if (is("expand", "...")) next();
-
-        expect_token("name");
-        if (is("operator", "?")) next();
-        expect(":");
-        typescript_type();
-    }
-    function typescript_commatized(till_type, till, cb) {
+    function _ts_commatized(till_type, till, cb) {
         while (!(is(till_type, till))) {
             cb();
-            if (!is(till_type, till)) {
-                expect(",");
-            } else {
-                break;
-            }
+            if (!is(till_type, till)) expect(",");
         }
     }
-    function typescript_commatized_while(while_type, cb) {
+    function _ts_commatized_while(while_type, cb) {
         while (is(while_type)) {
             cb();
             if (!is("punc", ",")) break;
             next();
         }
     }
-    function typescript_commas_or_semicolons(till_type, till, cb) {
+    function _ts_commas_or_semicolons(till_type, till, cb) {
         while (!is(till_type, till)) {
             cb();
             if (!is(till_type, till)) {
                 if (is("punc", ",") || is("punc", ";")) next();
                 else if (S.token.nlb) ; // ASI
                 else typescript_croak();
-            } else {
-                break;
             }
         }
     }
-    function typescript_template_string() {
+    function _ts_template_string() {
         while (!S.token.template_end) {
-            next(); // consume a template string
-
-            typescript_type();
-            if (!is("template_cont")) {
-                typescript_croak();
-            }
+            next(); // eat "string" part
+            _ts_type(); // eat "code" part
+            if (!is("template_cont")) typescript_croak();
         }
-        next();
-    }
-    function typescript_croak() {
-        croak("invalid or unsupported TypeScript syntax");
+        next(); // eat last part
     }
 
     if (options.expression) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -3882,7 +3882,13 @@ function parse($TEXT, options) {
     function _ts_primary_type() {
         if (is("name", "readonly")) next();
 
-        if (is("punc", "(")) {
+        if (is("name", "import") && is_token(peek(), "punc", "(")) {
+            next();
+            expect("(");
+            _ts_type();
+            expect(")");
+            _ts_subscripts();
+        } else if (is("punc", "(")) {
             next();
             _ts_type();
             expect(")");
@@ -3917,17 +3923,19 @@ function parse($TEXT, options) {
     // Also used as `typeof`'s argument
     function _ts_type_name() {
         expect_token("name");
-        for (;;) {
-            if (is("punc", ".")) {
-                next();
-                expect_token("name");
-            } else if (is("punc", "[") && !is_token(peek(), "punc", "]")) {
-                expect_token("punc", "[");
-                _ts_type();
-                expect_token("punc", "]");
-            } else {
-                break;
-            }
+        _ts_subscripts();
+    }
+    function _ts_subscripts() {
+        if (is("punc", ".")) {
+            next();
+            expect_token("name");
+            return _ts_subscripts();
+        }
+        if (is("punc", "[") && !is_token(peek(), "punc", "]")) {
+            expect_token("punc", "[");
+            _ts_type();
+            expect_token("punc", "]");
+            return _ts_subscripts();
         }
     }
     function _ts_object_body() {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1244,6 +1244,14 @@ function parse($TEXT, options) {
                     return node;
                 }
             }
+            if (S.token.value === "type" && is_token(peek(), "name")) {
+                typescript_type_statement();
+                return new AST_EmptyStatement();
+            }
+            if (S.token.value === "interface" && is_token(peek(), "name")) {
+                typescript_interface_statement();
+                return new AST_EmptyStatement();
+            }
             return is_token(peek(), "punc", ":")
                 ? labeled_statement()
                 : simple_statement();
@@ -1581,6 +1589,10 @@ function parse($TEXT, options) {
 
         if (name && ctor !== AST_Accessor && !(name instanceof AST_SymbolDeclaration))
             unexpected(prev());
+
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
 
         var args = [];
         var body = _function_body(true, is_generator, is_async, name, args);
@@ -2114,7 +2126,6 @@ function parse($TEXT, options) {
      */
     function vardefs(no_in, kind) {
         var var_defs = [];
-        var def;
         for (;;) {
             var sym_type =
                 kind === "var" ? AST_SymbolVar :
@@ -2123,26 +2134,30 @@ function parse($TEXT, options) {
                 kind === "using" ? AST_SymbolUsing :
                 kind === "await using" ? AST_SymbolUsing : null;
             var def_type = kind === "using" || kind === "await using" ? AST_UsingDef : AST_VarDef;
-            // var { a } = b
-            if (is("punc", "{") || is("punc", "[")) {
-                def = new def_type({
-                    start: S.token,
-                    name: binding_element(undefined, sym_type),
-                    value: is("operator", "=") ? (expect_token("operator", "="), expression(false, no_in)) : null,
-                    end: prev()
-                });
-            } else {
-                def = new def_type({
-                    start : S.token,
-                    name  : as_symbol(sym_type),
-                    value : is("operator", "=")
-                        ? (next(), expression(false, no_in))
-                        : !no_in && (kind === "const" || kind === "using" || kind === "await using")
-                            ? croak("Missing initializer in " + kind + " declaration") : null,
-                    end   : prev()
-                });
-                if (def.name.name == "import") croak("Unexpected token: import");
+            var start = S.token;
+            var name = is("punc", "{") || is("punc", "[")
+                ? binding_element(undefined, sym_type)
+                : as_symbol(sym_type);
+
+            if (name.name == "import") croak("Unexpected token: import");
+
+            if (is("punc", ":")) {
+                next();
+                typescript_type();
             }
+
+            var value = is("operator", "=")
+                ? (next(), expression(false, no_in))
+                : !no_in && (kind === "const" || kind === "using" || kind === "await using")
+                    ? croak("Missing initializer in " + kind + " declaration")
+                    : null;
+
+            var def = new def_type({
+                start,
+                name,
+                value,
+                end: prev()
+            });
             var_defs.push(def);
             if (!is("punc", ","))
                 break;
@@ -3330,6 +3345,12 @@ function parse($TEXT, options) {
             val.end = S.token;
             next();
         }
+        if (is("name", "as")) {
+            typescript_as();
+        }
+        if (is("name", "satisfies")) {
+            typescript_satisfies();
+        }
         return val;
     };
 
@@ -3528,6 +3549,261 @@ function parse($TEXT, options) {
         var ret = cont();
         --S.in_loop;
         return ret;
+    }
+
+    // TS type stripping
+    // These functions are called when we know S.token begins some TS fluff
+    // Just call next() and friends, skipping TypeScript information
+
+    function typescript_type_parameters() {
+        expect_token("operator", "<");
+        for (;;) {
+            typescript_type_parameter();
+            if (is("punc", ",")) {
+                next();
+                if (!typescript_pop_gt_operator()) {
+                    continue;
+                }
+            }
+            break;
+        }
+
+        if (!typescript_pop_gt_operator()) {
+            typescript_croak();
+        }
+    }
+
+    function typescript_pop_gt_operator() {
+        // HACK: JS has >, >>, >>>. TS only knows >
+        if (S.token.type === "operator" && S.token.value.startsWith(">")) {
+            if (S.token.value === ">") {
+                return next();
+            } else {
+                S.token.value = S.token.value.slice(1);
+                return true;
+            }
+        }
+    }
+
+    function typescript_type_parameter() {
+        typescript_type();
+        typescript_constraint();
+    }
+
+    function typescript_constraint() {
+        if (is("keyword", "extends")) {
+            expect_token("keyword", "extends");
+            typescript_type();
+        }
+    }
+
+    function typescript_type() {
+        if (is("operator", "new")) {
+            // new(...args) => Type
+            next();
+            if (is("operator", "<")) typescript_type_parameters();
+            typescript_parenthesized_parameter_list();
+            expect_token("arrow", "=>");
+            typescript_type();
+        } else if (is("punc", "(")) {
+            // (...args) => Type
+            typescript_parenthesized_parameter_list();
+            expect_token("arrow", "=>");
+            typescript_type();
+            expect_token("punc", ")");
+        } else {
+            do {
+                if (is("operator", "|") || is("operator", "&")) next();
+                typescript_primary_type();
+            } while (is("operator", "|") || is("operator", "&"));
+        }
+    }
+
+    var TS_PREDEFINED_TYPES = makePredicate(["any", "number", "boolean", "string", "symbol", "void"]);
+    function typescript_primary_type() {
+        if (is("punc", "(")) {
+            next();
+            typescript_type();
+            expect(")");
+        } else if (is("name") && TS_PREDEFINED_TYPES.has(S.token.value)) {
+            next();
+        } else if (is("string") || is("num") || is("big_int") || is("atom")) {
+            next();
+        } else if (is("name")) {
+            typescript_type_name();
+            if (is("operator", "<")) typescript_type_parameters();
+        } else if (is("punc", "{")) {
+            typescript_type_body();
+        } else if (is("punc", "[")) {
+            next();
+            typescript_tuple_types();
+            expect_token("punc", "]");
+        } else if (is("operator", "typeof")) {
+            next();
+            typescript_type_name();
+        } else {
+            typescript_croak();
+        }
+
+        // ArrayType
+        while (is("punc", "[") && is_token(peek(), "punc", "]")) {
+            next();
+            next();
+        }
+    }
+
+    function typescript_type_name() {
+        expect_token("name");
+        while (is("punc", ".")) {
+            next();
+            expect_token("name");
+        }
+    }
+
+    function typescript_type_body() {
+        expect_token("punc", "{");
+        typescript_commas_or_semicolons("punc", "}", () => {
+            // IS A FUNCTION OR CONSTRUCTOR
+            if (
+                (is("operator", "new") && next())
+                || is("punc", "(")
+            ) {
+                typescript_parenthesized_parameter_list();
+                expect(":");
+                typescript_type();
+                return;
+            }
+
+            // KEY
+            if (is("name") || is("string")) {
+                next();
+            } else if (is("punc", "[")) {
+                next();
+                expect_token("name");
+                expect(":");
+                typescript_type();
+                expect("]");
+            } else {
+                typescript_croak();
+            }
+
+            // VALUE (method or thing)
+            if (is("punc", "(")) {
+                typescript_parenthesized_parameter_list();
+            } else if (is("punc", ":")) {
+                next();
+                typescript_type();
+            } else {
+                typescript_croak();
+            }
+        });
+        expect_token("punc", "}");
+    }
+
+    function typescript_tuple_types() {
+        typescript_commatized("punc", "]", () => {
+            if (is("expand", "...")) {
+                next();
+            }
+
+            if (is("name")) {
+                typescript_type();
+                if (is("punc", ":")) {
+                    typescript_type();
+                }
+            } else {
+                typescript_type();
+            }
+
+            if (is("operator", "?")) {
+                next();
+            }
+        });
+    }
+
+    function typescript_parenthesized_parameter_list() {
+        expect("(");
+        typescript_commatized("punc", ")", typescript_parameter);
+        expect(")");
+    }
+
+    function typescript_parameter() {
+        if (is("expand", "...")) next();
+
+        expect_token("name");
+        expect(":");
+        typescript_type();
+    }
+
+    function typescript_commatized(till_type, till, cb) {
+        if (is(till_type, till)) return;
+
+        for (;;) {
+            cb();
+
+            if (is("punc", ",")) {
+                next();
+                if (!is(till_type, till)) {
+                    continue;
+                }
+            }
+
+            break;
+        }
+    }
+
+    function typescript_commas_or_semicolons(till_type, till, cb) {
+        if (is(till_type, till)) return;
+
+        for (;;) {
+            cb();
+
+            if ((is("punc", ",") && next()) || (is("punc", ";") && next()) || S.token.nlb) {
+                if (!is(till_type, till)) {
+                    continue;
+                }
+            }
+
+            break;
+        }
+    }
+
+    function typescript_as() {
+        while (is("name", "as")) {
+            expect_token("name", "as");
+            typescript_type();
+        }
+    }
+
+    function typescript_satisfies() {
+        expect_token("name", "satisfies");
+        typescript_type();
+    }
+
+    function typescript_type_statement() {
+        expect_token("name", "type");
+        expect_token("name");
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
+        expect_token("operator", "=");
+        typescript_type();
+    }
+    function typescript_interface_statement() {
+        expect_token("name", "interface");
+        expect_token("name");
+        if (is("operator", "<")) {
+            typescript_type_parameters();
+        }
+        if (is("keyword", "extends")) {
+            next();
+            typescript_type();
+        }
+        typescript_type_body();
+    }
+
+    function typescript_croak() {
+        croak("invalid or unsupported TypeScript syntax");
     }
 
     if (options.expression) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1314,11 +1314,11 @@ function parse($TEXT, options) {
                     return node;
                 }
             }
-            if (S.token.value === "type" && is_token(peek(), "name")) {
+            if (S.token.value === "type" && is_token(peek(), "name") && !has_newline_before(peek())) {
                 typescript_type_statement();
                 return new AST_EmptyStatement();
             }
-            if (S.token.value === "interface" && is_token(peek(), "name")) {
+            if (S.token.value === "interface" && is_token(peek(), "name") && !has_newline_before(peek())) {
                 typescript_interface_statement();
                 return new AST_EmptyStatement();
             }
@@ -1629,8 +1629,6 @@ function parse($TEXT, options) {
         if (has_newline_before(S.token)) {
             croak("Unexpected newline before arrow (=>)");
         }
-
-        if (is("punc", ":")) typescript_type_annotation();
 
         expect_token("arrow", "=>");
 
@@ -2247,9 +2245,11 @@ function parse($TEXT, options) {
 
             var value = is("operator", "=")
                 ? (next(), expression(false, no_in))
-                : !no_in && (kind === "const" || kind === "using" || kind === "await using")
-                    ? croak("Missing initializer in " + kind + " declaration")
-                    : null;
+                : null;
+
+            if (!value && !no_in && (kind === "const" || kind === "using" || kind === "await using")) {
+                croak("Missing initializer in " + kind + " declaration");
+            }
 
             var def = new def_type({
                 start,
@@ -3255,8 +3255,7 @@ function parse($TEXT, options) {
             if (tmp.value === "[") {
                 next();
                 var ex = expression(false);
-                if (typescript_class_index_notation && is("punc", ":")) {
-                    typescript_type_annotation();
+                if (typescript_class_index_notation && is("punc", ":") && typescript_type_annotation()) {
                     expect("]");
                     if (is("punc", ":")) typescript_type_annotation();
                     return typescript_ellide;
@@ -3890,6 +3889,7 @@ function parse($TEXT, options) {
 
         expect_token("punc", ":");
         _ts_type();
+        return true;
     }
     function typescript_skip_this_type() {
         if (!options.experimental_typescript) return;

--- a/test/compress.js
+++ b/test/compress.js
@@ -101,9 +101,16 @@ function as_template_string_code(ast) {
     }
 }
 
-function as_toplevel(test, input, mangle_options) {
+function as_toplevel(test, input, mangle_options, parse_options) {
     var toplevel, tpl_input;
     if (input instanceof AST.AST_BlockStatement) {
+        if (parse_options) {
+            throw new Error(tmpl("When providing `parse` options, use a template string as `input`. [{line},{col}]\n{code}", {
+                line: input.start.line,
+                col: input.start.col,
+                code: make_code(input, { beautify: false })
+            }));
+        }
         for (var i = 0; i < input.body.length; i++) {
             var stat = input.body[i];
             if (stat instanceof AST.AST_SimpleStatement && stat.body instanceof AST.AST_String)
@@ -115,7 +122,7 @@ function as_toplevel(test, input, mangle_options) {
         (tpl_input = as_template_string_code(input))
     ) {
         try {
-            var toplevel = parse(tpl_input);
+            var toplevel = parse(tpl_input, parse_options);
         } catch (error) {
             log(test, "!!! Cannot parse input\n---INPUT---\n{input}\n--PARSE ERROR--\n{error}\n\n", {
                 input: tpl_input,
@@ -313,7 +320,7 @@ async function run_compress_tests(test_files, in_child_process) {
             var bad_input = as_template_string_code(test.bad_input);
             if (bad_input != null) {
                 try {
-                    var input = parse(bad_input);
+                    var input = parse(bad_input, test.parse);
                 } catch (ex) {
                     if (!test.expect_error) {
                         log(test, "!!! Test is missing an `expect_error` clause\n", {});
@@ -349,7 +356,7 @@ async function run_compress_tests(test_files, in_child_process) {
                 log(test, "!!! Test cannot have an `expect_error` clause without a template string `bad_input`\n", {});
                 return false;
             } else {
-                var input = as_toplevel(test, test.input, test.mangle);
+                var input = as_toplevel(test, test.input, test.mangle, test.parse);
                 if (!input) return false;
                 var input_code = make_code(input, output_options);
                 var input_formatted = make_code(test.input, {

--- a/test/compress/harmony.js
+++ b/test/compress/harmony.js
@@ -520,6 +520,16 @@ fat_arrow_as_param: {
     expect_exact: "foo(x=>x);foo(x=>x,y=>y);foo(x=>(x,x));foo(x=>(x,x),y=>(y,y));"
 }
 
+arrow_function_and_async_keyword: {
+    input: {
+        (async => 1);
+        (async () => 1);
+        (async (a) => 1);
+        (async(a));
+    }
+    expect_exact: "async=>1;async()=>1;async a=>1;async(a);"
+}
+
 default_assign: {
     options = {
         keep_fargs: false,

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -405,3 +405,27 @@ typescript_export_from: {
         export { a } from 'module'
     }
 }
+
+typescript_disabled_type: {
+    parse = { experimental_typescript: false }
+    input: `
+        type
+        name = 1;
+    `
+    expect: {
+        type;
+        name = 1;
+    }
+}
+typescript_disabled_interface: {
+    parse = { experimental_typescript: false }
+    input: `
+        interface
+        name
+        {};
+    `
+    expect: {
+        interface;
+        name;
+    }
+}

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -11,6 +11,17 @@ type_aliases: {
     expect: { }
 }
 
+type_tuples: {
+    parse = { experimental_typescript: true }
+    input: `
+        type Named = [1, foo: 2]
+        type Optional = [1?]
+        type Optional2 = [foo?: 2]
+        type Rest = [...T]
+    `
+    expect: { }
+}
+
 type_object: {
     parse = { experimental_typescript: true }
     input: `
@@ -38,6 +49,36 @@ type_interface: {
         }
         interface ExtendsOne extends T1 {}
         interface ExtendsMany extends T1, T2, T3, NS.T4 {}
+    `
+    expect: { }
+}
+
+type_numeric_keys: {
+    parse = { experimental_typescript: true }
+    input: `
+        interface NumericKeys {
+            1: number
+            [2]: number
+            3(): number
+            [4](): number
+            5()
+            [6]()
+        }
+    `
+    expect: { }
+}
+
+type_string_keys: {
+    parse = { experimental_typescript: true }
+    input: `
+        interface StringKeys {
+            '1': string
+            ['2']: string
+            '3'(): string
+            ['4'](): string
+            '5'()
+            ['6']()
+        }
     `
     expect: { }
 }

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -1,0 +1,241 @@
+
+type_aliases: {
+    parse = { experimental_typescript: true }
+    input: `
+        type TypeName<T extends string> = number;
+        type Union = "haha" | 2 | null;
+        type Tuple = ["string", 1];
+        type TupleReadonly = readonly ["tuple"];
+        type Heh = [1, string?];
+    `
+    expect: { }
+}
+
+type_object: {
+    parse = { experimental_typescript: true }
+    input: `
+        type Obj = {
+            property: 123 | "strings" | 1234n,
+            tuple: [number, string?],
+            new(foo: string, ...bar: Lmao[]): 1,
+            new<Type, Parameters>(): 2,
+            <T>(arg: T): T,
+            (hewwo: Type): 12345,
+        };
+    `
+    expect: { }
+}
+
+type_interface: {
+    parse = { experimental_typescript: true }
+    input: `
+        interface UwU<T> {
+            [key: string]: Value<T>;
+            semicolon: true
+            nothing: false
+            optional?: T
+            optionalMethod?(optionalParam?: boolean)
+        }
+        interface ExtendsOne extends T1 {}
+        interface ExtendsMany extends T1, T2, T3, NS.T4 {}
+    `
+    expect: { }
+}
+
+type_readonly: {
+    parse = { experimental_typescript: true }
+    input: `
+        interface ReadonlyProps {
+            readonly number: 1,
+            tuple: readonly [],
+            readonly readonlyTuple: readonly [Tuple],
+            // misdirection
+            readonly<x>(),
+            readonly: 1,
+            readonly(): 1,
+            readonly?(): 1,
+        }
+    `
+    expect: { }
+}
+
+type_body_separators: {
+    parse = { experimental_typescript: true }
+    input: `
+        interface Commas {
+            a: 1,
+            b: 2,
+        }
+        interface Semicolons {
+            a: 1;
+            b: 2;
+        }
+        interface NoComma {
+            a: 1
+            b: 2
+        }
+        interface NoTrailingComma {
+            a: 1
+        }
+    `
+    expect: { }
+}
+
+typed_declarations: {
+    parse = { experimental_typescript: true }
+    input: `
+        var x: number = 3 as string;
+        const x2 = {} satisfies BigInt;
+        var y: typeof func = 3;
+        var z: typeof func.property['computed'] = 4;
+        try { } catch (e: ErrorType) {};
+    `
+    expect: {
+        var x = 3;
+        const x2 = {};
+        var y = 3;
+        var z = 4;
+        try { } catch (e) {};
+    }
+}
+
+type_parameters_calls: {
+    parse = { experimental_typescript: true }
+    input: `
+        callExpression<T>(arg);
+        optionalCallExpression?.<T>(arg);
+        optionalCallExpression2<T>?.(arg);
+        method.call<T>(arg);
+    `
+    expect: {
+        callExpression(arg);
+        optionalCallExpression?.(arg);
+        optionalCallExpression2?.(arg);
+        method.call(arg);
+    }
+}
+
+type_parameters: {
+    parse = { experimental_typescript: true }
+    input: `
+        function functionDeclaration<T extends Foo.Bar = 1>(this: Type): ReturnType { }
+        ;(function functionExpression<T extends Foo.Bar = 1>(this: Type): ReturnType { })
+        const arrowBlock = <T>(): ReturnType => { }
+        const arrowExpr = <T>(): ReturnType => expr()
+        const asyncArrow = async (typed: Type) => null
+        const asyncArrowT = async <T>(typed: Type) => null
+        call<T>(1);
+        call<T1, T2>();
+    `
+    expect: {
+        function functionDeclaration() { }
+        ;(function functionExpression() { })
+        const arrowBlock = () => { }
+        const arrowExpr = () => expr()
+        const asyncArrow = async (typed) => null
+        const asyncArrowT = async (typed) => null
+        call(1);
+        call();
+    }
+}
+
+typed_function_args: {
+    parse = { experimental_typescript: true }
+    input: `
+        function args(this: Type, typed: Type, untyped, optional?: number, { destructured }: Typed, ...rest: any[]): Ret {}
+        const arrowFunctionArgs = (typed: Type, untyped, optional?: number, { destructured }: Typed, ...rest: any[]): Ret => {}
+    `
+    expect: {
+        function args(typed, untyped, optional, { destructured }, ...rest) {}
+        const arrowFunctionArgs = (typed, untyped, optional, { destructured }, ...rest) => {}
+    }
+}
+
+typed_class_head: {
+    parse = { experimental_typescript: true }
+    input: `
+        class ClassTypeParameters<T> {}
+        class ClassImplements implements Type {}
+        class ClassExtendsImplements extends OtherClass implements Type {}
+        class ClassImplementsMany extends OtherClass implements T1, T2 {}
+    `
+    expect: {
+        class ClassTypeParameters {}
+        class ClassImplements {}
+        class ClassExtendsImplements extends OtherClass {}
+        class ClassImplementsMany extends OtherClass {}
+    }
+}
+
+
+typed_class_elements: {
+    parse = { experimental_typescript: true }
+    input: `
+        class ClassElements {
+            constructor() // no impl. should not appear in output
+            private constructor(typed: Type) {}
+
+            protected static declared<TypeParams>(arg: Typed) // no impl
+            protected static declared<TypeParams>(arg: Typed) {}
+
+            private static readonly 3: number = 3
+            private static get foo<T>(): Type {}
+            private static set foo<T>(value: Type): Type {}
+
+            [ident: string]: number
+        }
+    `
+    expect: {
+        class ClassElements {
+            constructor(typed) {}
+
+            static declared(arg) {}
+
+            static 3 = 3
+            static get foo() {}
+            static set foo(value) {}
+        }
+    }
+}
+
+typed_objects: {
+    parse = { experimental_typescript: true }
+    input: `
+        const object = {
+            get property(): number { },
+            set property(arg: Type) { },
+        }
+    `
+    expect: {
+        const object = {
+            get property() { },
+            set property(arg) { },
+        }
+    }
+}
+
+typescript_ambiguous_with_comparison_syntax: {
+    parse = { experimental_typescript: true }
+    input: `
+        ambiguous<">">(1)
+        ambiguous<"]">(1)
+        ambiguous<T
+            // >
+        >(1)
+        ambiguous<T/* > */>(1)
+        ambiguous<\`>\`>(1)
+        ambiguous<\`]\`>(1)
+        ambiguous<\`foo $\{T} bar\`>(1)
+        ambiguous<\`$\{[">"]}\`>(1)
+    `
+    expect: {
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+        ambiguous(1);
+    }
+}

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -280,3 +280,12 @@ typescript_ambiguous_with_comparison_syntax: {
         ambiguous(1);
     }
 }
+
+typescript_dynamic_imports: {
+    parse = { experimental_typescript: true }
+    input: `
+        type T = import('./module.ts')
+        type TDot = import('./module.ts').Property
+    `
+    expect: {}
+}

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -284,8 +284,124 @@ typescript_ambiguous_with_comparison_syntax: {
 typescript_dynamic_imports: {
     parse = { experimental_typescript: true }
     input: `
-        type T = import('./module.ts')
-        type TDot = import('./module.ts').Property
+        type T = import('module')
+        type TDot = import('module').Property
     `
     expect: {}
+}
+
+typescript_imports: {
+    parse = { experimental_typescript: true }
+    input: `
+        // fully typescript imports
+        import type Default from "module"
+        import type * as Star from "module"
+        import type { Named } from "module"
+        import type { Named as Renamed } from "module"
+        import type { default as NamedDefault } from "module"
+        import type A, { F } from 'module'
+
+        // partially typescript imports
+        import { Partial, type Removed } from "module"
+        import { Partial, type Removed as RenamedRemoved } from "module"
+
+        // misdirection
+        import type from 'module'
+        import { type } from 'module'
+        import { type as Renamed } from 'module'
+        import type, { A } from 'module'
+    `
+    expect: {
+        // fully typescript imports
+        // (ellided)
+
+        // partially typescript imports
+        import { Partial } from "module"
+        import { Partial } from "module"
+
+        // misdirection
+        import type from 'module'
+        import { type } from 'module'
+        import { type as Renamed } from 'module'
+        import type, { A } from 'module'
+    }
+}
+
+typescript_imports_incompatible_with_estree_test: {
+    parse = { experimental_typescript: true }
+    input: `
+        import { type 'string' as NamedStringType } from "module"
+        import { type default as NamedDefaultType } from "module"
+        import A, { type F } from 'module'
+    `
+    expect: {
+        import {  } from "module"
+        import {  } from "module"
+        import A, { } from "module"
+    }
+    no_mozilla_ast = true // ESTree can't represent the "{ }"
+}
+
+typescript_exports: {
+    parse = { experimental_typescript: true }
+    input: `
+        // fully typescript exports
+        export type X = 1
+        export interface Interface {}
+        export type { X }
+        export type { X as Y }
+        export type { X as default }
+        export type { X as 'stringly' }
+
+        // partially typescript exports
+        export { Value, type X }
+        export { OtherValue, type X as Y }
+        export { OtherValue, type X as default }
+        export { OtherValue, type X as 'stringly' }
+    `
+    expect: {
+        // fully typescript exports
+        // (ellided)
+
+        // partially typescript exports
+        export { Value }
+        export { OtherValue }
+        export { OtherValue }
+        export { OtherValue }
+    }
+}
+
+typescript_export_from: {
+    parse = { experimental_typescript: true }
+    input: `
+        // fully typescript export-from
+        export type * from 'module'
+        export type * as NamedStar from 'module'
+        export type { X } from 'module'
+        export type { X as Y } from 'module'
+        export type { default } from 'module'
+        export type { 'stringly' as default } from 'module'
+        export type { 'stringly' } from 'module'
+        export type { 'stringly' as 'otherstringly' } from 'module'
+
+        // partially typescript export-from
+        export { a, type X } from 'module'
+        export { a, type X as Y } from 'module'
+        export { a, type default } from 'module'
+        export { a, type 'stringly' as default } from 'module'
+        export { a, type 'stringly' } from 'module'
+        export { a, type 'stringly' as 'otherstringly' } from 'module'
+    `
+    expect: {
+        // fully typescript export-from
+        // (ellided)
+
+        // partially typescript export-from
+        export { a } from 'module'
+        export { a } from 'module'
+        export { a } from 'module'
+        export { a } from 'module'
+        export { a } from 'module'
+        export { a } from 'module'
+    }
 }

--- a/test/compress/typescript.js
+++ b/test/compress/typescript.js
@@ -406,8 +406,109 @@ typescript_export_from: {
     }
 }
 
+// Counter examples
+typescript_disabled_forward_declaration: {
+    bad_input: `function forward();`
+    expect_error: ({ pos: 18 })
+}
+typescript_disabled_async_forward_declaration: {
+    bad_input: `async function forward();`
+    expect_error: ({ pos: 24 })
+}
+typescript_disabled_method_forward_declaration: {
+    bad_input: `(class{forward();});`
+    expect_error: ({ pos: 16 })
+}
+typescript_disabled_type_parameters: {
+    bad_input: `function params<T>() {}`
+    expect_error: ({ pos: 15 })
+}
+typescript_disabled_call_type_parameters: {
+    bad_input: `params<T>();`
+    expect_error: ({ pos: 11 })
+}
+typescript_disabled_call_type_parameters_are_valid_js: {
+    input: `params<T>(1, 2);`
+    expect: { params < T > (1, 2); }
+}
+typescript_disabled_type_parameters_arrow: {
+    bad_input: `var x = <T>(arg) => null`
+    expect_error: ({ pos: 8 })
+}
+typescript_disabled_type_parameters_async_arrow: {
+    bad_input: `var x = lmao <T>(arg) => null`
+    expect_error: ({ pos: 22 })
+}
+typescript_disabled_arg_type: {
+    bad_input: `(function(arg: T) {})`
+    expect_error: ({ pos: 13 })
+}
+typescript_disabled_ret_type: {
+    bad_input: `(function(arg): T {})`
+    expect_error: ({ pos: 14 })
+}
+typescript_disabled_this_arg_type: {
+    bad_input: `(function(this: T) {})`
+    expect_error: ({ pos: 10 })
+}
+typescript_disabled_this_arg: {
+    bad_input: `(function(this) {})`
+    expect_error: ({ pos: 10 })
+}
+typescript_disabled_arrow_arg_type: {
+    bad_input: `var x = (arg: T) => null`
+    expect_error: ({ pos: 12 })
+}
+typescript_disabled_arrow_ret_type: {
+    bad_input: `var x = (arg): Ret => null`
+    expect_error: ({ pos: 13 })
+}
+typescript_disabled_typed_vardecl: {
+    bad_input: `var x: num`
+    expect_error: ({ pos: 5 })
+}
+typescript_disabled_declared_method: {
+    bad_input: `(class{meth();meth(){}})`
+    expect_error: ({ pos: 13 })
+}
+typescript_disabled_class_implements: {
+    bad_input: `class X implements T{}`
+    expect_error: ({ pos: 8 })
+}
+typescript_disabled_class_tricky_fields: {
+    input: `
+        class X {
+            private() {}
+            public() {}
+            protected() {}
+            readonly() {}
+            private
+            public
+            protected
+            readonly
+        }
+        console.log(new X);
+    `
+    expect_stdout: true
+}
+typescript_disabled_import_type: {
+    bad_input: `import type X from "module";`
+    expect_error: ({ pos: 12 })
+}
+typescript_disabled_import_type_2: {
+    bad_input: `import { type X } from "module";`
+    expect_error: ({ pos: 14 })
+}
+typescript_disabled_as: {
+    bad_input: `x as T;`
+    expect_error: ({ pos: 2 })
+}
+typescript_disabled_satisfies: {
+    bad_input: `x satisfies T;`
+    expect_error: ({ pos: 2 })
+}
+
 typescript_disabled_type: {
-    parse = { experimental_typescript: false }
     input: `
         type
         name = 1;
@@ -418,7 +519,6 @@ typescript_disabled_type: {
     }
 }
 typescript_disabled_interface: {
-    parse = { experimental_typescript: false }
     input: `
         interface
         name

--- a/test/mocha/tokens.js
+++ b/test/mocha/tokens.js
@@ -24,8 +24,8 @@ describe("tokens", function() {
     });
 
     it("Should give correct positions for accessors", async function() {
-        // location             0         1         2         3         4
-        //                      01234567890123456789012345678901234567890123456789
+        // location      0         1         2         3         4
+        //               01234567890123456789012345678901234567890123456789
         var ast = parse("var obj = { get latest() { return undefined; } }");
         // test all AST_ObjectProperty tokens are set as expected
         var found = false;


### PR DESCRIPTION
Parse some [TypeScript erasable syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option) and eliminate it.

The objective here is to have the option to parse & ignore typescript, so that it's possible to use TypeScript in Terser without another compiler, just like we can with nodejs.

Like with other bits of our parser, we're not looking for correctness. As long as all valid types are skipped correctly, the goal is met. Terser will not validate TypeScript correctness.

See also: https://github.com/bloomberg/ts-blank-space

Not done:

- [x] test the else-branches (going into the regular parser)

Not planned for now:

- [ ] testing the typescript part too much
- [ ] supporting code-generating syntax such as `enum`, `namespace`, `public/private` arguments in constructors.
- [ ] supporting syntax like `declare` or pure `namespace`s