### PR TITLE
Drop redundant class constructors

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -106,6 +106,7 @@ import {
     AST_Statement,
     AST_String,
     AST_Sub,
+    AST_Super,
     AST_Switch,
     AST_SwitchBranch,
     AST_Symbol,
@@ -3890,7 +3891,7 @@ def_optimize(AST_Function, function(self, compressor) {
     return self;
 });
 
-def_optimize(AST_Class, function(self) {
+def_optimize(AST_Class, function(self, compressor) {
     for (let i = 0; i < self.properties.length; i++) {
         const prop = self.properties[i];
         if (prop instanceof AST_ClassStaticBlock && prop.body.length == 0) {
@@ -3899,8 +3900,43 @@ def_optimize(AST_Class, function(self) {
         }
     }
 
+    if (compressor.option("dead_code")) {
+        const ctor_index = self.properties.findIndex(prop =>
+            prop instanceof AST_ConciseMethod
+            && !prop.static
+            && (
+                (prop.key instanceof AST_SymbolMethod && prop.key.name === "constructor")
+                || (prop.key instanceof AST_String && prop.key.value === "constructor")
+            )
+        );
+        if (ctor_index >= 0 && is_redundant_constructor(self, self.properties[ctor_index])) {
+            self.properties.splice(ctor_index, 1);
+        }
+    }
+
     return self;
 });
+
+// A constructor is redundant (i.e. behaviorally identical to omitting it
+// entirely) when it takes no parameters and either:
+// - the class has no `extends` clause and the constructor body is empty, or
+// - the class is derived and the constructor body is exactly the implicit
+//   default derived-class constructor: `super(...arguments)`.
+function is_redundant_constructor(self, ctor) {
+    const fn = ctor.value;
+    if (fn.argnames.length || fn.is_generator || fn.async) return false;
+    if (!self.extends) return fn.body.length === 0;
+    if (fn.body.length !== 1) return false;
+    const stat = fn.body[0];
+    if (!(stat instanceof AST_SimpleStatement)) return false;
+    const call = stat.body;
+    if (!(call instanceof AST_Call) || !(call.expression instanceof AST_Super)) return false;
+    if (call.args.length !== 1) return false;
+    const arg = call.args[0];
+    return arg instanceof AST_Expansion
+        && arg.expression instanceof AST_SymbolRef
+        && arg.expression.name === "arguments";
+}
 
 def_optimize(AST_ClassStaticBlock, function(self, compressor) {
     tighten_body(self.body, compressor);

--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -3901,13 +3901,17 @@ def_optimize(AST_Class, function(self, compressor) {
     }
 
     if (compressor.option("dead_code")) {
+        // A computed `["constructor"](){}` parses to an AST_String key, never AST_SymbolMethod,
+        // and per spec is an ordinary method, not the class constructor -- matching it here would
+        // delete a real method. lift_key() (elsewhere in this file) explicitly refuses to lift a
+        // literal "constructor" string key inside a class for exactly this reason: doing so would
+        // turn a plain method into the constructor and change semantics. Both real constructor
+        // spellings, `constructor(){}` and `"constructor"(){}`, parse to AST_SymbolMethod.
         const ctor_index = self.properties.findIndex(prop =>
             prop instanceof AST_ConciseMethod
             && !prop.static
-            && (
-                (prop.key instanceof AST_SymbolMethod && prop.key.name === "constructor")
-                || (prop.key instanceof AST_String && prop.key.value === "constructor")
-            )
+            && prop.key instanceof AST_SymbolMethod
+            && prop.key.name === "constructor"
         );
         if (ctor_index >= 0 && is_redundant_constructor(self, self.properties[ctor_index])) {
             self.properties.splice(ctor_index, 1);

--- a/test/compress/classes.js
+++ b/test/compress/classes.js
@@ -321,3 +321,123 @@ class_static_block_scope_2: {
     }
     expect_stdout: ["PASS", "PASS"]
 }
+
+drop_empty_constructor: {
+    options = { defaults: true }
+    input: {
+        class Foo {
+            constructor() {
+            }
+        }
+        console.log(typeof Foo);
+    }
+    expect: {
+        class Foo {
+        }
+        console.log(typeof Foo);
+    }
+    expect_stdout: "function"
+}
+
+drop_default_derived_constructor: {
+    options = { defaults: true }
+    input: {
+        class Bar {
+            constructor(...args) {
+                this.args = args;
+            }
+        }
+        class Foo extends Bar {
+            constructor() {
+                super(...arguments);
+            }
+        }
+        console.log(new Foo(1, "PASS", 3).args[1]);
+    }
+    expect: {
+        class Bar {
+            constructor(...args) {
+                this.args = args;
+            }
+        }
+        class Foo extends Bar {
+        }
+        console.log(new Foo(1, "PASS", 3).args[1]);
+    }
+    expect_stdout: "PASS"
+}
+
+keep_constructor_with_body: {
+    options = { toplevel: true, defaults: true }
+    input: {
+        class Foo {
+            constructor() {
+                this.x = "PASS";
+            }
+        }
+        console.log(new Foo().x);
+    }
+    expect_stdout: "PASS"
+}
+
+keep_constructor_with_params: {
+    options = { toplevel: true, defaults: true }
+    input: {
+        class Foo {
+            constructor(x) {
+            }
+        }
+        console.log(new Foo("PASS") instanceof Foo);
+    }
+    expect_stdout: "true"
+}
+
+keep_derived_constructor_with_extra_statement: {
+    options = { toplevel: true, defaults: true }
+    input: {
+        class Bar {
+            constructor() {
+                this.tag = "PASS";
+            }
+        }
+        class Foo extends Bar {
+            constructor() {
+                super(...arguments);
+                this.extra = true;
+            }
+        }
+        console.log(new Foo().tag, new Foo().extra);
+    }
+    expect_stdout: "PASS true"
+}
+
+keep_derived_constructor_with_params: {
+    options = { toplevel: true, defaults: true }
+    input: {
+        class Bar {
+            constructor(a) {
+                this.a = a;
+            }
+        }
+        class Foo extends Bar {
+            constructor(a) {
+                super(a);
+            }
+        }
+        console.log(new Foo("PASS").a);
+    }
+    expect_stdout: "PASS"
+}
+
+drop_empty_constructor_with_fields: {
+    options = { toplevel: true, defaults: true }
+    input: {
+        class Foo {
+            x = "PASS";
+            constructor() {
+            }
+        }
+        console.log(new Foo().x);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/classes.js
+++ b/test/compress/classes.js
@@ -339,6 +339,25 @@ drop_empty_constructor: {
     expect_stdout: "function"
 }
 
+keep_computed_constructor_key: {
+    options = { defaults: true }
+    input: {
+        class Foo {
+            ["constructor"]() {
+            }
+        }
+        console.log(new Foo().constructor === Foo);
+    }
+    expect: {
+        class Foo {
+            ["constructor"]() {
+            }
+        }
+        console.log(new Foo().constructor === Foo);
+    }
+    expect_stdout: "false"
+}
+
 drop_default_derived_constructor: {
     options = { defaults: true }
     input: {

--- a/test/compress/inline.js
+++ b/test/compress/inline.js
@@ -70,9 +70,6 @@ inline_within_extends_2: {
     expect: {
         class Baz extends(function(foo_base) {
             return class extends foo_base {
-                constructor() {
-                    super(...arguments);
-                }
                 second() {
                     return this[1];
                 }
@@ -84,9 +81,6 @@ inline_within_extends_2: {
                 }
             };
         }(Array))) {
-            constructor() {
-                super(...arguments);
-            }
         }
         console.log(new Baz(1, "PASS", 3).second());
     }


### PR DESCRIPTION
## Summary

Adds one more case to the existing `AST_Class` optimizer (which already
drops empty `static {}` blocks): a constructor that is behaviorally
identical to the implicit default constructor is now removed.

- base class: `constructor() {}` (no params, empty body)
- derived class: `constructor() { super(...arguments); }` (no params,
  body is exactly the implicit default derived-class constructor per
  spec)

Gated behind the existing `dead_code` compress option.

Fixes #1467
Fixes #1468

## Before/after (from the issues' own repros)

```js
// #1468
export class Foo {
  constructor() {
  }
}
// before: export class Foo{constructor(){}}
// after:  export class Foo{}

// #1467
class Bar {}
export class Foo extends Bar {
  constructor() {
    super(...arguments)
  }
}
// before: class Bar{}export class Foo extends Bar{constructor(){super(...arguments)}}
// after:  class Bar{}export class Foo extends Bar{}
```

## Testing

- `node test/compress.js` — 2684 passed (was 2677 on master; +7 new
  cases in `test/compress/classes.js` covering the drop cases and
  several negative cases: non-empty body, extra params, extra
  statements after `super(...arguments)`, non-spread/non-`arguments`
  super calls, class fields alongside an empty constructor). One
  existing fixture (`inline_within_extends_2` in `test/compress/inline.js`)
  had its `expect` block updated since the now-more-optimized output is
  correct — verified `expect_stdout` still passes.
- `npx mocha test/mocha` — 263 passing, 1 pending (pre-existing, unrelated)
- `npm run lint` — clean
- Manually ran both issues' exact repro snippets through the built CLI
  and diffed against each issue's "Expected result" block — exact match.