### PR TITLE
Fix boolean context through nullish coalescing

### DIFF
--- a/lib/compress/index.js
+++ b/lib/compress/index.js
@@ -376,7 +376,7 @@ class Compressor extends TreeWalker {
                     && (
                         p.operator == "&&"
                         || p.operator == "||"
-                        || p.operator == "??"
+                        || p.operator == "??" && p.right === self
                     )
                 || p instanceof AST_Conditional
                 || p.tail_node() === self

--- a/test/compress/nullish.js
+++ b/test/compress/nullish.js
@@ -119,6 +119,41 @@ nullish_coalescing_boolean_context: {
     }
 }
 
+nullish_coalescing_left_operand_preserves_nullishness: {
+    options = {
+        booleans: true,
+        conditionals: true,
+    }
+
+    input: {
+        function f(a, b) {
+            return (a == null ? null : a.x) ?? b ? 1 : 2;
+        }
+        console.log(f(null, "fallback"));
+    }
+
+    expect_stdout: "1"
+}
+
+nullish_coalescing_right_operand_uses_boolean_context: {
+    options = {
+        booleans: true,
+        conditionals: true,
+    }
+
+    input: {
+        function f(a, b, c) {
+            return a ?? (b ? c : null) ? 1 : 2;
+        }
+    }
+
+    expect: {
+        function f(a, b, c) {
+            return a ?? (b && c) ? 1 : 2;
+        }
+    }
+}
+
 nullish_coalescing_mandatory_parens: {
     input: {
         (x ?? y) || z;


### PR DESCRIPTION
Fixes #1719

## Problem

A conditional in the left operand of `??` inherited boolean context from an outer conditional. Terser could then rewrite a `null` result to `false`, changing which side of `??` was selected.

## Root cause

`Compressor.in_boolean_context()` propagated boolean context through both children of `??`. Its left child is selected by nullishness, not truthiness.

## Change

Propagate boolean context through `??` only for its right child. Add:

- an executable regression test for the reported branch change
- a characterization test preserving the valid right-child optimization

## Proof

- RED: the reported case printed `2` instead of `1`
- `node test/compress.js nullish.js`: 10 passed
- `npm test`: 2,679 compressor cases and 263 Mocha tests passed; one existing pending
- `npm run build`
- `npm run lint`
- `npm run ls-lint`

The change is limited to the context walk and nullish tests.
