### PR TITLE
docs: recommend native source map support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,12 @@ https://opencollective.com/terser
 
 **Complete CLI command or `minify()` options used**
 
-<!-- Note: if you used the node API directly, you're expected to enable the source-map-support module such that your stack traces make sense. -->
+<!--
+If you used the Node.js API directly, enable source maps so stack traces make
+sense. Pass `--enable-source-maps` to Node.js, or set it through `NODE_OPTIONS`
+when another tool launches Node.js. Older Node.js versions can use the
+source-map-support package instead.
+-->
 
 **`terser` input**
 

--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,25 @@ If you're not sure how to set an environment variable on your shell (the above e
 
 ## Stack traces
 
-In the terser CLI we use [source-map-support](https://npmjs.com/source-map-support) to produce good error stacks. In your own app, you're expected to enable source-map-support (read their docs) to have nice stack traces that will help you write good issues.
+The Terser CLI uses
+[source-map-support](https://npmjs.com/source-map-support) to produce useful
+error stacks. When using Terser through the Node.js API, enable Node.js'
+[native source map support](https://nodejs.org/api/cli.html#--enable-source-maps)
+so stack traces point back to the original source:
+
+```sh
+node --enable-source-maps your-script.js
+```
+
+If another tool launches the Node.js process, pass the flag through
+`NODE_OPTIONS` instead:
+
+```sh
+NODE_OPTIONS=--enable-source-maps your-command
+```
+
+On Node.js versions that do not support this flag, install and register the
+`source-map-support` package instead.
 
 <!-- REPORTING_ISSUES:END -->
 


### PR DESCRIPTION
## Summary

- document Node.js native `--enable-source-maps` for API users
- show `NODE_OPTIONS` for tools that launch Node.js indirectly
- update the issue template while keeping the fallback for older Node.js versions

## Validation

- `git diff --check`
- verified both the direct flag and `NODE_OPTIONS` on Node.js v22.22.3
- documentation-only change; no dependency install or runtime test suite needed

Closes #732