### PR TITLE
fix: do not fold assignments into objects with computed accessors

### DIFF
--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -54,6 +54,7 @@ import {
     AST_Case,
     AST_Chain,
     AST_Class,
+    AST_ConciseMethod,
     AST_Conditional,
     AST_Constant,
     AST_Continue,
@@ -80,8 +81,10 @@ import {
     AST_Node,
     AST_Number,
     AST_Object,
+    AST_ObjectGetter,
     AST_ObjectKeyVal,
     AST_ObjectProperty,
+    AST_ObjectSetter,
     AST_PropAccess,
     AST_RegExp,
     AST_Return,
@@ -1410,6 +1413,19 @@ export function tighten_body(statements, compressor) {
             if (prop instanceof AST_Node)
                 break;
             prop = "" + prop;
+            // Computed accessors/methods are not known statically.
+            // The .name check below reads the expression identifier
+            // (k in set [k]), so a later o.x = ... would be folded
+            // in beside the accessor and skip the setter/getter.
+            // https://github.com/terser/terser/issues/1709
+            if (def.value.properties.some(function (node) {
+                return (node instanceof AST_ObjectGetter
+                    || node instanceof AST_ObjectSetter
+                    || node instanceof AST_ConciseMethod)
+                    && node.computed_key();
+            })) {
+                break;
+            }
             var diff = compressor.option("ecma") < 2015
                 && compressor.has_directive("use strict") ? function (node) {
                     return node.key != prop && (node.key && node.key.name != prop);

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1948,6 +1948,48 @@ join_object_assignments_regex: {
     expect_stdout: "1"
 }
 
+join_object_assignments_computed_setter: {
+    options = {
+        join_vars: true,
+    }
+    input: {
+        const k = "x";
+        const o = {
+            set [k](v) { console.log("setter ran:", v); }
+        };
+        o.x = 1;
+    }
+    expect: {
+        const k = "x", o = {
+            set [k](v) { console.log("setter ran:", v); }
+        };
+        o.x = 1;
+    }
+    expect_stdout: "setter ran: 1"
+}
+
+join_object_assignments_computed_getter: {
+    options = {
+        join_vars: true,
+    }
+    input: {
+        const k = "x";
+        const o = {
+            get [k]() { return 4; }
+        };
+        o.x = 8;
+        console.log(o.x);
+    }
+    expect: {
+        const k = "x", o = {
+            get [k]() { return 4; }
+        };
+        o.x = 8;
+        console.log(o.x);
+    }
+    expect_stdout: "4"
+}
+
 issue_2816: {
     options = {
         join_vars: true,


### PR DESCRIPTION
Fixes #1709.

`join_vars` folds later property assignments into an object literal. Collision detection uses `node.key.name`, which for a computed accessor is the expression identifier (`k` in `set [k]`), not the runtime key. That lets `o.x = 1` become a data property on `{ set [k](v) { ... } }` when `k` is `"x"`, so the setter never runs.

```js
const k = "x";
const o = {
    set [k](v) { console.log("setter ran:", v); }
};
o.x = 1;
```

was compressed to:

```js
const k = "x", o = {
    set [k](v) { console.log("setter ran:", v); },
    x: 1
};
```

### Fix

Stop folding assignments into an object that already has a computed getter, setter, or concise method. Those keys are not known statically, so the existing `.name` check cannot tell them apart from a later `o.x = ...`.

Static accessors (`set x(v)`) are unchanged: `key.name` is already `"x"`, so a colliding assignment is still refused.

After the fix, `join_vars` may still merge the `const` declarations, but the assignment stays outside the literal:

```js
const k = "x", o = {
    set [k](v) { console.log("setter ran:", v); }
};
o.x = 1;
```

### Tests

Added `join_object_assignments_computed_setter` and `join_object_assignments_computed_getter` in `test/compress/properties.js`.

- `npm run lint` (eslint lib) passes
- `npm test`: 2681 compress cases, 263 mocha passing