### PR TITLE
fix: preserve mixed BigInt operation errors

### DIFF
--- a/lib/compress/drop-side-effect-free.js
+++ b/lib/compress/drop-side-effect-free.js
@@ -85,7 +85,12 @@ import { make_node, return_null, return_this } from "../utils/index.js";
 import { first_in_statement } from "../utils/first_in_statement.js";
 
 import { pure_prop_access_globals } from "./native-objects.js";
-import { lazy_op, unary_side_effects, is_nullish_shortcircuited } from "./inference.js";
+import {
+    binary_may_throw,
+    lazy_op,
+    unary_side_effects,
+    is_nullish_shortcircuited,
+} from "./inference.js";
 import { WRITE_ONLY, set_flag, clear_flag } from "./compressor-flags.js";
 import { make_sequence, is_func_expr, is_iife_call } from "./common.js";
 
@@ -213,6 +218,7 @@ def_drop_side_effect_free([
 });
 
 def_drop_side_effect_free(AST_Binary, function (compressor, first_in_statement) {
+    if (binary_may_throw(this, compressor)) return this;
     var right = this.right.drop_side_effect_free(compressor);
     if (!right)
         return this.left.drop_side_effect_free(compressor, first_in_statement);

--- a/lib/compress/inference.js
+++ b/lib/compress/inference.js
@@ -142,6 +142,17 @@ export const bitwise_binop = makePredicate("<<< >> << & | ^ ~");
 export const lazy_op = makePredicate("&& || ??");
 export const unary_side_effects = makePredicate("delete ++ --");
 
+const mixed_numeric_ops = makePredicate("+ - * / % ** & | ^ << >>");
+
+export function binary_may_throw(node, compressor) {
+    if (mixed_numeric_ops.has(node.operator)) {
+        return node.left.is_bigint(compressor) && node.right.is_number(compressor)
+            || node.left.is_number(compressor) && node.right.is_bigint(compressor);
+    }
+    return node.operator == ">>>"
+        && (node.left.is_bigint(compressor) || node.right.is_bigint(compressor));
+}
+
 // methods to determine whether an expression has a boolean result type
 (function(def_is_boolean) {
     const unary_bool = makePredicate("! delete");
@@ -425,7 +436,8 @@ export function is_nullish(node, compressor) {
         return any(this.body, compressor);
     });
     def_has_side_effects(AST_Binary, function(compressor) {
-        return this.left.has_side_effects(compressor)
+        return binary_may_throw(this, compressor)
+            || this.left.has_side_effects(compressor)
             || this.right.has_side_effects(compressor);
     });
     def_has_side_effects(AST_Assign, return_true);
@@ -558,7 +570,8 @@ export function is_nullish(node, compressor) {
         return this.left.may_throw(compressor);
     });
     def_may_throw(AST_Binary, function(compressor) {
-        return this.left.may_throw(compressor)
+        return binary_may_throw(this, compressor)
+            || this.left.may_throw(compressor)
             || this.right.may_throw(compressor);
     });
     def_may_throw(AST_Block, function(compressor) {

--- a/test/compress/big_int.js
+++ b/test/compress/big_int.js
@@ -93,6 +93,29 @@ big_int_math_counter_examples: {
     expect_stdout: true
 }
 
+big_int_mixed_types_have_side_effects: {
+    node_version = ">= 12"
+    options = {
+        side_effects: true
+    }
+    input: {
+        0n + 0;
+        0 - 0n;
+        0n * 0;
+        0 / 0n;
+        0n % 0;
+        0 ** 0n;
+        0n & 0;
+        0 | 0n;
+        0n ^ 0;
+        0 << 0n;
+        0n >> 0;
+        0n >>> 0n;
+    }
+    expect_exact: "0n+0;0-0n;0n*0;0/0n;0n%0;0**0n;0n&0;0|0n;0n^0;0<<0n;0n>>0;0n>>>0n;"
+    expect_stdout: true
+}
+
 big_int_slow_math_counter_examples: {
     node_version = ">= 12"
     options = {


### PR DESCRIPTION
Closes #1301.

An unused mixed BigInt/Number expression such as `0n * 0` must throw a `TypeError`, but the side-effect trimming path reduced both operands independently and removed the operation.

This adds a shared check for binary operations that are known to reject mixed numeric types, and uses it from side-effect detection, throw inference, and side-effect trimming. Same-type Number and BigInt expressions remain removable when their results are unused.

### Tests

- `npm test` (2680 compressor cases; 263 Mocha tests passed, 1 pending)
- `npm run lint`
- `npm run ls-lint`
- `npm run build`
