### PR TITLE
keep CaseBlock function declarations when dropping dead switch cases

### DIFF
--- a/lib/compress/tighten-body.js
+++ b/lib/compress/tighten-body.js
@@ -90,6 +90,7 @@ import {
     AST_SimpleStatement,
     AST_Sub,
     AST_Switch,
+    AST_SwitchBranch,
     AST_Symbol,
     AST_SymbolConst,
     AST_SymbolDeclaration,
@@ -199,18 +200,24 @@ export function extract_from_unreachable_code(compressor, stat, target) {
             if (no_initializers) target.push(no_initializers);
             return true;
         }
-        if (
-            node instanceof AST_Defun
-            && (node === stat || !compressor.has_directive("use strict"))
-        ) {
-            target.push(node === stat ? node : make_node(AST_Var, node, {
-                definitions: [
-                    make_node(AST_VarDef, node, {
-                        name: make_node(AST_SymbolVar, node.name, node.name),
-                        value: null
-                    })
-                ]
-            }));
+        if (node instanceof AST_Defun) {
+            // Direct case/default FunctionDeclarations belong to the
+            // CaseBlock and are initialized before case selection.
+            // Nested ones (if/block) still follow the sloppy `var`
+            // extraction below.
+            const keep_defun = node === stat
+                || (stat instanceof AST_SwitchBranch
+                    && stat.body.indexOf(node) >= 0);
+            if (keep_defun || !compressor.has_directive("use strict")) {
+                target.push(keep_defun ? node : make_node(AST_Var, node, {
+                    definitions: [
+                        make_node(AST_VarDef, node, {
+                            name: make_node(AST_SymbolVar, node.name, node.name),
+                            value: null
+                        })
+                    ]
+                }));
+            }
             return true;
         }
         if (node instanceof AST_Export || node instanceof AST_Import) {

--- a/test/compress/switch.js
+++ b/test/compress/switch.js
@@ -3258,3 +3258,112 @@ regression_retain_var_in_eliminated_default: {
     }
     expect_stdout: "100"
 }
+
+issue_1729_case_block_defun: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        side_effects: true,
+        switches: true,
+    }
+    input: {
+        switch (0) {
+          case 0:
+            console.log(g());
+            break;
+          case 1:
+            function g() { return "fn"; }
+        }
+    }
+    expect: {
+        {
+            function g() {
+                return "fn";
+            }
+            console.log(g());
+        }
+    }
+    expect_stdout: "fn"
+}
+
+issue_1729_case_block_defun_strict: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        side_effects: true,
+        switches: true,
+    }
+    input: {
+        "use strict";
+        switch (0) {
+          case 0:
+            console.log(g());
+            break;
+          case 1:
+            function g() { return "fn"; }
+        }
+    }
+    expect: {
+        "use strict";
+        {
+            function g() {
+                return "fn";
+            }
+            console.log(g());
+        }
+    }
+    expect_stdout: "fn"
+}
+
+issue_1729_default_defun: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        side_effects: true,
+        switches: true,
+    }
+    input: {
+        switch (0) {
+          case 0:
+            console.log(g());
+            break;
+          default:
+            function g() { return "fn"; }
+        }
+    }
+    expect: {
+        {
+            function g() {
+                return "fn";
+            }
+            console.log(g());
+        }
+    }
+    expect_stdout: "fn"
+}
+
+issue_1729_nested_block_defun: {
+    options = {
+        dead_code: true,
+        evaluate: true,
+        side_effects: true,
+        switches: true,
+    }
+    input: {
+        switch (0) {
+          case 0:
+            console.log(typeof g);
+            break;
+          case 1: {
+            function g() { return "fn"; }
+          }
+        }
+    }
+    expect: {
+        var g;
+        console.log(typeof g);
+    }
+    expect_stdout: "undefined"
+    reminify: false
+}
+


### PR DESCRIPTION
Thanks for the report in #1729. A FunctionDeclaration in a case or default is part of the CaseBlock, so the engine initializes it before picking a case. Compress was treating that dead branch like a nested block and only keeping `var g`, which makes `g()` throw.

This keeps the function when it is a direct statement of the dropped branch, including in strict mode. A nested `{ function g() {} }` still extracts as `var g` in sloppy code, which matches browsers.