### PR TITLE
fix: don't crash when evaluating BigInt modulo by zero

### DIFF
--- a/lib/compress/evaluate.js
+++ b/lib/compress/evaluate.js
@@ -291,12 +291,12 @@ def_eval(AST_Binary, function (compressor, depth) {
     }
 
     // Do not mix BigInt and Number
-    // Don't use `>>>` on BigInt or `/ 0n` (error)
+    // Don't use `>>>` on BigInt or `/ 0n` or `% 0n` (error)
     // Don't use `**` on BigInt (slow)
     if (
         (typeof left === "bigint") !== (typeof right === "bigint")
         || typeof left === "bigint"
-            && (this.operator === "/" && Number(right) === 0
+            && ((this.operator === "/" || this.operator === "%") && Number(right) === 0
                 || this.operator === ">>>"
                 || this.operator === "**")
     ) {

--- a/test/compress/big_int.js
+++ b/test/compress/big_int.js
@@ -87,9 +87,10 @@ big_int_math_counter_examples: {
             mixing_types: 1 * 10n,
             bad_shift: 1n >>> 0n,
             bad_div: 1n / 0n,
+            bad_mod: 1n % 0n,
         });
     }
-    expect_exact: "console.log({mixing_types:1*10n,bad_shift:1n>>>0n,bad_div:1n/0n});"
+    expect_exact: "console.log({mixing_types:1*10n,bad_shift:1n>>>0n,bad_div:1n/0n,bad_mod:1n%0n});"
     expect_stdout: true
 }
 


### PR DESCRIPTION
An unused or foldable `x % 0n` where both operands are BigInt throws `RangeError: Division by zero` while constant-folding, and the exception escapes `_eval`, so `minify()` itself throws on valid input instead of compiling it:

```js
await minify("console.log(5n % 0n)"); // RangeError: Division by zero
```

The zero-divisor guard in `AST_Binary._eval` already exists for `/` (`1n / 0n` is preserved); this extends it to `%` so the expression is left intact instead of folded, matching the existing `1n / 0n` behavior. Normal folding is unaffected (`7n % 3n` still folds to `1n`, `7 % 0` still folds to `NaN`).

Adds a `bad_mod` counter-example to `test/compress/big_int.js`.
