### PR TITLE
Performance: Reduce fixed per-call overhead in `minify()`

### DIFF
--- a/lib/compress/native-objects.js
+++ b/lib/compress/native-objects.js
@@ -49,8 +49,24 @@ import { is_undeclared_ref } from "./inference.js";
 // Note: Lots of methods and functions are missing here, in case they aren't pure
 // or not available in all JS environments.
 
-const make_nested_lookup = (feature_callback) => (compressor) => {
-    const obj = feature_callback(feature_variables(compressor));
+// The tables depend only on the two feature variables, so build each one once
+// per distinct option pair instead of once per Compressor
+const memoize_by_features = (build) => {
+    const cache = new Map();
+    return (compressor) => {
+        const { sloppy, es } = feature_variables(compressor);
+        const key = sloppy + "|" + es;
+        let lookup = cache.get(key);
+        if (lookup === undefined) {
+            lookup = build({ sloppy, es });
+            cache.set(key, lookup);
+        }
+        return lookup;
+    };
+};
+
+const make_nested_lookup = (feature_callback) => memoize_by_features((features) => {
+    const obj = feature_callback(features);
 
     const out = new Map();
     for (var key of Object.keys(obj)) {
@@ -59,31 +75,19 @@ const make_nested_lookup = (feature_callback) => (compressor) => {
         }
     }
 
-    const does_have = (global_name, fname) => {
+    return (global_name, fname) => {
         const inner_map = out.get(global_name);
         return inner_map != null && inner_map.has(fname);
     };
-    return does_have;
-};
+});
 
-const make_lookup = (feature_callback) => (compressor) => {
-    const obj = feature_callback(feature_variables(compressor));
-
-    const predicate = makePredicate(remove_false(obj));
-    const does_have = (global_name) => {
-        return predicate.has(global_name);
-    };
-    return does_have;
-};
+const make_lookup = (feature_callback) => memoize_by_features((features) => {
+    const predicate = makePredicate(remove_false(feature_callback(features)));
+    return (global_name) => predicate.has(global_name);
+});
 
 function remove_false(arr) {
-    for (let i = 0; i < arr.length; i++) {
-        if (arr[i] === false) {
-            arr.splice(i, 1);
-            i--;
-        }
-    }
-    return arr;
+    return arr.filter((entry) => entry !== false);
 }
 
 /** Generate the object with arguments seen below */

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -46,7 +46,6 @@
 import {
     defaults,
     keep_name,
-    mergeSort,
     push_uniq,
     make_node,
     return_false,
@@ -1061,29 +1060,37 @@ AST_Toplevel.DEFMETHOD("compute_char_frequency", function(options) {
 });
 
 const base54 = (() => {
-    const leading = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_".split("");
-    const digits = "0123456789".split("");
+    const leading = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_";
+    const digits = "0123456789";
+    // Frequencies are counted per ASCII code point; `consider` runs over every
+    // character of the printed program, so this stays off the Map and GC paths
+    const frequency = new Int32Array(128);
+    const leading_codes = Array.from(leading, (ch) => ch.charCodeAt(0));
+    const digit_codes = Array.from(digits, (ch) => ch.charCodeAt(0));
+    // Alphabet position per code point, used as the sort tie-breaker
+    const rank = new Int32Array(128);
+    leading_codes.forEach((code, i) => rank[code] = i);
+    digit_codes.forEach((code, i) => rank[code] = i);
     let chars;
-    let frequency;
     function reset() {
-        frequency = new Map();
-        leading.forEach(function(ch) {
-            frequency.set(ch, 0);
-        });
-        digits.forEach(function(ch) {
-            frequency.set(ch, 0);
-        });
+        frequency.fill(0);
     }
     function consider(str, delta) {
         for (var i = str.length; --i >= 0;) {
-            frequency.set(str[i], frequency.get(str[i]) + delta);
+            const code = str.charCodeAt(i);
+            if (code < 128) frequency[code] += delta;
         }
     }
-    function compare(a, b) {
-        return frequency.get(b) - frequency.get(a);
+    // Descending frequency, ties broken by alphabet position so the result is
+    // stable without relying on the engine's sort being stable
+    function by_frequency(a, b) {
+        return frequency[b] - frequency[a] || rank[a] - rank[b];
     }
     function sort() {
-        chars = mergeSort(leading, compare).concat(mergeSort(digits, compare));
+        chars = String.fromCharCode.apply(
+            null,
+            leading_codes.slice().sort(by_frequency).concat(digit_codes.slice().sort(by_frequency))
+        );
     }
     // Ensure this is in a usable initial state.
     reset();

--- a/lib/unicode.js
+++ b/lib/unicode.js
@@ -32,14 +32,16 @@ export function is_basic_identifier_string(str) {
 }
 
 export function get_full_char(str, pos) {
-    if (is_surrogate_pair_head(str.charCodeAt(pos))) {
+    // Fast path for the BMP (runs once per character of the input)
+    const code = str.charCodeAt(pos);
+    // NaN (pos out of range) takes the fast path, too
+    if (!(code >= 0xd800 && code <= 0xdfff)) return str.charAt(pos);
+    if (is_surrogate_pair_head(code)) {
         if (is_surrogate_pair_tail(str.charCodeAt(pos + 1))) {
             return str.charAt(pos) + str.charAt(pos + 1);
         }
-    } else if (is_surrogate_pair_tail(str.charCodeAt(pos))) {
-        if (is_surrogate_pair_head(str.charCodeAt(pos - 1))) {
-            return str.charAt(pos - 1) + str.charAt(pos);
-        }
+    } else if (is_surrogate_pair_head(str.charCodeAt(pos - 1))) {
+        return str.charAt(pos - 1) + str.charAt(pos);
     }
     return str.charAt(pos);
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -156,34 +156,10 @@ function remove(array, el) {
     }
 }
 
-function mergeSort(array, cmp) {
-    if (array.length < 2) return array.slice();
-    function merge(a, b) {
-        var r = [], ai = 0, bi = 0, i = 0;
-        while (ai < a.length && bi < b.length) {
-            cmp(a[ai], b[bi]) <= 0
-                ? r[i++] = a[ai++]
-                : r[i++] = b[bi++];
-        }
-        if (ai < a.length) r.push.apply(r, a.slice(ai));
-        if (bi < b.length) r.push.apply(r, b.slice(bi));
-        return r;
-    }
-    function _ms(a) {
-        if (a.length <= 1)
-            return a;
-        var m = Math.floor(a.length / 2), left = a.slice(0, m), right = a.slice(m);
-        left = _ms(left);
-        right = _ms(right);
-        return merge(left, right);
-    }
-    return _ms(array);
-}
-
 function makePredicate(words) {
     if (!Array.isArray(words)) words = words.split(" ");
 
-    return new Set(words.sort());
+    return new Set(words);
 }
 
 function map_add(map, key, value) {
@@ -288,7 +264,6 @@ export {
     map_to_object,
     MAP,
     member,
-    mergeSort,
     noop,
     push_uniq,
     regexp_source_fix,


### PR DESCRIPTION
Using Terser in some projects where it slows some operations down, I checked on performance optimizations. Proposing a couple of contained improvements. Disclosure: I used Claude Opus 5 to double-check and assist with the summary:

Work that doesn’t depend on the input was being redone on every `minify()` call. It’s invisible on large files but dominates when a caller minifies many small snippets.

## Changes

1. `native-objects.js`: Memoize the five lookup tables. They’re rebuilt per `Compressor`, but depend only on `(unsafe, builtins_ecma)`. It seems this made up 15.0µs of the 18.3µs constructor. Also swaps the `splice` loop in `remove_false` for `filter` (it was O(n²)).
2. `makePredicate`: Drop the sort. The result is a `Set` used only via `.has()`, so ordering is dead work. 1.46µs → 0.50µs.
3. `base54`: Count frequency in an `Int32Array` indexed by code point instead of a `Map`, and sort with an explicit rank tie-breaker instead of the allocating `mergeSort`. `consider()` runs over every character of the printed program; `sort()` cost 10.5µs per call. The tie-breaker also removes the reliance on the engine’s sort being stable, which matters given `engines` still allows Node 10.
4. (Remove `mergeSort`, now unused.)

## Metrics

Node 24, macOS, process-isolated A/B against `master`, median of repeated runs:

| Workload | Before | After | |
| --- | --- | --- | --- |
| `minify("0")` (fixed overhead) | 62µs | 37µs | **1.80×** |
| Inline-snippet corpus | 174µs/call | 139µs/call | **1.25×** |
| 4 library bundles (126K–875K) | — | — | −1.6% to −3.0% |

## Correctness

Output is byte-identical—verified across four library bundles under three option sets plus the snippet corpus. `get_full_char` was differentially tested against the old implementation over 200k random surrogate-heavy strings. Full suite passes.

## Not included

I tried rewriting `defaults()` with `Object.keys`—it was 35% slower, since V8’s `for...in` enum cache beats the array allocation. Reverted. The remaining ~2.7µs × ~5 calls per `minify()` is the ~58 property stores, not loop mechanics, so it needs prebuilt option objects rather than a micro-optimization. Happy to follow up.